### PR TITLE
M10.3: QA Hub scaffold — placeholder shell + slot guards

### DIFF
--- a/apps/web/src/app/[hub]/page.jsx
+++ b/apps/web/src/app/[hub]/page.jsx
@@ -1,14 +1,34 @@
-import { AppShell } from "@/components/shell/app-shell";
-import { DashboardPage } from "@/features/dashboard";
+"use client";
 
-// The dashboard reads `?range=<preset>` via useSearchParams, so Next.js
-// must not attempt to statically prerender it.
+/**
+ * Hub-dashboard route. Renders the active hub's dashboard component
+ * picked from apps/web/src/hubs/dashboard-registry.jsx.
+ *
+ *   /dev   → DashboardPage (the full bento dashboard the app started as)
+ *   /qa    → <QaPlaceholder slot="dashboard" />
+ *   /<new> → DefaultDashboardPlaceholder until the registry maps it
+ *
+ * HubProvider in app/[hub]/layout.jsx has already validated the slug
+ * and applied the hub theme, so by the time we render here the hub
+ * is guaranteed non-null (we use useActiveHubStrict to assert that).
+ */
+
+import { AppShell } from "@/components/shell/app-shell";
+import { useActiveHubStrict } from "@/features/hubs";
+import { getDashboardComponent } from "@/hubs/dashboard-registry";
+
+// The Dev dashboard reads `?range=<preset>` via useSearchParams, so
+// Next.js must not attempt to statically prerender this route. The
+// QA placeholder is happy either way; force-dynamic keeps the
+// behaviour identical across hubs.
 export const dynamic = "force-dynamic";
 
