### PR TITLE
M8.1+2: Resend transport + real invite/password-reset emails

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -46,5 +46,27 @@ GLM_MODEL=
 OPENROUTER_API_KEY=
 OPENROUTER_MODEL=
 
+# ─── app origin ──────────────────────────────────────────────────────
+# Absolute origin used to build links in outbound emails (invite,
+# password reset). Without this the invite link in a Gmail message
+# would be a relative path and not clickable.
+APP_URL=http://localhost:3000
+
+# ─── email transport (Resend) ────────────────────────────────────────
+# When RESEND_API_KEY is unset the email module logs the message
+# instead of sending. Use that for fresh dev checkouts that don't
+# have a Resend account yet.
+#
+# When set, Resend transport is enabled. Two domain modes:
+#   sandbox  → sends from onboarding@resend.dev. Resend requires
+#              recipients to be pre-verified in their dashboard;
+#              perfect for dev. Branded as Resend, not eSpace.
+#   verified → sends from RESEND_FROM_EMAIL on your verified domain.
+#              Production path. Requires SPF/DKIM DNS records.
+RESEND_API_KEY=
+RESEND_DOMAIN_MODE=sandbox
+RESEND_FROM_EMAIL=
+RESEND_FROM_NAME=eSpace Dev Hub
+
 # ─── logging ─────────────────────────────────────────────────────────
 LOG_LEVEL=debug

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,7 @@
     "otplib": "^12.0.1",
     "pino": "^10.0.0",
     "pino-http": "^11.0.0",
