### PR TITLE
ESD-104: Upgrade dependencies for security patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Closes ESD-104. Turns on Dependabot weekly npm scans after the CVE sweep flagged four advisories last Friday.