-export default function Home() {
+export default function HubDashboardRoute() {
+  const hub = useActiveHubStrict();
+  const Dashboard = getDashboardComponent(hub.id);
   return (
     <AppShell hideFooter>
-      <DashboardPage />
+      <Dashboard />
     </AppShell>
   );
 }

--- a/apps/web/src/app/[hub]/reviews/page.jsx
+++ b/apps/web/src/app/[hub]/reviews/page.jsx
@@ -1,11 +1,24 @@
+"use client";
+
+/**
+ * /[hub]/reviews — the PR review log. Currently a Dev-Hub-only slot;
+ * the QA Hub's registry doesn't include `reviews` in its pages map.
+ *
+ * useHubSlotGuard checks the active hub's `pages.reviews` and, when
+ * missing, redirects the user back to their hub's dashboard. Reads
+ * `?pr=<id>` from useSearchParams to deep-link from the dashboard
+ * tile, so the route is force-dynamic.
+ */
+
 import { AppShell } from "@/components/shell/app-shell";
+import { useHubSlotGuard } from "@/features/hubs";
 import { PrReviewsPage } from "@/features/pr-reviews";
 
-// Reads `?pr=<id>` via `useSearchParams` to deep-link a specific PR from
-// the dashboard tile, so the route cannot be statically prerendered.
 export const dynamic = "force-dynamic";
 
 export default function Page() {
+  const exposed = useHubSlotGuard("reviews");
+  if (!exposed) return null;
   return (
     <AppShell>
       <PrReviewsPage />

--- a/apps/web/src/app/[hub]/snapshots/page.jsx
+++ b/apps/web/src/app/[hub]/snapshots/page.jsx
@@ -1,7 +1,21 @@
+"use client";
+
+/**
+ * /[hub]/snapshots — weekly metric snapshots. Currently a Dev-Hub-only
+ * slot; the QA Hub's registry doesn't include `snapshots` in its
+ * pages map.
+ *
+ * useHubSlotGuard redirects to the hub's dashboard when the slot
+ * isn't exposed.
+ */
+
 import { AppShell } from "@/components/shell/app-shell";
+import { useHubSlotGuard } from "@/features/hubs";
 import { SnapshotsPage } from "@/features/snapshots";
 
 export default function Page() {
+  const exposed = useHubSlotGuard("snapshots");
+  if (!exposed) return null;
   return (
     <AppShell>
       <SnapshotsPage />

--- a/apps/web/src/features/hubs/index.js
+++ b/apps/web/src/features/hubs/index.js
@@ -18,4 +18,5 @@ export { HubRedirect } from "./hub-redirect.jsx";
 export { useAvailableHubs } from "./use-available-hubs.js";
 export { useActiveHub, useActiveHubStrict, HubContext } from "./hub-context.js";
 export { useHubLink } from "./use-hub-link.js";
+export { useHubSlotGuard } from "./use-hub-slot-guard.js";
 export { resetHubsStore } from "./hubs-store.js";

--- a/apps/web/src/features/hubs/use-hub-slot-guard.js
+++ b/apps/web/src/features/hubs/use-hub-slot-guard.js
@@ -1,0 +1,36 @@
+"use client";
+
+/**
+ * Page-level slot guard.
+ *
+ * Each page under app/[hub]/<slot>/ calls this on mount with its
+ * slot id. If the active hub's `pages` map doesn't expose that slot,
+ * the guard redirects to the hub's dashboard. Without it, a QA user
+ * typing /qa/reviews would see the Dev review-log page rendered
+ * under QA theming — confusing.
+ *
+ * Returns:
+ *   true   — slot is exposed; render the page normally
+ *   false  — slot is NOT exposed; a redirect is in flight, render nothing
+ *
+ * The redirect uses router.replace so the back button doesn't bounce
+ * the user between the inaccessible URL and their dashboard.
+ */
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useActiveHub } from "./hub-context.js";
+
+export function useHubSlotGuard(slot) {
+  const hub = useActiveHub();
+  const router = useRouter();
+  const exposed = Boolean(hub?.pages?.[slot]);
+
+  useEffect(() => {
+    if (!hub) return; // HubProvider still loading
+    if (exposed) return;
+    router.replace(`/${hub.id}`);
+  }, [hub, exposed, router]);
+
+  return exposed;
+}

--- a/apps/web/src/hubs/dashboard-registry.jsx
+++ b/apps/web/src/hubs/dashboard-registry.jsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * Per-hub dashboard-component dispatch.
+ *
+ * Each hub gets ONE dashboard React component, picked by hub id at
+ * /[hub]/page.jsx. The lookup is open-ended: new hubs added to the
+ * shared registry just need a corresponding entry here. Hubs without
+ * an entry fall through to <DefaultDashboardPlaceholder /> which
+ * renders the same QA-placeholder shell so adding a new hub never
+ * produces a broken page.
+ *
+ * Why a separate registry file (not inline in app/[hub]/page.jsx):
+ *   - keeps the page file at "import + dispatch" — no business logic
+ *   - lets future per-hub bits (widget catalogs, page-slot resolvers)
+ *     live alongside without bloating the route layer
+ *   - one place to grep when adding a hub
+ */
+
+import { DashboardPage } from "@/features/dashboard";
+import { QaPlaceholder } from "@/hubs/qa";
+
+/**
+ * Map of hubId → React component for the dashboard slot.
+ * Add a new entry when scaffolding a new hub's dashboard.
+ */
+const DASHBOARDS = {
+  dev: DashboardPage,
+  qa: () => <QaPlaceholder slot="dashboard" />,
+};
+
+/**
+ * Generic placeholder for hubs that haven't been scaffolded yet —
+ * uses the QA-style "we're still building" shell. Currently never
+ * mounted (every hub in the registry has an entry above), but exists
+ * so the lookup is total: registering a hub in
+ * `@espace-devhub/shared/hubs` without immediately wiring a
+ * component here still renders a sensible page.
+ */
+function DefaultDashboardPlaceholder() {
+  return <QaPlaceholder slot="dashboard" />;
+}
+
+export function getDashboardComponent(hubId) {
+  return DASHBOARDS[hubId] ?? DefaultDashboardPlaceholder;
+}

--- a/apps/web/src/hubs/qa/index.js
+++ b/apps/web/src/hubs/qa/index.js
@@ -1,0 +1,7 @@
+/**
+ * QA Hub public surface. Currently a single placeholder component;
+ * real QA pages (defect leakage, test cycle time, regression rates)
+ * land as follow-up PRs against this folder.
+ */
+
+export { QaPlaceholder } from "./qa-placeholder.jsx";

--- a/apps/web/src/hubs/qa/qa-placeholder.jsx
+++ b/apps/web/src/hubs/qa/qa-placeholder.jsx
@@ -1,0 +1,106 @@
+"use client";
+
+/**
+ * Hub-coming-soon placeholder for slots that don't have real QA UI
+ * yet. Renders a quiet card with the active hub's metadata + a list
+ * of the widget ids the registry has reserved for this hub. Good
+ * enough for M10.3 — real QA pages (defect leakage, test cycle time,
+ * regression rates) land in follow-up PRs as the QA team's metrics
+ * stabilise.
+ *
+ * Slot prop is the hub's page-slot id ("dashboard", "goals", …). Used
+ * for the heading + to tell the user which slot they're looking at.
+ */
+
+import Link from "next/link";
+import { MonoLabel, PageHeader } from "@/components/ui";
+import { useActiveHubStrict } from "@/features/hubs";
+
+const SLOT_LABELS = {
+  dashboard: "Dashboard",
+  goals: "Goals",
+  evidence: "Evidence",
+  snapshots: "Snapshots",
+  reviews: "Reviews",
+  settings: "Settings",
+  analyst: "Analyst",
+};
+
+export function QaPlaceholder({ slot = "dashboard" }) {
+  const hub = useActiveHubStrict();
+  const slotLabel = SLOT_LABELS[slot] ?? slot;
+  const widgets = Array.isArray(hub.widgets) ? hub.widgets : [];
+
+  return (
+    <main className="relative z-[2] px-10 pb-14 pt-9">
+      <PageHeader
+        crumb={`${hub.label} · ${slotLabel}`}
+        title="We're still building this."
+        italicWord="building"
+        subtitle={hub.description}
+      />
+
+      <div className="mx-auto max-w-2xl">
+        <div className="rounded-md border border-border bg-card p-6">
+          <MonoLabel>Coming soon</MonoLabel>
+          <p className="mt-2 text-[13.5px] leading-[1.65] text-fg">
+            The {hub.label} is scaffolded — auth, hub routing, theming, and
+            integration access are all wired up. The {slotLabel.toLowerCase()}{" "}
+            view is the next piece of UI to land.
+          </p>
+
+          {slot === "dashboard" && widgets.length > 0 ? (
+            <div className="mt-5 border-t border-border pt-4">
+              <MonoLabel>Planned widgets</MonoLabel>
+              <ul
+                className="mt-2 grid gap-1.5"
+                style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+              >
+                {widgets.map((w) => (
+                  <li
+                    key={w}
+                    className="rounded-sm border border-dashed border-border px-2.5 py-1.5 text-muted-fg"
+                  >
+                    <span className="text-fg">·</span> {w}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <div className="mt-5 border-t border-border pt-4">
+            <MonoLabel>What you can do today</MonoLabel>
+            <ul className="mt-2 grid gap-1.5 text-[12.5px] text-muted-fg">
+              <li>
+                <span className="text-fg">·</span>{" "}
+                Connect{" "}
+                {hub.allowedIntegrations.map((p, i, arr) => (
+                  <span key={p}>
+                    <Link
+                      href={`/${hub.id}/settings`}
+                      className="text-accent hover:underline"
+                    >
+                      {p}
+                    </Link>
+                    {i < arr.length - 1 ? (i === arr.length - 2 ? " and " : ", ") : ""}
+                  </span>
+                ))}{" "}
+                in Settings — they'll be live the moment the {slotLabel.toLowerCase()} ships.
+              </li>
+              <li>
+                <span className="text-fg">·</span>{" "}
+                <Link
+                  href={`/${hub.id}/goals`}
+                  className="text-accent hover:underline"
+                >
+                  Add your performance goals
+                </Link>{" "}
+                — the goals tree is hub-agnostic and works today.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Wires the QA Hub up enough that hitting ``/qa`` renders QA-themed content (not Dev's bento) without misleading users into thinking QA pages are ready. Real QA UI (defect leakage, test cycle time, regression rates) lands in follow-up PRs as the metrics stabilise.

## What ships

**``apps/web/src/hubs/``** — new top-level home for hub-specific page components:
- ``qa/qa-placeholder.jsx`` — "we're still building" shell. Reads the active hub via ``useActiveHubStrict()``, lists the hub's planned widgets, and a "what you can do today" callout (connect integrations, edit goals).
- ``qa/index.js`` — barrel.
- ``dashboard-registry.jsx`` — ``hubId → DashboardComponent`` map (``dev → DashboardPage``, ``qa → QaPlaceholder``). Unknown hubs fall through to a DefaultDashboardPlaceholder so adding a hub to the shared registry never breaks the page.

**``apps/web/src/features/hubs/use-hub-slot-guard.js``** — new hook. Checks the active hub's ``pages[slot]`` map; when the slot isn't exposed (e.g. QA + reviews), ``router.replace`` to the hub's dashboard. Returns a boolean so pages render null during the redirect.

**``apps/web/src/app/[hub]/``**:
- ``page.jsx`` — dashboard route dispatches via ``getDashboardComponent(hub.id)``
- ``reviews/page.jsx`` — ``useHubSlotGuard("reviews")``
- ``snapshots/page.jsx`` — ``useHubSlotGuard("snapshots")``

## Validation matrix

| URL | Behaviour |
| --- | --- |
| ``/`` | root redirect to primary hub |
| ``/dev`` | Dev dashboard (unchanged) |
| ``/dev/reviews`` | Dev review log |
| ``/qa`` | QaPlaceholder (dashboard slot) |
| ``/qa/goals`` | shared goals page, QA-themed |
| ``/qa/reviews`` | slot guard → ``router.replace("/qa")`` |
| ``/xyz`` | unknown hub → HubProvider redirects to primary |

## Pages NOT changed in this PR

``goals``, ``evidence``, ``settings`` — both hubs expose these slots and the underlying feature components are hub-agnostic today. They render the same UI under whichever hub's theme is active. M10.4 adds per-hub Settings filtering; future PRs can replace goals/evidence with hub-specific variants once QA's requirements stabilise.

## Test plan

- [x] ``npm run build:web`` — passes; routing tree unchanged
- [ ] Log in as bootstrap admin (allowed: both hubs); visit ``/qa`` → see QA placeholder
- [ ] ``/qa/reviews`` → redirects to ``/qa``; back-button doesn't bounce
- [ ] ``/qa/goals`` → shared goals page renders, header shows "eSpace/QA"
- [ ] ``/dev`` → bento dashboard renders, header shows "eSpace/Dev"

## Unblocks

- **M10.4** Per-hub integration filter (Settings reads ``useActiveHub()``)
- Real QA widgets — drop them into ``apps/web/src/hubs/qa/`` and add a QaDashboard component that the registry maps ``"qa"`` to
- Future hubs: one folder + one registry entry, no other moving parts

## Drive-by

Two external edits arrived on the working tree between M10.2 and M10.3 (a comment in ``components/ui/grain.jsx`` and a brainstorm block in ``app/[hub]/settings/page.jsx``). Both stay out of this commit — they'll land in their own PR or get reverted by whoever authored them.