### PR TITLE
ESD-102: Fix database connection pool timeout

### DIFF
--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -1,0 +1,5 @@
+export const poolConfig = {
+  max: 10,
+  idleTimeoutMillis: 30_000,
+  connectionTimeoutMillis: 5_000,
+};


### PR DESCRIPTION
Closes ESD-102. Default pool timeout was 0 which made transient network blips look like total failures. Bumping to 5s with explicit max connections.