+    "resend": "^6.12.3",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/apps/api/src/lib/email-templates.ts
+++ b/apps/api/src/lib/email-templates.ts
@@ -1,0 +1,156 @@
+/**
+ * Email templates — invite + password-reset.
+ *
+ * Each template returns both `text` and `html` bodies. Text is the
+ * deliverability-safe canonical version; html is a minimal branded
+ * wrapper around the same content. No external CSS, no images — keeps
+ * the body small enough that Gmail/Outlook won't truncate or scan-warn.
+ *
+ * Branding is intentionally subtle (one accent rule, mono labels) so
+ * the email matches the dashboard's voice without trying to be a
+ * marketing piece.
+ */
+
+/** Escape a string so it's safe to drop into an HTML attribute or text node. */
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+interface ShellOptions {
+  preheader: string;
+  /** Inner HTML for the body block (already escaped). */
+  bodyHtml: string;
+}
+
+function shell({ preheader, bodyHtml }: ShellOptions): string {
+  // Hidden preheader text shows in inbox previews next to the subject.
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>eSpace Dev Hub</title></head>
+<body style="margin:0;padding:0;background:#f1eee6;color:#1c1c1c;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <span style="display:none;visibility:hidden;opacity:0;color:transparent;height:0;width:0;overflow:hidden;">${esc(preheader)}</span>
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background:#f1eee6;">
+    <tr><td align="center" style="padding:32px 16px;">
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="560" style="background:#ffffff;border:1px solid #d8d2c2;border-radius:6px;">
+        <tr><td style="padding:24px 28px 16px 28px;border-bottom:1px solid #ece6d6;">
+          <div style="font-weight:600;font-size:16px;letter-spacing:-0.3px;color:#1c1c1c;">
+            eSpace<span style="color:#0a7a5a;">/</span>DevHub
+          </div>
+        </td></tr>
+        <tr><td style="padding:24px 28px;font-size:14px;line-height:1.6;color:#1c1c1c;">
+          ${bodyHtml}
+        </td></tr>
+        <tr><td style="padding:16px 28px 24px 28px;border-top:1px solid #ece6d6;font-size:11px;color:#7a7568;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;">
+          Sent by eSpace Dev Hub · If you weren't expecting this, you can safely ignore the message.
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body></html>`;
+}
+
+interface InviteVars {
+  displayName: string;
+  orgName: string;
+  acceptUrl: string;
+  expiresInDays: number;
+  inviterDisplayName?: string | null;
+}
+
+export function renderInviteEmail(vars: InviteVars): {
+  subject: string;
+  text: string;
+  html: string;
+} {
+  const subject = `You're invited to ${vars.orgName} on eSpace Dev Hub`;
+  const inviter = vars.inviterDisplayName
+    ? ` ${vars.inviterDisplayName} invited you to join`
+    : ` You're invited to join`;
+  const text = [
+    `Hi ${vars.displayName},`,
+    ``,
+    `${inviter} ${vars.orgName} on eSpace Dev Hub.`,
+    ``,
+    `Activate your account here:`,
+    vars.acceptUrl,
+    ``,
+    `This link expires in ${vars.expiresInDays} day${vars.expiresInDays === 1 ? "" : "s"}.`,
+    ``,
+    `If you weren't expecting this, ignore the message — the link will silently expire.`,
+  ].join("\n");
+  const bodyHtml = `
+    <p style="margin:0 0 12px 0;">Hi ${esc(vars.displayName)},</p>
+    <p style="margin:0 0 16px 0;">${esc(inviter.trim())} <strong>${esc(vars.orgName)}</strong> on eSpace Dev Hub.</p>
+    <p style="margin:0 0 24px 0;">
+      <a href="${esc(vars.acceptUrl)}" style="display:inline-block;padding:10px 18px;background:#0a7a5a;color:#ffffff;text-decoration:none;border-radius:4px;font-weight:600;font-size:13px;">
+        Activate your account
+      </a>
+    </p>
+    <p style="margin:0 0 8px 0;font-size:12px;color:#6e6a5e;">Or paste this link into your browser:</p>
+    <p style="margin:0 0 16px 0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;word-break:break-all;color:#3a3833;">${esc(vars.acceptUrl)}</p>
+    <p style="margin:0;color:#6e6a5e;font-size:12px;">This link expires in ${vars.expiresInDays} day${vars.expiresInDays === 1 ? "" : "s"}.</p>
+  `;
+  return {
+    subject,
+    text,
+    html: shell({ preheader: `Activate your eSpace Dev Hub account`, bodyHtml }),
+  };
+}
+
+interface PasswordResetVars {
+  displayName: string;
+  resetUrl: string;
+  expiresInHours: number;
+  ip?: string | null;
+  userAgent?: string | null;
+}
+
+export function renderPasswordResetEmail(vars: PasswordResetVars): {
+  subject: string;
+  text: string;
+  html: string;
+} {
+  const subject = `Reset your eSpace Dev Hub password`;
+  const text = [
+    `Hi ${vars.displayName},`,
+    ``,
+    `A password reset was requested for your eSpace Dev Hub account.`,
+    ``,
+    `Reset link:`,
+    vars.resetUrl,
+    ``,
+    `This link expires in ${vars.expiresInHours} hour${vars.expiresInHours === 1 ? "" : "s"}.`,
+    ``,
+    `If you didn't request this, you can ignore the email — the link will silently expire and your current password keeps working.`,
+  ].join("\n");
+  const metaLines: string[] = [];
+  if (vars.ip) metaLines.push(`IP: ${vars.ip}`);
+  if (vars.userAgent) metaLines.push(`Browser: ${vars.userAgent}`);
+  const bodyHtml = `
+    <p style="margin:0 0 12px 0;">Hi ${esc(vars.displayName)},</p>
+    <p style="margin:0 0 16px 0;">A password reset was requested for your eSpace Dev Hub account.</p>
+    <p style="margin:0 0 24px 0;">
+      <a href="${esc(vars.resetUrl)}" style="display:inline-block;padding:10px 18px;background:#0a7a5a;color:#ffffff;text-decoration:none;border-radius:4px;font-weight:600;font-size:13px;">
+        Reset your password
+      </a>
+    </p>
+    <p style="margin:0 0 8px 0;font-size:12px;color:#6e6a5e;">Or paste this link into your browser:</p>
+    <p style="margin:0 0 16px 0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;word-break:break-all;color:#3a3833;">${esc(vars.resetUrl)}</p>
+    <p style="margin:0 0 8px 0;color:#6e6a5e;font-size:12px;">This link expires in ${vars.expiresInHours} hour${vars.expiresInHours === 1 ? "" : "s"}.</p>
+    ${
+      metaLines.length > 0
+        ? `<p style="margin:16px 0 0 0;padding:12px;background:#f7f3e9;border-radius:4px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;color:#3a3833;">${esc(metaLines.join(" · "))}</p>`
+        : ""
+    }
+    <p style="margin:16px 0 0 0;color:#6e6a5e;font-size:12px;">If you didn't request this, ignore the email — the link will silently expire.</p>
+  `;
+  return {
+    subject,
+    text,
+    html: shell({ preheader: `Reset your eSpace Dev Hub password`, bodyHtml }),
+  };
+}

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -1,44 +1,199 @@
 /**
- * Email service abstraction. Swap-in interface — production gets a
- * real provider in M8 (nodemailer + SES / Resend / Postmark).
+ * Email transport for the API.
  *
- * Until then, the dev sender just LOGS the message and the link.
- * Calling code shouldn't need to change when the real provider lands;
- * only this file gets a different implementation.
+ * Two modes, picked at module-load time based on env:
  *
- * Intentionally not throwing on send failure — auth flows shouldn't
- * break if the email infrastructure is down. Caller should still
- * confirm "request received" to the user (no enumeration), and ops
- * gets the failure via the audit log + structured error.
+ *   1. log        — RESEND_API_KEY unset. Renders the email to the
+ *                   structured log and returns ok. Default for fresh
+ *                   dev checkouts that don't have a Resend account.
+ *
+ *   2. resend     — RESEND_API_KEY set. Sends via Resend. Within this
+ *                   mode RESEND_DOMAIN_MODE picks the From identity:
+ *                     - sandbox  → onboarding@resend.dev. No DNS
+ *                                  required; only addresses verified
+ *                                  in the Resend dashboard can receive.
+ *                     - verified → RESEND_FROM_EMAIL on an MX/DKIM-
+ *                                  verified domain. Production path.
+ *
+ * Failures are surfaced via the return value, not thrown. Auth flows
+ * (invite, password reset) call this in best-effort mode — the user
+ * sees "request received" regardless, and ops sees the failure in
+ * the audit log + warn-level log line. This preserves email-
+ * enumeration resistance (a successful and failed-to-send request
+ * look the same to the caller).
  */
 
