### PR TITLE
M8.3: per-IP rate limiting on public auth endpoints

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.5.1",
     "helmet": "^8.1.0",
     "mongodb": "^6.21.0",
     "nanoid": "^5.1.6",

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,134 @@
+/**
+ * Rate-limit middleware factories for the auth routes.
+ *
+ * Goal: protect the public auth endpoints from credential-stuffing,
+ * email-enumeration spam, and brute-force attacks. Complements the
+ * existing per-account lockout (5 failed logins → 15 min lockout in
+ * the user document) — that handles account-level abuse; this layer
+ * handles per-source (IP) abuse so an attacker sweeping many accounts
+ * from a single host gets throttled before lockout even triggers.
+ *
+ * Storage: in-process memory store (the express-rate-limit default).
+ * Trade-offs:
+ *   - Cheap: zero infra, restart-safe (a restart wipes counters but
+ *     a horizon of minutes is fine for the threat model).
+ *   - Single-instance: counters don't share across processes. The
+ *     API runs as one Node process today; when we go multi-instance
+ *     we swap in a Redis store (`rate-limit-redis`) — that's a
+ *     one-file change because the limiters all read from a single
+ *     factory below.
+ *
+ * Error shape: when the limit triggers, the middleware throws an
+ * HttpError(429, "rate_limited", …). That goes through the existing
+ * error handler so the response matches the standard envelope. The
+ * client gets RateLimit-* headers (RFC 9728 draft) so it can back
+ * off gracefully.
+ */
+
+import rateLimit, { type Options } from "express-rate-limit";
+import type { Request, Response, NextFunction } from "express";
+import { HttpError } from "./error-handler.js";
+
+interface LimiterConfig {
+  /** Window length in ms. */
+  windowMs: number;
+  /** Max requests per window per key. */
+  max: number;
+  /** Identifier used in the error message ("login", "totp-verify", …). */
+  label: string;
+}
+
+/**
+ * Build a per-IP limiter that fits the rest of the API's error shape.
+ * The handler synthesises an HttpError so the response envelope is
+ * the standard `{ok:false, error:{code, message}}` — never the
+ * default plain-text "Too many requests" from express-rate-limit.
+ */
+function buildLimiter(cfg: LimiterConfig) {
+  const opts: Partial<Options> = {
+    windowMs: cfg.windowMs,
+    max: cfg.max,
+    standardHeaders: "draft-7", // RateLimit-Policy, RateLimit, RateLimit-Reset
+    legacyHeaders: false, // suppress X-RateLimit-* (redundant)
+    skipSuccessfulRequests: false,
+    // Express handles trust-proxy globally; use whatever it resolves
+    // to as the rate-limit key. For the public auth endpoints that's
+    // the client's IP — the only thing we have before authentication.
+    keyGenerator: (req: Request) => req.ip ?? "unknown",
+    handler: (_req: Request, _res: Response, next: NextFunction) => {
+      next(
+        new HttpError(
+          429,
+          "rate_limited",
+          `Too many ${cfg.label} attempts. Wait a moment and try again.`,
+        ),
+      );
+    },
+  };
+  return rateLimit(opts);
+}
+
+// ─── per-endpoint limiters ────────────────────────────────────────────
+//
+// Window + max values picked to be generous enough that a real user
+// fat-fingering a password 4-5 times doesn't hit the limit, but tight
+// enough that automated credential-stuffing burns out fast. Per-account
+// lockout (in the user document) is the second layer; this is the
+// per-IP layer.
+
+/**
+ * /login — 10 attempts per 5 minutes per IP. A user mistyping a few
+ * times is fine; a stuffing tool gets 10 tries before a 5-minute pause.
+ */
+export const loginLimiter = buildLimiter({
+  windowMs: 5 * 60 * 1000,
+  max: 10,
+  label: "login",
+});
+
+/**
+ * /totp/verify — 10 attempts per 5 minutes per IP. Step 2 of two-step
+ * login. TOTP codes are 6 digits → 10^6 space; 10/5min means a brute
+ * force on a single 30s window is bounded to a tiny success probability.
+ */
+export const totpLimiter = buildLimiter({
+  windowMs: 5 * 60 * 1000,
+  max: 10,
+  label: "TOTP-verify",
+});
+
+/**
+ * /password/reset-request — 5 per hour per IP. The endpoint always
+ * returns 200 regardless of whether the email is registered (no
+ * enumeration), so the limit's job is to prevent email-spam abuse:
+ * an attacker can't trigger 1000 reset emails per hour against a
+ * victim's address.
+ */
+export const passwordResetRequestLimiter = buildLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  label: "password-reset-request",
+});
+
+/**
+ * /password/reset — 10 per hour per IP. Token redemption. Tokens are
+ * single-use and time-bounded; the limit just slows brute-force of
+ * the token space (tokens are random 32-byte → cryptographically
+ * infeasible to guess; the limiter is belt-and-suspenders).
+ */
+export const passwordResetLimiter = buildLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+  label: "password-reset",
+});
+
+/**
+ * /accept-invite — 20 per hour per IP. Same shape as password-reset
+ * (token redemption). Window is more generous because legitimate
+ * users sometimes click the link twice.
+ */
+export const inviteAcceptLimiter = buildLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 20,
+  label: "invite-accept",
+});

