### PR TITLE
M7.9b: logout button + session-aware user chip in header

### DIFF
--- a/apps/web/src/app/login/page.jsx
+++ b/apps/web/src/app/login/page.jsx
@@ -8,16 +8,32 @@
  * Redirect target precedence:
  *   1. `?next=...` query param (set by AuthGuard when it bounced)
  *   2. "/" (dashboard) when no hint
+ *
+ * The form is wrapped in a <Suspense> boundary because `useSearchParams`
+ * forces a client-side rendering bailout that Next.js refuses to silently
+ * prerender — without the boundary, `next build` errors on this route.
  */
 
+import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { LoginForm } from "@/features/auth";
 
-export default function LoginPage() {
+function LoginInner() {
   const router = useRouter();
   const params = useSearchParams();
   const next = params.get("next") || "/";
 
+  return (
+    <LoginForm
+      onSuccess={() => {
+        // Hard-replace so the address bar reflects the destination.
+        router.replace(next);
+      }}
+    />
+  );
+}
+
+export default function LoginPage() {
   return (
     <main
       style={{
@@ -28,12 +44,9 @@ export default function LoginPage() {
         flexDirection: "column",
       }}
     >
-      <LoginForm
-        onSuccess={() => {
-          // Hard-replace so the address bar reflects the destination.
-          router.replace(next);
-        }}
-      />
+      <Suspense fallback={null}>
+        <LoginInner />
+      </Suspense>
     </main>
   );
 }

--- a/apps/web/src/components/shell/header.jsx
+++ b/apps/web/src/components/shell/header.jsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { LogoMark } from "./logo-mark";
 import { AnalystActivator } from "@/features/analyst";
 import { useIntegrations } from "@/features/integrations";
+import { UserChip } from "@/features/auth";
 import { cn } from "@/lib/cn";
 
 const NAV = [
@@ -18,7 +19,7 @@ const VERSION = "v0.3.1";
 
 export function Header() {
   const pathname = usePathname();
-  const { connectedProviders, me } = useIntegrations();
+  const { connectedProviders } = useIntegrations();
   const isLive = connectedProviders.length > 0;
 
   return (
@@ -89,15 +90,9 @@ export function Header() {
         </div>
         {/* Inverse-themed activator — opens the accent-ground analyst page. */}
         <AnalystActivator />
-        <div className="flex items-center gap-2 rounded-full border border-border py-1 pl-1 pr-3">
-          <div
-            className="grid h-6 w-6 place-items-center rounded-full bg-accent font-bold text-accent-on"
-            style={{ fontSize: 11 }}
-          >
-            {me?.initials ?? "?"}
-          </div>
-          <div className="text-[12px] font-semibold">{me?.name ?? "Sign in"}</div>
-        </div>
+        {/* Session-aware chip with logout dropdown. Falls back to the
+            integrations-derived identity in pure-localStorage mode. */}
+        <UserChip />
       </div>
     </header>
   );

--- a/apps/web/src/features/auth/index.js
+++ b/apps/web/src/features/auth/index.js
@@ -5,9 +5,11 @@
  *   <SessionProvider>   — mount once at the root layout
  *   <LoginForm>         — used by /login page (and reusable elsewhere)
  *   <AuthGuard>         — wraps protected page contents
+ *   <UserChip>          — header chip showing the session user + logout
  */
 
 export { useSession } from "./use-session.js";
 export { SessionProvider } from "./session-provider.jsx";
 export { LoginForm } from "./login-form.jsx";
 export { AuthGuard } from "./auth-guard.jsx";
+export { UserChip } from "./user-chip.jsx";

--- a/apps/web/src/features/auth/user-chip.jsx
+++ b/apps/web/src/features/auth/user-chip.jsx
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * Header chip showing the currently authenticated user, with a dropdown
+ * that exposes Logout (and, in future, links to /settings/profile etc.).
+ *
+ * Resolution order for the displayed identity:
+ *   1. The active server session (useSession()) — the post-M2 source
+ *      of truth. Shows displayName + email.
+ *   2. The integrations-derived `me` — legacy v0 path used when
+ *      NEXT_PUBLIC_AUTH_REQUIRED=false and the user is operating in
+ *      pure-localStorage mode. We don't show a logout for this case
+ *      because there's no session to destroy.
+ *   3. A "Sign in" link to /login when neither is available.
+ *
+ * Once the legacy proxy routes retire (M7.9c), the integrations
+ * fallback can be dropped and this becomes session-only.
+ */
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@radix-ui/react-dropdown-menu";
+import { useSession } from "./use-session.js";
+import { useIntegrations } from "@/features/integrations";
+import { cn } from "@/lib/cn";
+
+function initialsOf(name, fallbackEmail) {
+  const source = name || fallbackEmail || "";
+  if (!source) return "?";
+  return (
+    source
+      .split(/[\s@.]+/)
+      .map((s) => s[0])
+      .filter(Boolean)
+      .slice(0, 2)
+      .join("")
+      .toUpperCase() || "?"
+  );
+}
+
+export function UserChip() {
+  const { user, loading, logout } = useSession();
+  // Legacy integrations-derived identity — only consulted when there's
+  // no session user. Keeps the header useful in pure-localStorage mode.
+  const { me: legacyMe } = useIntegrations();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  // While the initial /auth/me round-trip is in flight, render a
+  // placeholder so the chip doesn't pop in/out.
+  if (loading && !user && !legacyMe) {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-full border border-border py-1 pl-1 pr-3 opacity-60"
+        aria-hidden
+      >
+        <div
+          className="grid h-6 w-6 place-items-center rounded-full bg-accent-dim text-fg"
+          style={{ fontSize: 11 }}
+        >
+          ·
+        </div>
+        <div className="text-[12px] font-semibold text-muted-fg">…</div>
+      </div>
+    );
+  }
+
+  // Authenticated — full chip with dropdown.
+  if (user) {
+    const displayName = user.displayName || user.email;
+    const initials = initialsOf(user.displayName, user.email);
+
+    const onLogout = () => {
+      startTransition(async () => {
+        await logout();
+        setOpen(false);
+        router.replace("/login");
+      });
+    };
+
+    return (
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "flex items-center gap-2 rounded-full border border-border py-1 pl-1 pr-3 transition-colors hover:bg-accent-dim/60",
+              open && "bg-accent-dim/60",
+            )}
+            aria-label={`Account menu for ${displayName}`}
+          >
+            <div
+              className="grid h-6 w-6 place-items-center rounded-full bg-accent font-bold text-accent-on"
+              style={{ fontSize: 11 }}
+            >
+              {initials}
+            </div>
+            <div className="text-[12px] font-semibold">{displayName}</div>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          sideOffset={6}
+          className="z-50 min-w-[220px] rounded-md border border-border bg-card p-1 shadow-lg"
+          style={{
+            background: "var(--card)",
+            borderColor: "var(--border-strong)",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          <DropdownMenuLabel className="px-2.5 py-2 text-[11px] uppercase tracking-[0.4px] text-dim-fg">
+            Signed in as
+          </DropdownMenuLabel>
+          <div className="px-2.5 pb-2 text-[12px] leading-tight">
+            <div className="font-semibold">{displayName}</div>
+            <div className="text-muted-fg">{user.email}</div>
+          </div>
+          <DropdownMenuSeparator className="my-1 h-px bg-border" />
+          <DropdownMenuItem
+            disabled={isPending}
+            onSelect={(e) => {
+              // Keep the menu open while the async logout runs so the
+              // disabled state is visible; we close manually after.
+              e.preventDefault();
+              onLogout();
+            }}
+            className={cn(
+              "cursor-pointer rounded-sm px-2.5 py-2 text-[12px] outline-none",
+              "hover:bg-accent-dim focus:bg-accent-dim",
+              isPending && "cursor-wait opacity-60",
+            )}
+          >
+            {isPending ? "Signing out…" : "Sign out"}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  }
+
+  // Legacy: integrations-derived identity, no session.
+  if (legacyMe) {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-full border border-border py-1 pl-1 pr-3"
+        title="Local-only mode — no server session"
+      >
+        <div
+          className="grid h-6 w-6 place-items-center rounded-full bg-accent font-bold text-accent-on"
+          style={{ fontSize: 11 }}
+        >
+          {legacyMe.initials || "?"}
+        </div>
+        <div className="text-[12px] font-semibold">{legacyMe.name}</div>
+      </div>
+    );
+  }
+
+  // Neither — show a sign-in entry point.
+  return (
+    <Link
+      href="/login"
+      className="flex items-center gap-2 rounded-full border border-border py-1 pl-1 pr-3 transition-colors hover:bg-accent-dim/60"
+    >
+      <div
+        className="grid h-6 w-6 place-items-center rounded-full bg-accent-dim text-fg"
+        style={{ fontSize: 11 }}
+      >
+        ?
+      </div>
+      <div className="text-[12px] font-semibold">Sign in</div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

Surfaces the post-M2 session in the header chrome and gives users a way to actually sign out. Before this commit the only chip in the header was derived from connected integrations — useful when there was no real auth, useless now that sessions are backed by Mongo.

## What ships

- **`features/auth/user-chip.jsx`** — new component. Reads `useSession()`. Renders an avatar + name chip with a Radix dropdown that shows `displayName` + `email` and a **Sign out** action. Sign-out destroys the server session, clears the local session-store, and `router.replace`s to `/login`.
- **`features/auth/index.js`** — re-exports `UserChip` in the barrel.
- **`components/shell/header.jsx`** — replaces the inline integrations-derived chip with `<UserChip />`. Drops the unused `me` destructure from `useIntegrations`.

Graceful degradation: when there's no session but `integrations.me` has a name (pure-localStorage mode, `NEXT_PUBLIC_AUTH_REQUIRED=false`), the chip falls back to the legacy identity with a "Local-only mode" tooltip. That fallback can be removed once M7.9c retires the legacy Next.js proxy routes.

## Drive-by

`app/login/page.jsx` — wrapped the inner client component (which reads `useSearchParams`) in a `<Suspense>` boundary. Pre-existing build break that surfaced when I ran `npm run build:web` to verify this PR. Fixing it here because `/login` is now the destination the logout flow redirects to and it needs to actually render.

## Test plan

- [x] `npm run build:web` passes; `/login` prerenders cleanly
- [ ] Sign in via the password + TOTP flow; verify the chip shows the right display name and email
- [ ] Click the chip; dropdown opens with the user info and a Sign out button
- [ ] Click Sign out; UI shows "Signing out…", then the page navigates to `/login` and the chip is gone
- [ ] In pure-localStorage mode (`NEXT_PUBLIC_AUTH_REQUIRED=false`), legacy chip shows the integrations-derived name with no dropdown