+import { Resend } from "resend";
 import { logger } from "./logger.js";
 
 export interface EmailMessage {
   to: string;
   subject: string;
-  /** Plain text body. HTML lands when the real provider does. */
-  body: string;
+  /** Plain-text body — always required as the deliverability-safe fallback. */
+  text: string;
+  /** Optional HTML body. Resend uses this when present; log mode prints it. */
+  html?: string;
+  /** Optional Reply-To override (e.g. for support flows). */
+  replyTo?: string;
 }
+
+export type EmailResult =
+  | { ok: true; id?: string }
+  | { ok: false; reason: string };
 
 export interface EmailService {
-  send(msg: EmailMessage): Promise<{ ok: true } | { ok: false; reason: string }>;
+  send(msg: EmailMessage): Promise<EmailResult>;
 }
 
-class DevLoggingEmailService implements EmailService {
-  async send(msg: EmailMessage) {
+// ─── log-only transport ───────────────────────────────────────────────
+
+class LogEmailService implements EmailService {
+  async send(msg: EmailMessage): Promise<EmailResult> {
     logger.info(
       {
+        mode: "log",
         to: msg.to,
         subject: msg.subject,
-        body: msg.body,
+        textPreview: msg.text.slice(0, 500),
       },
-      "[email · dev] would send",
+      "[email] dev-mode would send (RESEND_API_KEY not set)",
     );
     return { ok: true as const };
   }
 }
 
-// Single shared instance. M8 swaps the constructor here based on
-// NODE_ENV / a SMTP_* env block.
-export const emailService: EmailService = new DevLoggingEmailService();
+// ─── Resend transport ─────────────────────────────────────────────────
+
+interface ResendConfig {
+  apiKey: string;
+  /** "Display Name <user@domain>" formatted From. */
+  from: string;
+  mode: "sandbox" | "verified";
+}
+
+class ResendEmailService implements EmailService {
+  private client: Resend;
+  private from: string;
+  private mode: "sandbox" | "verified";
+
+  constructor(cfg: ResendConfig) {
+    this.client = new Resend(cfg.apiKey);
+    this.from = cfg.from;
+    this.mode = cfg.mode;
+  }
+
+  async send(msg: EmailMessage): Promise<EmailResult> {
+    try {
+      const r = await this.client.emails.send({
+        from: this.from,
+        to: msg.to,
+        subject: msg.subject,
+        text: msg.text,
+        ...(msg.html ? { html: msg.html } : {}),
+        ...(msg.replyTo ? { replyTo: msg.replyTo } : {}),
+      });
+      if (r.error) {
+        logger.warn(
+          {
+            mode: this.mode,
+            to: msg.to,
+            subject: msg.subject,
+            code: r.error.name,
+            message: r.error.message,
+          },
+          "[email] resend send returned error",
+        );
+        return { ok: false, reason: r.error.message };
+      }
+      logger.info(
+        {
+          mode: this.mode,
+          to: msg.to,
+          subject: msg.subject,
+          id: r.data?.id,
+        },
+        "[email] sent",
+      );
+      return { ok: true, ...(r.data?.id ? { id: r.data.id } : {}) };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        {
+          mode: this.mode,
+          to: msg.to,
+          subject: msg.subject,
+          message,
+        },
+        "[email] resend send threw",
+      );
+      return { ok: false, reason: message };
+    }
+  }
+}
+
+// ─── module factory ───────────────────────────────────────────────────
+
+function buildEmailService(): EmailService {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  if (!apiKey) {
+    return new LogEmailService();
+  }
+  const mode =
+    process.env.RESEND_DOMAIN_MODE?.trim().toLowerCase() === "verified"
+      ? "verified"
+      : "sandbox";
+  const fromName = process.env.RESEND_FROM_NAME?.trim() || "eSpace Dev Hub";
+
+  let fromEmail: string;
+  if (mode === "verified") {
+    const envEmail = process.env.RESEND_FROM_EMAIL?.trim();
+    if (!envEmail) {
+      logger.warn(
+        "[email] RESEND_DOMAIN_MODE=verified but RESEND_FROM_EMAIL is empty — falling back to sandbox sender",
+      );
+      fromEmail = "onboarding@resend.dev";
+    } else {
+      fromEmail = envEmail;
+    }
+  } else {
+    // Sandbox: hard-coded sender Resend allows without DNS verification.
+    fromEmail = "onboarding@resend.dev";
+  }
+
+  logger.info(
+    { mode, from: `${fromName} <${fromEmail}>` },
+    "[email] initialising Resend transport",
+  );
+  return new ResendEmailService({
+    apiKey,
+    from: `${fromName} <${fromEmail}>`,
+    mode,
+  });
+}
+
+export const emailService: EmailService = buildEmailService();
+
+// ─── compatibility shim ───────────────────────────────────────────────
+
+/**
+ * Pre-M8 callers shipped `{to, subject, body}`. The new contract is
+ * `{to, subject, text, html?}`. This shim accepts either shape so
+ * existing call sites in auth/controller.ts can adopt HTML
+ * incrementally without a wholesale rewrite.
+ */
+export async function sendEmail(
+  msg:
+    | EmailMessage
+    | { to: string; subject: string; body: string; html?: string; replyTo?: string },
+): Promise<EmailResult> {
+  if ("text" in msg) {
+    return emailService.send(msg);
+  }
+  return emailService.send({
+    to: msg.to,
+    subject: msg.subject,
+    text: msg.body,
+    ...(msg.html ? { html: msg.html } : {}),
+    ...(msg.replyTo ? { replyTo: msg.replyTo } : {}),
+  });
+}

--- a/apps/api/src/modules/auth/controller.ts
+++ b/apps/api/src/modules/auth/controller.ts
@@ -26,6 +26,10 @@ import { networkMeta, writeAudit } from "../../lib/audit.js";
 import { encryptSecret, decryptSecret } from "../../lib/crypto-secret.js";
 import { emailService } from "../../lib/email.js";
 import {
+  renderInviteEmail,
+  renderPasswordResetEmail,
+} from "../../lib/email-templates.js";
+import {
   INVITE_TTL_MS,
   PASSWORD_RESET_TTL_MS,
   deleteTokensFor,
@@ -279,15 +283,31 @@ export { type ObjectId };
 // ─── POST /api/v1/auth/invite (admin-only) ───────────────────────────
 
 /**
+ * App origin used to build absolute URLs in outbound emails. Without
+ * this the invite/reset links would be relative — fine inside the app,
+ * useless in an email client.
+ *
+ * Set APP_URL (or NEXT_PUBLIC_APP_URL as a fallback) in production.
+ * Defaults to localhost:3000 for dev.
+ */
+function appOrigin(): string {
+  const raw =
+    process.env.APP_URL?.trim() ||
+    process.env.NEXT_PUBLIC_APP_URL?.trim() ||
+    "http://localhost:3000";
+  return raw.replace(/\/$/, "");
+}
+
+/**
  * Public URL the user clicks to accept an invite. Frontend renders the
  * page; the page POSTs the token to /api/v1/auth/accept-invite.
  */
 function buildInviteUrl(token: string): string {
-  return `/accept-invite?token=${encodeURIComponent(token)}`;
+  return `${appOrigin()}/accept-invite?token=${encodeURIComponent(token)}`;
 }
 
 function buildPasswordResetUrl(token: string): string {
-  return `/password-reset?token=${encodeURIComponent(token)}`;
+  return `${appOrigin()}/password-reset?token=${encodeURIComponent(token)}`;
 }
 
 export async function inviteHandler(
@@ -362,20 +382,41 @@ export async function inviteHandler(
       userAgent: meta.ua,
     });
 
-    await emailService.send({
-      to: email,
-      subject: `You're invited to ${org.name}`,
-      body: [
-        `Hi ${displayName},`,
-        ``,
-        `You've been invited to join ${org.name} on eSpace Dev Hub.`,
-        `Click the link below to set your password and activate your account:`,
-        ``,
-        buildInviteUrl(plaintext),
-        ``,
-        `This link expires in 7 days.`,
-      ].join("\n"),
+    // Look up the inviter's display name for the email greeting.
+    // Best-effort — if it fails the template falls back to the
+    // generic "You're invited" wording.
+    let inviterDisplayName: string | null = null;
+    try {
+      const inviter = await users.findOne(
+        { _id: session.userId },
+        { projection: { displayName: 1 } },
+      );
+      inviterDisplayName = inviter?.displayName ?? null;
+    } catch {
+      /* non-fatal */
+    }
+
+    const expiresInDays = Math.round(INVITE_TTL_MS / (24 * 60 * 60 * 1000));
+    const inviteUrl = buildInviteUrl(plaintext);
+    const inviteEmail = renderInviteEmail({
+      displayName,
+      orgName: org.name,
+      acceptUrl: inviteUrl,
+      expiresInDays,
+      inviterDisplayName,
     });
+    const inviteResult = await emailService.send({
+      to: email,
+      subject: inviteEmail.subject,
+      text: inviteEmail.text,
+      html: inviteEmail.html,
+    });
+    if (!inviteResult.ok) {
+      logger.warn(
+        { email, reason: inviteResult.reason },
+        "[auth.invite] email send failed — token minted, user must be informed manually",
+      );
+    }
 
     await writeAudit({
       orgId: org._id,
@@ -518,20 +559,29 @@ export async function passwordResetRequestHandler(
         userAgent: meta.ua,
       });
 
-      await emailService.send({
-        to: email,
-        subject: "Reset your eSpace Dev Hub password",
-        body: [
-          `Hi ${user.displayName},`,
-          ``,
-          `A password reset was requested for your account.`,
-          `Click the link below to choose a new password:`,
-          ``,
-          buildPasswordResetUrl(plaintext),
-          ``,
-          `This link expires in 1 hour. If you didn't request this, ignore this email — your password will stay unchanged.`,
-        ].join("\n"),
+      const expiresInHours = Math.max(
+        1,
+        Math.round(PASSWORD_RESET_TTL_MS / (60 * 60 * 1000)),
+      );
+      const resetEmail = renderPasswordResetEmail({
+        displayName: user.displayName,
+        resetUrl: buildPasswordResetUrl(plaintext),
+        expiresInHours,
+        ip: meta.ip,
+        userAgent: meta.ua,
       });
+      const resetResult = await emailService.send({
+        to: email,
+        subject: resetEmail.subject,
+        text: resetEmail.text,
+        html: resetEmail.html,
+      });
+      if (!resetResult.ok) {
+        logger.warn(
+          { email, reason: resetResult.reason },
+          "[auth.password-reset] email send failed — token minted but not delivered",
+        );
+      }
 
       await writeAudit({
         orgId: user.orgId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "otplib": "^12.0.1",
         "pino": "^10.0.0",
         "pino-http": "^11.0.0",
+        "resend": "^6.12.3",
         "zod": "^4.1.13"
       },
       "devDependencies": {
@@ -3556,6 +3557,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -5425,6 +5432,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -7416,6 +7429,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
@@ -7833,6 +7852,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -8296,6 +8336,16 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/static-eval": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.1.tgz",
@@ -8404,6 +8454,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/swagger2openapi": {


### PR DESCRIPTION
## Summary

Replaces the dev-only log-and-pretend emailer with a Resend-backed transport. Invite + password-reset emails now actually send when ``RESEND_API_KEY`` is configured, with a graceful fallback to logging for fresh dev checkouts.

## Three modes (picked from env at module load)

- **log** — ``RESEND_API_KEY`` unset. Message body lands in the structured log. Fresh dev checkouts work with zero config.
- **sandbox** — key set + ``RESEND_DOMAIN_MODE=sandbox`` (default). Sends from ``onboarding@resend.dev`` to recipients verified in the Resend dashboard. No DNS required.
- **verified** — ``RESEND_DOMAIN_MODE=verified``. Sends from ``RESEND_FROM_EMAIL`` on a DKIM/SPF-verified domain. Production.

Flip-the-switch upgrade path: add DNS records on eSpace's domain, set ``RESEND_DOMAIN_MODE=verified``. Zero code change.

## What ships

- ``apps/api/src/lib/email.ts`` — two transports, picked at module-load. Discriminated ``{ok, id?} | {ok, reason}`` result so callers know whether delivery actually succeeded. Failures never throw; auth flows respond 200 either way to preserve email-enumeration resistance.
- ``apps/api/src/lib/email-templates.ts`` — pure ``renderInviteEmail`` + ``renderPasswordResetEmail``. Branded HTML wrapper + plain-text body, minimal CSS, no images. Small enough to dodge Gmail truncation. Hidden preheader for inbox preview.
- ``apps/api/src/modules/auth/controller.ts`` — invite + password-reset handlers use the new renderers. New ``appOrigin()`` reads ``APP_URL`` so invite/reset links are absolute (otherwise unclickable in Gmail). Invite handler looks up the inviter's displayName for the greeting (best-effort).
- ``apps/api/.env.example`` — documents ``APP_URL`` + the four ``RESEND_*`` vars.
- ``apps/api/package.json`` — adds ``resend`` as a runtime dep.

## Test plan

- [x] ``npm run typecheck:api`` — clean
- [x] ``npm run build:api`` — clean; dist resolves ``resend``
- [x] Node smoke import — ``sendEmail()`` returns ``{ok: true}`` in log mode without ``RESEND_API_KEY``
- [ ] Set ``RESEND_API_KEY`` (sandbox), verify your test email in the Resend dashboard, trigger an invite — message lands in your inbox with the branded template
- [ ] Trigger a password reset — message lands, IP/UA footer renders correctly
- [ ] Failed send (e.g. unverified recipient in sandbox) — handler still responds 200, ``[auth.invite] email send failed`` warn line appears in the API log

## Follow-ups (out of scope)

- DNS verification on eSpace's domain → flip ``RESEND_DOMAIN_MODE=verified``
- ``/admin/email/test`` endpoint so ops can poke the transport without going through invite/reset
- Rate limit the invite + password-reset endpoints (M8.3, next PR)