### PR TITLE
M7.9a: one-shot localStorage to API migration trigger

### DIFF
--- a/apps/web/src/app/layout.jsx
+++ b/apps/web/src/app/layout.jsx
@@ -8,6 +8,7 @@ import { ContextSync } from "@/features/goal-context";
 import { InputsSync } from "@/features/goal-inputs";
 import { SpecsSync } from "@/features/goal-specs";
 import { GoalsSync } from "@/features/goals";
+import { MigrateOnce } from "@/features/migrate";
 
 const interTight = Inter_Tight({
   subsets: ["latin"],
@@ -42,6 +43,13 @@ export default function RootLayout({ children }) {
             the API once on session establishment, merging into
             localStorage. M7.2 mirror-mode rollout. */}
         <SessionProvider>
+          {/* MigrateOnce runs the first-session localStorage→API upload
+              for devices that carry pre-M7 legacy data. It's silent
+              on devices with no legacy data and idempotent on the
+              server side. Sits alongside the per-store <*Sync /> pulls,
+              which only replace local state when the server has
+              content — so the pull/migrate race is safe. */}
+          <MigrateOnce />
           <GradingSync />
           <SnapshotsSync />
           <ContextSync />

--- a/apps/web/src/app/login/page.jsx
+++ b/apps/web/src/app/login/page.jsx
@@ -8,16 +8,32 @@
  * Redirect target precedence:
  *   1. `?next=...` query param (set by AuthGuard when it bounced)
  *   2. "/" (dashboard) when no hint
+ *
+ * The form is wrapped in a <Suspense> boundary because `useSearchParams`
+ * forces a client-side rendering bailout that Next.js refuses to silently
+ * prerender — without the boundary, `next build` errors on this route.
  */
 
+import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { LoginForm } from "@/features/auth";
 
-export default function LoginPage() {
+function LoginInner() {
   const router = useRouter();
   const params = useSearchParams();
   const next = params.get("next") || "/";
 
+  return (
+    <LoginForm
+      onSuccess={() => {
+        // Hard-replace so the address bar reflects the destination.
+        router.replace(next);
+      }}
+    />
+  );
+}
+
+export default function LoginPage() {
   return (
     <main
       style={{
@@ -28,12 +44,9 @@ export default function LoginPage() {
         flexDirection: "column",
       }}
     >
-      <LoginForm
-        onSuccess={() => {
-          // Hard-replace so the address bar reflects the destination.
-          router.replace(next);
-        }}
-      />
+      <Suspense fallback={null}>
+        <LoginInner />
+      </Suspense>
     </main>
   );
 }

--- a/apps/web/src/features/migrate/collect-payload.js
+++ b/apps/web/src/features/migrate/collect-payload.js
@@ -1,0 +1,136 @@
+/**
+ * Assemble the /api/v1/migrate/import payload from the seven
+ * localStorage keys the legacy stores write. Pure read — never
+ * mutates localStorage.
+ *
+ * Shape returned matches the server's importSchema (Zod) verbatim:
+ * each top-level field is optional and is omitted entirely when the
+ * corresponding storage key is empty or absent. The server accepts a
+ * partial payload, so an empty body would be a valid (no-op) call —
+ * but emitting only what we actually have keeps the request small
+ * and makes the audit log readable.
+ *
+ * Returns `{ payload, hasAny }`:
+ *   payload  the request body to POST
+ *   hasAny   true when at least one key contributed something
+ *            (lets the caller skip the call entirely on a fresh
+ *            device that has no legacy data to migrate)
+ */
+
+const KEYS = {
+  goals: "espace-devhub:goals",
+  goalSpecs: "espace-devhub:goal-specs",
+  goalContext: "espace-devhub:goal-context",
+  goalInputs: "espace-devhub:goal-inputs",
+  snapshots: "espace-devhub:snapshots",
+  grading: "espace-devhub:grading",
+  integrations: "espace-devhub:integrations",
+};
+
+function readJSON(key) {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function nonEmptyArray(value) {
+  return Array.isArray(value) && value.length > 0 ? value : null;
+}
+
+function nonEmptyObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return Object.keys(value).length > 0 ? value : null;
+}
+
+export function collectMigrationPayload() {
+  const payload = {};
+  let hasAny = false;
+
+  // ── goals ─────────────────────────────────────────────────────────
+  // Stored as { schemaVersion, l1s }. The server only wants { l1s }.
+  const goalsRaw = readJSON(KEYS.goals);
+  const l1s = nonEmptyArray(goalsRaw?.l1s);
+  if (l1s) {
+    payload.goals = { l1s };
+    hasAny = true;
+  }
+
+  // ── goal-specs ────────────────────────────────────────────────────
+  // Stored as { specs: {goalId: spec}, lastAnalyzedAt }. Server wants
+  // { specs }.
+  const specsRaw = readJSON(KEYS.goalSpecs);
+  const specs = nonEmptyObject(specsRaw?.specs);
+  if (specs) {
+    payload.goalSpecs = { specs };
+    hasAny = true;
+  }
+
+  // ── goal-context ──────────────────────────────────────────────────
+  // Stored as { [goalId]: { ...answers, __updatedAt? } }. Server
+  // accepts the same shape and strips __updatedAt itself.
+  const contextRaw = readJSON(KEYS.goalContext);
+  const context = nonEmptyObject(contextRaw);
+  if (context) {
+    payload.goalContext = context;
+    hasAny = true;
+  }
+
+  // ── goal-inputs ───────────────────────────────────────────────────
+  // Stored as { [goalId]: [entry, …] }. Server accepts the same.
+  const inputsRaw = readJSON(KEYS.goalInputs);
+  const inputs = nonEmptyObject(inputsRaw);
+  if (inputs) {
+    // Filter out empty arrays so the server doesn't see noise.
+    const trimmed = {};
+    for (const [goalId, entries] of Object.entries(inputs)) {
+      if (Array.isArray(entries) && entries.length > 0) {
+        trimmed[goalId] = entries;
+      }
+    }
+    if (Object.keys(trimmed).length > 0) {
+      payload.goalInputs = trimmed;
+      hasAny = true;
+    }
+  }
+
+  // ── snapshots ─────────────────────────────────────────────────────
+  // Stored as an array.
+  const snapshotsRaw = readJSON(KEYS.snapshots);
+  const snapshots = nonEmptyArray(snapshotsRaw);
+  if (snapshots) {
+    payload.snapshots = snapshots;
+    hasAny = true;
+  }
+
+  // ── grading verdicts ──────────────────────────────────────────────
+  // Stored as { [cacheKey]: {prId, rubricHash, verdict, gradedAt} }.
+  // Server accepts the same; cacheKey is ignored in favour of
+  // (prId, rubricHash).
+  const gradingRaw = readJSON(KEYS.grading);
+  const grading = nonEmptyObject(gradingRaw);
+  if (grading) {
+    payload.gradingVerdicts = grading;
+    hasAny = true;
+  }
+
+  // ── integrations ──────────────────────────────────────────────────
+  // Stored as { [providerId]: {accessToken?, apiToken?, …} }. Server
+  // encrypts before insert; we send plaintext over the wire (the
+  // request body is HTTPS in non-dev). Migration is one-shot per
+  // device, so the plaintext exposure is bounded.
+  const integrationsRaw = readJSON(KEYS.integrations);
+  const integrations = nonEmptyObject(integrationsRaw);
+  if (integrations) {
+    payload.integrations = integrations;
+    hasAny = true;
+  }
+
+  return { payload, hasAny };
+}
+
+export const MIGRATION_SOURCE_KEYS = KEYS;

--- a/apps/web/src/features/migrate/index.js
+++ b/apps/web/src/features/migrate/index.js
@@ -1,0 +1,17 @@
+/**
+ * Public API for the one-shot localStorage→API migration.
+ *
+ * Mount <MigrateOnce /> alongside the other sync components in the
+ * root layout. It fires once per device per browser profile after
+ * the first authenticated load and is silent on devices with no
+ * legacy data.
+ */
+
+export { MigrateOnce } from "./migrate-once.jsx";
+export {
+  readMigrationMarker,
+  writeMigrationMarker,
+  clearMigrationMarker,
+  MIGRATION_MARKER_KEY,
+} from "./migrate-store";
+export { collectMigrationPayload, MIGRATION_SOURCE_KEYS } from "./collect-payload";

--- a/apps/web/src/features/migrate/migrate-once.jsx
+++ b/apps/web/src/features/migrate/migrate-once.jsx
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * One-shot localStorage→API migration trigger.
+ *
+ * Mounted alongside the per-store <*Sync /> components in the root
+ * layout. The component renders nothing — it's a lifecycle effect.
+ *
+ * Flow:
+ *   1. Wait until useSession() reports an authenticated user.
+ *   2. If the local migration marker is already set, exit. The
+ *      device has already uploaded; the per-store mirror writes
+ *      keep things in sync from here on.
+ *   3. Read the seven legacy localStorage keys via
+ *      collectMigrationPayload(). If nothing to send, set the
+ *      marker anyway and exit — a fresh device shouldn't keep
+ *      retrying the no-op call every session.
+ *   4. POST to /api/v1/migrate/import. On success, write the
+ *      marker with the server-returned counts. On failure, log
+ *      and bail (next session retries).
+ *
+ * Concurrency with the <*Sync /> pulls:
+ *   The pull helpers only replaceLocal() when the server returns
+ *   non-empty content. On a fresh user the pulls are no-ops, so
+ *   they can't clobber the local data we're about to upload.
+ *   We don't await the pulls — both run in parallel and converge.
+ *
+ * Toast:
+ *   Uses sonner (already mounted at the root). A one-off "Synced
+ *   N items to your account" with the per-collection counts. Quiet
+ *   on no-data devices.
+ */
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { useSession } from "@/features/auth";
+import { apiPost } from "@/lib/api-client";
+import { collectMigrationPayload } from "./collect-payload";
+import { readMigrationMarker, writeMigrationMarker } from "./migrate-store";
+
+const LOG_PREFIX = "[migrate-once]";
+
+function totalImported(counts) {
+  if (!counts || typeof counts !== "object") return 0;
+  let n = 0;
+  for (const value of Object.values(counts)) {
+    if (typeof value === "number") {
+      n += value;
+    } else if (value && typeof value === "object" && "imported" in value) {
+      n += Number(value.imported) || 0;
+    }
+  }
+  return n;
+}
+
+export function MigrateOnce() {
+  const { user, loading } = useSession();
+  // Guards against React 18 StrictMode double-mounting in dev — we
+  // only want one POST per page lifetime.
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) return;
+    if (firedRef.current) return;
+
+    // Already migrated on this device — nothing to do.
+    if (readMigrationMarker()) {
+      firedRef.current = true;
+      return;
+    }
+
+    const { payload, hasAny } = collectMigrationPayload();
+
+    // No legacy data on this device. Set the marker so we don't
+    // keep checking on every future session.
+    if (!hasAny) {
+      writeMigrationMarker(null);
+      firedRef.current = true;
+      return;
+    }
+
+    firedRef.current = true;
+
+    (async () => {
+      const result = await apiPost("/migrate/import", payload);
+      if (!result.ok) {
+        // Auth failures: just leave the marker unset — next session
+        // will retry once the cookie is good.
+        // eslint-disable-next-line no-console
+        console.warn(
+          `${LOG_PREFIX} import failed:`,
+          result.error?.code,
+          result.error?.message,
+        );
+        firedRef.current = false;
+        return;
+      }
+
+      const counts = result.data?.counts ?? null;
+      writeMigrationMarker(counts);
+
+      const total = totalImported(counts);
+      if (total > 0) {
+        toast.success(`Synced ${total} item${total === 1 ? "" : "s"} to your account.`, {
+          description: "Your local dashboard is now backed up to the server.",
+        });
+      }
+    })();
+  }, [user, loading]);
+
+  return null;
+}

--- a/apps/web/src/features/migrate/migrate-store.js
+++ b/apps/web/src/features/migrate/migrate-store.js
@@ -1,0 +1,52 @@
+/**
+ * One-shot localStorage→API migration marker.
+ *
+ * The marker is per-device by design: each browser/profile carries
+ * its own legacy localStorage, and each device's first authenticated
+ * load triggers one upload. Re-uploads from the same device are a
+ * no-op server-side (every collection has a unique-keyed upsert,
+ * except goal_inputs which is append-only — that's why we gate on
+ * a marker rather than relying purely on server idempotency).
+ *
+ * Stored value: a JSON object with the completion timestamp and
+ * the counts the server returned, so the UI can show "imported 14
+ * goals, 3 specs, …" if it wants to. The presence of the key is
+ * what matters; the body is informational.
+ */
+
+const MARKER_KEY = "espace-devhub:migrate-completed-at";
+
+export function readMigrationMarker() {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(MARKER_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function writeMigrationMarker(counts) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(
+      MARKER_KEY,
+      JSON.stringify({ completedAt: Date.now(), counts: counts ?? null }),
+    );
+  } catch {
+    // Storage quota or private-mode failure — fine to swallow. The
+    // worst case is we retry the (idempotent) migration next session.
+  }
+}
+
+/**
+ * Test-only escape hatch. Not exposed in the public barrel; reach in
+ * directly if you ever need to force a re-migration during dev.
+ */
+export function clearMigrationMarker() {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(MARKER_KEY);
+}
+
+export const MIGRATION_MARKER_KEY = MARKER_KEY;


### PR DESCRIPTION
## Summary

Completes the data round-trip for users with pre-M7 legacy data. The `/api/v1/migrate/import` endpoint has existed since M6.2; this PR wires the frontend trigger that calls it on first authenticated load.

## What ships

- **`features/migrate/migrate-store.js`** — per-device marker (`espace-devhub:migrate-completed-at`) so the upload happens once per browser profile.
- **`features/migrate/collect-payload.js`** — pure-read assembler. Walks the seven legacy storage keys, omits empty fields, returns `{payload, hasAny}` so fresh devices can short-circuit.
- **`features/migrate/migrate-once.jsx`** — `<MigrateOnce />` lifecycle component. Mounted alongside the per-store `<*Sync />` components.
  - waits for `useSession()` authenticated
  - bails if the marker is set
  - sets the marker and exits if `hasAny=false` (fresh device, nothing to migrate — don't re-check on every future session)
  - otherwise POSTs `/migrate/import`, writes the marker with counts on success, quietly toasts ``Synced N items to your account``
  - on auth failure leaves the marker unset so the next session retries
  - StrictMode-safe via `firedRef`
- **`features/migrate/index.js`** — barrel
- **`app/layout.jsx`** — mounts `<MigrateOnce />` inside `<SessionProvider />` before the sync pulls. Pull/migrate race is safe because pulls only replace local on non-empty server content.

## Drive-by

`app/login/page.jsx` — wrapped the inner client component in `<Suspense>` so `next build` stops erroring on the pre-existing `useSearchParams` prerender failure. Identical to the fix on the M7.9b branch (#28); git will auto-collapse when both PRs land.

## Test plan

- [x] `npm run build:web` passes
- [ ] Fresh device with legacy localStorage, log in: data shows immediately, toast confirms upload, marker is set
- [ ] Reload the page after success: no second POST (marker prevents it)
- [ ] Fresh device with no legacy localStorage, log in: no toast, no POST, marker is still set (so we don't re-check)
- [ ] Sign in/out and back in: marker persists, no re-migration
- [ ] Verify the server's `audit_log` records `user.migrate_import` with per-collection counts

## Out of scope (future)

- Force-re-migrate admin action (`clearMigrationMarker()` is already exported for this).
- Server-side dedup on `goal_inputs` re-import (currently relies on the marker; v2 of the endpoint could dedupe on `(goalId, ts)`).