### PR TITLE
ESD-101: Add /healthz endpoint for readiness probes

### DIFF
--- a/src/routes/healthz.js
+++ b/src/routes/healthz.js
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/healthz", (_req, res) => {
+  res.json({ status: "ok", uptime: process.uptime() });
+});
+
+export default router;


### PR DESCRIPTION
Closes ESD-101. Adds a simple /healthz endpoint returning {status:"ok"} for Kubernetes readiness probes.