### PR TITLE
ESD-105: Refactor settlement worker to extract RetryPolicy

### DIFF
--- a/src/workers/settlement.js
+++ b/src/workers/settlement.js
@@ -1,0 +1,20 @@
+export class RetryPolicy {
+  constructor({ maxAttempts = 3, baseDelayMs = 500 } = {}) {
+    this.maxAttempts = maxAttempts;
+    this.baseDelayMs = baseDelayMs;
+  }
+  delayFor(attempt) {
+    return this.baseDelayMs * 2 ** (attempt - 1);
+  }
+}
+
+export async function processSettlement(job, policy = new RetryPolicy()) {
+  for (let attempt = 1; attempt <= policy.maxAttempts; attempt++) {
+    try {
+      return await job();
+    } catch (err) {
+      if (attempt === policy.maxAttempts) throw err;
+      await new Promise((r) => setTimeout(r, policy.delayFor(attempt)));
+    }
+  }
+}


### PR DESCRIPTION
Closes ESD-105. Pulls the retry/backoff logic out of SettlementWorker into a reusable RetryPolicy value object — makes the worker testable and unblocks reuse in the refund worker.