### PR TITLE
ESD-107: Add role-based access control middleware

### DIFF
--- a/src/middleware/rbac.js
+++ b/src/middleware/rbac.js
@@ -1,0 +1,8 @@
+export function requireRole(...allowed) {
+  return (req, res, next) => {
+    const role = req.user?.role;
+    if (!role) return res.status(401).json({ error: "unauthorized" });
+    if (!allowed.includes(role)) return res.status(403).json({ error: "forbidden" });
+    next();
+  };
+}


### PR DESCRIPTION
Closes ESD-107. Introduces a requireRole() Express middleware so route handlers can gate on "admin" / "auditor" / "support" without re-implementing the check inline everywhere.

Still needs reviewer sign-off on the role shape and audit-trail plan for denied requests.