### PR TITLE
ESD-113: Cache layer for /healthz dependencies

### DIFF
--- a/src/healthz/cache.js
+++ b/src/healthz/cache.js
@@ -1,0 +1,6 @@
+// ESD-113 — Cache layer for /healthz dependencies
+//
+// Probe checks for downstream services (Redis, primary DB, settlement) now cache for 5s so a healthy probe doesn't hammer infra at probe-rate.
+
+// Generated for the eSpace Dev Hub mock repo to drive realistic
+// dashboard activity. Replace with the real implementation.


### PR DESCRIPTION
Probe checks for downstream services (Redis, primary DB, settlement) now cache for 5s so a healthy probe doesn't hammer infra at probe-rate.