### PR TITLE
M10.1: hub orchestrator primitives — registry + per-user hub access

### DIFF
--- a/apps/api/scripts/admin-create.ts
+++ b/apps/api/scripts/admin-create.ts
@@ -33,6 +33,7 @@ import { hashPassword } from "../src/lib/argon2.js";
 import { writeAudit } from "../src/lib/audit.js";
 import { logger } from "../src/lib/logger.js";
 import type { User } from "../src/db/types.js";
+import { DEFAULT_HUB_ID, HUB_ORDER } from "@espace-devhub/shared/hubs";
 
 interface Args {
   email: string;
@@ -162,6 +163,12 @@ async function main(): Promise<void> {
     lastLoginAt: null,
     failedLoginAttempts: 0,
     lockedUntil: null,
+    // Bootstrap admin lands with access to every hub by default —
+    // they're the org's first user and the most likely candidate to
+    // visit any hub for setup work. Onboarding (M-OB) and the admin
+    // config UI (M10.5) refine this for everyone else.
+    allowedHubs: [...HUB_ORDER],
+    primaryHub: DEFAULT_HUB_ID,
   } as unknown as User;
 
   await users.insertOne(draft);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -38,6 +38,7 @@ import { snapshotsRouter } from "./modules/snapshots/routes.js";
 import { gradingVerdictsRouter } from "./modules/grading-verdicts/routes.js";
 import { integrationsRouter } from "./modules/integrations/routes.js";
 import { migrateRouter } from "./modules/migrate/routes.js";
+import { hubsRouter } from "./modules/hubs/routes.js";
 
 /**
  * Cast a connect-style middleware to Express's RequestHandler. helmet,
@@ -127,6 +128,7 @@ export function buildApp(): Application {
   app.use("/api/v1/grading-verdicts", gradingVerdictsRouter);
   app.use("/api/v1/integrations", integrationsRouter);
   app.use("/api/v1/migrate", migrateRouter);
+  app.use("/api/v1/hubs", hubsRouter);
 
   // ─── tail handlers ─────────────────────────────────────────────────
   app.use(notFoundHandler);

--- a/apps/api/src/db/schemas/users.schema.ts
+++ b/apps/api/src/db/schemas/users.schema.ts
@@ -62,6 +62,17 @@ export const usersValidator: Document = {
       lastLoginAt: { bsonType: ["date", "null"] },
       failedLoginAttempts: { bsonType: "int", minimum: 0 },
       lockedUntil: { bsonType: ["date", "null"] },
+      // M10.1: hub access. Both fields are OPTIONAL on existing rows
+      // so we don't force a backward-incompatible migration; the
+      // controller reads with defaults (allowedHubs ?? [DEFAULT_HUB_ID],
+      // primaryHub ?? DEFAULT_HUB_ID). New user-creation paths (invite
+      // accept, admin-create CLI) set them explicitly.
+      allowedHubs: {
+        bsonType: ["array", "null"],
+        items: { bsonType: "string", minLength: 1, maxLength: 64 },
+        maxItems: 32,
+      },
+      primaryHub: { bsonType: ["string", "null"], maxLength: 64 },
     },
   },
 };

--- a/apps/api/src/db/types.ts
+++ b/apps/api/src/db/types.ts
@@ -112,6 +112,22 @@ export interface User {
    */
   failedLoginAttempts: number;
   lockedUntil: Date | null;
+
+  // ─ hubs (M10.1). Both fields are optional on existing rows; readers
+  //   apply the DEFAULT_HUB_ID fallback so pre-M10 users keep working.
+  //   New user-creation paths (admin-create, invite-accept) populate
+  //   them explicitly. M-OB updates them when the user picks a hub.
+  /**
+   * Hub ids this user is allowed to access. Drives the hub-switcher
+   * in the header + the hub-route guard. Empty array would lock the
+   * user out of every hub; readers default to [DEFAULT_HUB_ID].
+   */
+  allowedHubs?: string[] | null;
+  /**
+   * Default landing hub when the user hits `/`. Must be a member of
+   * `allowedHubs`. Defaults to DEFAULT_HUB_ID when missing.
+   */
+  primaryHub?: string | null;
 }
 
 // ─── sessions ────────────────────────────────────────────────────────