--- a/apps/api/src/modules/auth/routes.ts
+++ b/apps/api/src/modules/auth/routes.ts
@@ -28,6 +28,13 @@ import { Router } from "express";
 import { requireAuth } from "../../middleware/require-auth.js";
 import { requireRole } from "../../middleware/require-role.js";
 import {
+  inviteAcceptLimiter,
+  loginLimiter,
+  passwordResetLimiter,
+  passwordResetRequestLimiter,
+  totpLimiter,
+} from "../../middleware/rate-limit.js";
+import {
   acceptInviteHandler,
   inviteHandler,
   loginHandler,
@@ -44,17 +51,27 @@ import {
 export const authRouter: Router = Router();
 
 // ─── public ──────────────────────────────────────────────────────────
-authRouter.post("/login", loginHandler);
+// Rate-limited per IP. Per-account lockout (in the user document) is
+// the second layer; this is the per-source-IP layer that handles a
+// stuffing attack sweeping many accounts from one host.
+authRouter.post("/login", loginLimiter, loginHandler);
 authRouter.post("/logout", logoutHandler);
-authRouter.post("/accept-invite", acceptInviteHandler);
-authRouter.post("/password/reset-request", passwordResetRequestHandler);
-authRouter.post("/password/reset", passwordResetHandler);
+authRouter.post("/accept-invite", inviteAcceptLimiter, acceptInviteHandler);
+authRouter.post(
+  "/password/reset-request",
+  passwordResetRequestLimiter,
+  passwordResetRequestHandler,
+);
+authRouter.post("/password/reset", passwordResetLimiter, passwordResetHandler);
 
 // ─── partial session OK ──────────────────────────────────────────────
 // requireTotp:false lets a totpVerified:false session reach this route
 // (the entire purpose of the route is to flip that bit to true).
+// Rate-limited because this is step 2 of the public login flow — an
+// attacker who has a valid password+cookie still has to clear TOTP.
 authRouter.post(
   "/totp/verify",
+  totpLimiter,
   requireAuth({ requireTotp: false }),
   totpVerifyLoginHandler,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.5.1",
         "helmet": "^8.1.0",
         "mongodb": "^6.21.0",
         "nanoid": "^5.1.6",
@@ -5380,6 +5381,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/ext": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
@@ -5908,6 +5927,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {


### PR DESCRIPTION
## Summary

Adds the per-source-IP rate-limit layer the auth flows were missing. Combined with the existing per-account lockout (5 failed logins → 15 min in the user document), an attacker now has to:
- spread the attack across many IPs to dodge this layer, **and**
- keep per-account attempts under 5 to dodge the account lockout

to make any progress.

## What ships

- ``apps/api/src/middleware/rate-limit.ts`` — single ``buildLimiter()`` factory returning an express-rate-limit instance wrapped to throw ``HttpError(429, "rate_limited")``. Goes through the standard error handler so 429s match the rest of the API's response envelope. RateLimit-* response headers (draft-7) emitted for graceful client back-off.
- Five limiters exported, one per endpoint shape:
  | Endpoint | Limit |
  | --- | --- |
  | ``/login`` | 10 / 5 min |
  | ``/totp/verify`` | 10 / 5 min |
  | ``/password/reset-request`` | 5 / 1 hr |
  | ``/password/reset`` | 10 / 1 hr |
  | ``/accept-invite`` | 20 / 1 hr |
- ``apps/api/src/modules/auth/routes.ts`` — each public endpoint gets its corresponding limiter prepended. ``/totp/verify`` gets the limiter **before** ``requireAuth`` so a stuffing attempt without a valid partial-session cookie still burns the IP's quota.

## Storage

In-process memory (express-rate-limit's default). Single-instance API today; counters wipe on restart (fine for the threat model — worst case is a 5–10 minute reprieve after a deploy). When we go multi-instance, swap to ``rate-limit-redis`` — one line inside ``buildLimiter()``, no consumer changes. Redis is already running in docker-compose so the upgrade path is clear.

## Trust-proxy

Already set to ``1`` in ``app.ts`` so ``req.ip`` resolves to the real client IP behind the dev-mode Next.js rewrite. Prod deploys behind a single reverse proxy keep the same value; deeper topologies bump the number.

## Test plan

- [x] ``npm run typecheck:api`` — clean
- [x] ``npm run build:api`` — clean
- [ ] Hit ``/login`` 11 times in 5 min from one IP → 11th attempt returns 429 with ``{error:{code:"rate_limited"}}``
- [ ] Reload after 5 min → succeeds again
- [ ] Verify ``RateLimit-Limit`` / ``RateLimit-Reset`` headers appear on every response

## Out of scope (future)

- Env-tunable windows/maxes (``RATE_LIMIT_LOGIN_MAX`` etc.). Defaults are deliberate; tune after observing real traffic.
- Redis-backed store (multi-instance scale).
- Per-account/per-email keyed limits as a third layer — account lockout covers most of that; revisit if we see distributed stuffing against a single account from many IPs.