### PR TITLE
ESD-111: Migrate metrics export to OpenTelemetry

### DIFF
--- a/src/metrics/otel.js
+++ b/src/metrics/otel.js
@@ -1,0 +1,6 @@
+// ESD-111 — Migrate metrics export to OpenTelemetry
+//
+// Replaced the home-grown statsd shim with the OTel SDK + OTLP exporter. Single dependency, native traces alongside metrics.
+
+// Generated for the eSpace Dev Hub mock repo to drive realistic
+// dashboard activity. Replace with the real implementation.


### PR DESCRIPTION
Replaced the home-grown statsd shim with the OTel SDK + OTLP exporter. Single dependency, native traces alongside metrics.