--- a/apps/api/src/modules/auth/controller.ts
+++ b/apps/api/src/modules/auth/controller.ts
@@ -29,6 +29,7 @@ import {
   renderInviteEmail,
   renderPasswordResetEmail,
 } from "../../lib/email-templates.js";
+import { DEFAULT_HUB_ID } from "@espace-devhub/shared/hubs";
 import {
   INVITE_TTL_MS,
   PASSWORD_RESET_TTL_MS,
@@ -367,6 +368,11 @@ export async function inviteHandler(
         lastLoginAt: null,
         failedLoginAttempts: 0,
         lockedUntil: null,
+        // M10.1: every new invite lands with access to the default hub.
+        // Onboarding (M-OB) can broaden allowedHubs based on the
+        // user's department; admins can override later via M10.5.
+        allowedHubs: [DEFAULT_HUB_ID],
+        primaryHub: DEFAULT_HUB_ID,
       } as unknown as User;
       await users.insertOne(draft);
       user = draft;

--- a/apps/api/src/modules/hubs/controller.ts
+++ b/apps/api/src/modules/hubs/controller.ts
@@ -1,0 +1,86 @@
+/**
+ * /api/v1/hubs/me — returns the hubs the current user can access.
+ *
+ * Reads the user's `allowedHubs` + `primaryHub` from the session-
+ * referenced user doc, resolves them against the shared registry,
+ * and returns:
+ *
+ *   {
+ *     hubs: HubDefinition[],     // ordered by HUB_ORDER
+ *     primaryHubId: string,      // member of hubs[*].id
+ *     defaultHubId: string,      // the registry's overall default
+ *   }
+ *
+ * Pre-M10 users have neither field on their doc; we apply the
+ * DEFAULT_HUB_ID fallback so the response stays useful while we
+ * roll out the schema (no migration required).
+ *
+ * Public per-hub metadata (theme, allowedIntegrations, page slots,
+ * widget catalog) ships in the response so the frontend can render
+ * the chrome without a separate registry fetch.
+ */
+
+import type { NextFunction, Request, Response } from "express";
+import {
+  DEFAULT_HUB_ID,
+  HUBS,
+  findHubById,
+  resolveAllowedHubs,
+} from "@espace-devhub/shared/hubs";
+import { getUsersCollection } from "../../db/collections.js";
+import { HttpError } from "../../middleware/error-handler.js";
+
+export async function listMyHubsHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+
+    const users = await getUsersCollection();
+    const user = await users.findOne(
+      { _id: session.userId },
+      { projection: { allowedHubs: 1, primaryHub: 1 } },
+    );
+    if (!user) {
+      // Session referenced a deleted user — let the existing auth
+      // path surface this as an unauthenticated state.
+      throw new HttpError(401, "unauthenticated", "User no longer exists.");
+    }
+
+    // Resolve allowed hubs through the registry. Unknown ids on the
+    // user doc are silently filtered out so a hub removed from the
+    // registry doesn't leave the user staring at a broken switcher.
+    const allowedIds =
+      Array.isArray(user.allowedHubs) && user.allowedHubs.length > 0
+        ? user.allowedHubs
+        : [DEFAULT_HUB_ID];
+    let hubs = resolveAllowedHubs(allowedIds);
+    if (hubs.length === 0) {
+      // Defense in depth: if the user's allowedHubs all reference
+      // unknown ids, fall back to the default rather than returning
+      // an empty list (which would lock the user out of every hub).
+      const fallback = findHubById(DEFAULT_HUB_ID);
+      hubs = fallback ? [fallback] : Object.values(HUBS);
+    }
+
+    const primaryHubId =
+      (typeof user.primaryHub === "string" &&
+        hubs.some((h) => h.id === user.primaryHub) &&
+        user.primaryHub) ||
+      hubs[0]?.id ||
+      DEFAULT_HUB_ID;
+
+    res.json({
+      hubs,
+      primaryHubId,
+      defaultHubId: DEFAULT_HUB_ID,
+    });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/apps/api/src/modules/hubs/routes.ts
+++ b/apps/api/src/modules/hubs/routes.ts
@@ -1,0 +1,19 @@
+/**
+ * /api/v1/hubs/* router.
+ *
+ *   GET /me   authed — returns the hubs the current user can access,
+ *                       their primary hub, and the registry's default.
+ *
+ * No write surface here yet. Updating a user's allowedHubs / primaryHub
+ * is an admin / onboarding-flow concern that lands in M10.5 (admin
+ * config) and M-OB (onboarding). The registry itself is code-only
+ * for M10.1; M10.5 layers an overrides collection on top.
+ */
+
+import { Router } from "express";
+import { requireAuth } from "../../middleware/require-auth.js";
+import { listMyHubsHandler } from "./controller.js";
+
+export const hubsRouter: Router = Router();
+
+hubsRouter.get("/me", requireAuth(), listMyHubsHandler);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,6 +14,10 @@
     "./goal-specs": {
       "types": "./src/goal-specs/index.d.ts",
       "default": "./src/goal-specs/index.js"
+    },
+    "./hubs": {
+      "types": "./src/hubs/index.d.ts",
+      "default": "./src/hubs/index.js"
     }
   },
   "files": [

--- a/packages/shared/src/hubs/index.d.ts
+++ b/packages/shared/src/hubs/index.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Type barrel for @espace-devhub/shared/hubs.
+ */
+
+export {
+  ALL_PROVIDERS,
+  DEFAULT_HUB_ID,
+  HUBS,
+  HUB_ORDER,
+  PAGE_SLOTS,
+  findHubById,
+  getHubIdForDepartment,
+  resolveAllowedHubs,
+} from "./registry.js";
+
+export type {
+  HubDefinition,
+  HubPageSlot,
+  HubTheme,
+} from "./registry.js";

--- a/packages/shared/src/hubs/index.js
+++ b/packages/shared/src/hubs/index.js
@@ -1,0 +1,17 @@
+/**
+ * Public API for the shared hub registry.
+ *
+ *   import { HUBS, findHubById, getHubIdForDepartment }
+ *     from "@espace-devhub/shared/hubs";
+ */
+
+export {
+  ALL_PROVIDERS,
+  DEFAULT_HUB_ID,
+  HUBS,
+  HUB_ORDER,
+  PAGE_SLOTS,
+  findHubById,
+  getHubIdForDepartment,
+  resolveAllowedHubs,
+} from "./registry.js";

--- a/packages/shared/src/hubs/registry.d.ts
+++ b/packages/shared/src/hubs/registry.d.ts
@@ -1,0 +1,60 @@
+/**
+ * Type signatures for the hub registry. Runtime lives in registry.js.
+ */
+
+export interface HubTheme {
+  /** Primary brand colour for the hub (text, borders, badges). */
+  primary: string;
+  /** Accent colour used for CTAs + selected nav state. */
+  accent: string;
+  /** Translucent variant used for chip / tile backgrounds. */
+  accentSurface: string;
+}
+
+export type HubPageSlot =
+  | "dashboard"
+  | "goals"
+  | "evidence"
+  | "snapshots"
+  | "reviews"
+  | "settings"
+  | "analyst";
+
+export interface HubDefinition {
+  /** Stable URL slug + storage key. */
+  id: string;
+  /** Human-readable name shown in switchers, page titles, emails. */
+  label: string;
+  /** One-line description for admin UI + onboarding hover state. */
+  description: string;
+  /** Hub-level theme overrides merged on top of the base palette. */
+  theme: HubTheme;
+  /** Integration provider ids the hub UI exposes. */
+  allowedIntegrations: readonly string[];
+  /**
+   * Page slots the hub mounts. Values are symbolic — apps/web resolves
+   * them to React components at render time. Missing slots aren't
+   * routable for that hub.
+   */
+  pages: Readonly<Partial<Record<HubPageSlot, string>>>;
+  /** Widget ids the hub's dashboard can mount. */
+  widgets: readonly string[];
+  /**
+   * Lowercased, whitespace-trimmed department strings that route to
+   * this hub during onboarding.
+   */
+  departments: readonly string[];
+}
+
+export const ALL_PROVIDERS: readonly ["github", "gitlab", "jira"];
+export const PAGE_SLOTS: readonly HubPageSlot[];
+
+export const HUBS: Readonly<Record<string, HubDefinition>>;
+export const HUB_ORDER: readonly string[];
+export const DEFAULT_HUB_ID: string;
+
+export function findHubById(id: unknown): HubDefinition | null;
+export function getHubIdForDepartment(department: unknown): string | null;
+export function resolveAllowedHubs(
+  allowedHubIds: readonly string[] | null | undefined,
+): HubDefinition[];

--- a/packages/shared/src/hubs/registry.js
+++ b/packages/shared/src/hubs/registry.js
@@ -1,0 +1,203 @@
+/**
+ * Hub registry — single source of truth for what hubs exist, what
+ * each one is capable of, and which departments map to it.
+ *
+ * Design contract (M10.1):
+ *   - Hubs are DATA, not modules. Adding a hub later is one entry
+ *     here + a folder under apps/web/src/hubs/<id>/ (M10.3+). Pages
+ *     and widgets reference symbolic ids the rest of the app resolves
+ *     to React components.
+ *   - The shape is forward-compatible with admin overrides (M10.5):
+ *     a future hub_configs Mongo collection holds per-(orgId, hubId)
+ *     toggles that merge on top of these defaults at request time.
+ *   - Everything here is pure data — no React, no Node-only APIs.
+ *     Same import works in apps/web (JS, browser) and apps/api (TS,
+ *     server).
+ *
+ * Currently two hubs:
+ *   dev  — Engineering performance & evidence tracking. The hub the
+ *          entire app started as.
+ *   qa   — QA performance & defect tracking. Scaffolded only at
+ *          M10.1; widgets land in M10.3.
+ *
+ * Adding a hub: append to HUBS below, add departments → hubId
+ * mappings, drop a folder under apps/web/src/hubs/<id>/. Onboarding
+ * (M-OB) reads `departments` to route the user.
+ */
+
+// ─── shapes ──────────────────────────────────────────────────────────
+
+/**
+ * Hub-level theme overrides. Hub layout merges these on top of the
+ * base CSS variables so each hub gets its own palette without a
+ * stylesheet swap. Only the variables a hub actually needs to
+ * override appear — the rest inherit.
+ */
+function freezeTheme(t) {
+  return Object.freeze({ ...t });
+}
+
+/** Catalog of currently-supported integration provider ids. */
+export const ALL_PROVIDERS = Object.freeze(["github", "gitlab", "jira"]);
+
+/**
+ * Page slot ids the hub layout can render. Each hub picks which
+ * slots it exposes and which component each maps to (resolved by
+ * apps/web at render time). The slot ids stay stable across hubs
+ * so a department-agnostic widget (e.g. snapshot list) can be
+ * routed to the same slot in any hub.
+ */
+export const PAGE_SLOTS = Object.freeze([
+  "dashboard",
+  "goals",
+  "evidence",
+  "snapshots",
+  "reviews",
+  "settings",
+  "analyst",
+]);
+
+// ─── hub definitions ─────────────────────────────────────────────────
+
+const DEV_HUB = Object.freeze({
+  id: "dev",
+  label: "Dev Hub",
+  description: "Engineering performance & evidence tracking.",
+  theme: freezeTheme({
+    primary: "#0a7a5a",
+    accent: "#0a7a5a",
+    accentSurface: "rgba(10,122,90,0.08)",
+  }),
+  /** Integrations the hub UI exposes in Settings. */
+  allowedIntegrations: Object.freeze(["github", "gitlab", "jira"]),
+  /**
+   * Pages this hub mounts under /<hubId>/. The values are symbolic
+   * — apps/web resolves "dashboard" to the right component at render
+   * time. Setting a value to `null` means "this hub doesn't expose
+   * that slot".
+   */
+  pages: Object.freeze({
+    dashboard: "dev:dashboard",
+    goals: "dev:goals",
+    evidence: "dev:evidence",
+    snapshots: "dev:snapshots",
+    reviews: "dev:reviews",
+    settings: "dev:settings",
+    analyst: "dev:analyst",
+  }),
+  /** Widget catalogue this hub's dashboard can mount. */
+  widgets: Object.freeze([
+    "pr-rounds",
+    "cycle-time",
+    "merged-count",
+    "review-turnaround",
+    "linkage",
+    "ticket-cycle",
+    "code-rubric",
+  ]),
+  /**
+   * Department strings (case-insensitive, normalised at lookup) that
+   * route to this hub on first-login onboarding. M-OB reads this.
+   */
+  departments: Object.freeze([
+    "engineering",
+    "platform",
+    "backend",
+    "frontend",
+    "mobile",
+    "devops",
+    "sre",
+  ]),
+});
+
+const QA_HUB = Object.freeze({
+  id: "qa",
+  label: "QA Hub",
+  description: "QA performance & defect tracking.",
+  theme: freezeTheme({
+    primary: "#7a4a0a",
+    accent: "#b8722d",
+    accentSurface: "rgba(184,114,45,0.08)",
+  }),
+  allowedIntegrations: Object.freeze(["gitlab", "jira"]),
+  // Pages are stubbed; M10.3 wires the real QA pages. The dashboard
+  // slot is present so onboarding routing has a valid landing target
+  // for QA users from day one.
+  pages: Object.freeze({
+    dashboard: "qa:dashboard",
+    goals: "qa:goals",
+    evidence: "qa:evidence",
+    settings: "qa:settings",
+  }),
+  widgets: Object.freeze([
+    // Placeholders — real QA widgets land in M10.3.
+    "defect-leakage",
+    "test-cycle-time",
+    "regression-rate",
+  ]),
+  departments: Object.freeze([
+    "qa",
+    "quality assurance",
+    "testing",
+    "quality",
+  ]),
+});
+
+/**
+ * The canonical registry. Indexed by id for O(1) lookup; iterate
+ * via Object.values(HUBS) when you need every hub.
+ */
+export const HUBS = Object.freeze({
+  [DEV_HUB.id]: DEV_HUB,
+  [QA_HUB.id]: QA_HUB,
+});
+
+/** Stable order for any list UI (header switcher, admin page). */
+export const HUB_ORDER = Object.freeze([DEV_HUB.id, QA_HUB.id]);
+
+/** The hub onboarding routes to when no department mapping matches. */
+export const DEFAULT_HUB_ID = DEV_HUB.id;
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Look up a hub by id. Returns null when no match — callers should
+ * check rather than assume so an unknown id (e.g. a stale URL) doesn't
+ * crash the layout.
+ */
+export function findHubById(id) {
+  if (typeof id !== "string") return null;
+  return HUBS[id] ?? null;
+}
+
+/**
+ * Map a department string (any case, any whitespace) to the matching
+ * hub id. Returns the DEFAULT_HUB_ID when nothing matches — onboarding
+ * (M-OB) calls this to pick where a new user lands. Returns null when
+ * `department` is empty/missing so the caller can prompt instead of
+ * silently routing to dev.
+ */
+export function getHubIdForDepartment(department) {
+  if (typeof department !== "string" || department.trim().length === 0) {
+    return null;
+  }
+  const norm = department.trim().toLowerCase();
+  for (const hub of Object.values(HUBS)) {
+    if (hub.departments.includes(norm)) return hub.id;
+  }
+  return DEFAULT_HUB_ID;
+}
+
+/**
+ * Resolve the list of HubDefinition objects a user can access, given
+ * their `allowedHubs` array. Unknown ids are filtered out silently so
+ * an admin removing a hub doesn't leave users staring at a broken
+ * switcher. Preserves HUB_ORDER.
+ */
+export function resolveAllowedHubs(allowedHubIds) {
+  if (!Array.isArray(allowedHubIds)) return [];
+  const set = new Set(allowedHubIds);
+  return HUB_ORDER.filter((id) => set.has(id))
+    .map((id) => HUBS[id])
+    .filter(Boolean);
+}


### PR DESCRIPTION
## Summary

Lays the groundwork for the hub family (Dev / QA / future) as **data, not code**. Adding a hub later is one registry entry + a folder under ``apps/web/src/hubs/<id>/``. After this PR the registry is consumable from both apps; M10.2 migrates the existing Dev Hub under ``/[hub]/…`` and M-OB / M10.3 / M10.5 land on top.

## What ships

**``packages/shared/src/hubs/``** — two ``HubDefinition``s (dev, qa) keyed on stable ids, with theme overrides, ``allowedIntegrations``, ``pages: {slot → symbolic id}``, ``widgets``, and ``departments`` for onboarding lookup. Three helpers (``findHubById``, ``getHubIdForDepartment``, ``resolveAllowedHubs``). Same JS-runtime + ``.d.ts``-sidecar pattern as ``goal-specs``.

**User schema** — ``allowedHubs?: string[]`` + ``primaryHub?: string`` added to the ``users`` ``$jsonSchema`` validator. Optional so existing rows continue to validate; readers apply the ``DEFAULT_HUB_ID`` fallback.

**``GET /api/v1/hubs/me``** — returns ``{hubs, primaryHubId, defaultHubId}``. Resolves the user's allowedHubs through the registry, filters unknown ids silently, and defends against an empty/all-stale list by falling back to the default. Only public surface in M10.1; writes land in M10.5 (admin) + M-OB (onboarding).

**User-creation paths backfilled**:
- Invite-accept draft: ``allowedHubs: [DEFAULT_HUB_ID]``, ``primaryHub: DEFAULT_HUB_ID``
- Bootstrap admin CLI: ``allowedHubs: [...HUB_ORDER]`` (every hub), ``primaryHub: DEFAULT_HUB_ID``

## Test plan

- [x] ``npm run typecheck:api`` — clean
- [x] ``npm run build:api`` — clean
- [x] ``npm run build:web`` — clean
- [x] Node smoke import — ``@espace-devhub/shared/hubs`` resolves from ``apps/api``; ``getHubIdForDepartment('QA')`` → ``qa``, ``Engineering`` → ``dev``, unknown → ``dev``; ``resolveAllowedHubs(['dev','qa'])`` preserves ``HUB_ORDER``
- [ ] Hit ``GET /api/v1/hubs/me`` as a fresh user → response includes both Dev + QA when admin, just Dev for invited users
- [ ] Hit it as a pre-M10 user (no ``allowedHubs`` field) → response defaults to Dev

## What this unblocks

| Milestone | Build |
|---|---|
| M10.2 | Route group ``/[hub]/…`` and Dev Hub migration |
| M10.3 | QA Hub UI scaffold |
| M10.4 | Per-hub integration filter in Settings |
| M10.5 | Admin overrides collection + merge layer |
| M-OB | Onboarding form that routes via ``getHubIdForDepartment`` |

## Not in this PR

- The ``/[hub]/…`` route group itself — M10.2 (moves routes is the migration)
- Frontend hook + hub gate component — M10.2
- Admin overrides — M10.5
- QA Hub UI — M10.3
- Onboarding — M-OB