### PR TITLE
M10.4: Settings + dashboard tile filter integrations per active hub

### DIFF
--- a/apps/web/src/features/dashboard/tiles/integrations-tile.jsx
+++ b/apps/web/src/features/dashboard/tiles/integrations-tile.jsx
@@ -2,18 +2,26 @@
 
 import Link from "next/link";
 import { BentoTile } from "@/components/ui";
-import { PROVIDERS, useIntegrations } from "@/features/integrations";
-import { useHubLink } from "@/features/hubs";
+import { useIntegrations } from "@/features/integrations";
+import { useAllowedProviders, useHubLink } from "@/features/hubs";
 
 export function IntegrationsTile() {
-  const { integrations, isConnected, connectedProviders } = useIntegrations();
+  const { integrations, isConnected } = useIntegrations();
   const link = useHubLink();
+  // M10.4: only count + show providers the active hub allows. The
+  // "connected" status comes from the global integrations store (a
+  // connection made under another hub still counts as connected when
+  // the user switches back to that hub), but the tile's denominator
+  // is the hub's allowed set so the ratio reads as "X / Y for this hub".
+  const allowed = useAllowedProviders();
+  const allowedIds = new Set(allowed.map((p) => p.id));
+  const connectedHere = Array.from(allowedIds).filter((id) => isConnected(id));
 
   return (
     <BentoTile
       col="span 3"
       row="span 2"
-      label={`Integrations · ${connectedProviders.length} / ${Object.keys(PROVIDERS).length}`}
+      label={`Integrations · ${connectedHere.length} / ${allowed.length}`}
       right={
         <Link
           href={link("/settings")}
@@ -25,7 +33,7 @@ export function IntegrationsTile() {
       }
     >
       <div className="mt-1 flex flex-col gap-2">
-        {Object.values(PROVIDERS).map((p) => {
+        {allowed.map((p) => {
           const connected = isConnected(p.id);
           const meta = integrations[p.id];
           return (

--- a/apps/web/src/features/hubs/index.js
+++ b/apps/web/src/features/hubs/index.js
@@ -19,4 +19,5 @@ export { useAvailableHubs } from "./use-available-hubs.js";
 export { useActiveHub, useActiveHubStrict, HubContext } from "./hub-context.js";
 export { useHubLink } from "./use-hub-link.js";
 export { useHubSlotGuard } from "./use-hub-slot-guard.js";
+export { useAllowedProviders } from "./use-allowed-providers.js";
 export { resetHubsStore } from "./hubs-store.js";

--- a/apps/web/src/features/hubs/use-allowed-providers.js
+++ b/apps/web/src/features/hubs/use-allowed-providers.js
@@ -1,0 +1,31 @@
+"use client";
+
+/**
+ * Returns the providers the ACTIVE hub allows, in registry order.
+ *
+ * Source: the active hub's `allowedIntegrations` array (from the
+ * shared registry). Cross-references the local PROVIDERS catalog so
+ * unknown ids on the registry side are filtered out silently — a
+ * hub registry entry that names a provider we haven't shipped yet
+ * doesn't leave a hole in the UI.
+ *
+ * When no hub is active (very brief loading window or a non-hub
+ * page somehow renders a hub-aware component), the helper returns
+ * ALL providers — the safe, backwards-compatible default that
+ * matches the pre-M10.4 behaviour.
+ */
+
+import { useMemo } from "react";
+import { PROVIDERS, PROVIDER_IDS } from "@/features/integrations";
+import { useActiveHub } from "./hub-context.js";
+
+export function useAllowedProviders() {
+  const hub = useActiveHub();
+  return useMemo(() => {
+    if (!hub) return PROVIDER_IDS.map((id) => PROVIDERS[id]).filter(Boolean);
+    const allowedSet = new Set(hub.allowedIntegrations || []);
+    return PROVIDER_IDS.filter((id) => allowedSet.has(id))
+      .map((id) => PROVIDERS[id])
+      .filter(Boolean);
+  }, [hub]);
+}

--- a/apps/web/src/features/settings/tabs/integrations-tab.jsx
+++ b/apps/web/src/features/settings/tabs/integrations-tab.jsx
@@ -7,6 +7,10 @@ import {
   PROVIDERS,
   useIntegrations,
 } from "@/features/integrations";
+import {
+  useActiveHub,
+  useAllowedProviders,
+} from "@/features/hubs";
 import { startGitHubOAuth } from "@/lib/oauth-pkce";
 import { GitLabTokenForm, JiraTokenForm } from "../token-forms";
 
@@ -16,13 +20,34 @@ const OAUTH_STARTERS = {
 };
 
 export function IntegrationsTab() {
+  // Per-hub provider filter (M10.4). Each hub's registry declares
+  // its `allowedIntegrations`; this tab shows only those. Connections
+  // made on another hub aren't deleted — they're hidden here. The
+  // dashed hint at the bottom of the list explains the filtering so
+  // the absence isn't surprising.
+  const allowed = useAllowedProviders();
+  const hub = useActiveHub();
+  const totalCatalog = Object.keys(PROVIDERS).length;
+  const hiddenCount = totalCatalog - allowed.length;
+
   return (
     <>
       <Section num="01 /" title="Connected providers">
         <div className="flex flex-col gap-3">
-          {Object.values(PROVIDERS).map((p) => (
+          {allowed.map((p) => (
             <ProviderCard key={p.id} provider={p} />
           ))}
+          {hub && hiddenCount > 0 ? (
+            <div
+              className="rounded-[var(--radius-sub)] border border-dashed border-border bg-card-alt px-4 py-3 text-[12px] text-muted-fg"
+              style={{ fontFamily: "var(--font-mono)" }}
+            >
+              {hiddenCount} provider{hiddenCount === 1 ? " is" : "s are"} hidden in
+              the <span className="text-fg">{hub.label}</span> — they aren't
+              used by this hub's widgets. Switch to a hub that uses them to
+              manage their tokens.
+            </div>
+          ) : null}
         </div>
       </Section>
 


### PR DESCRIPTION
## Summary

Each hub's registry entry declares ``allowedIntegrations``. Until this PR the Integrations tab + the dashboard tile always showed all three providers; QA users had no obvious reason ``github`` was offered when the QA hub doesn't use it. Now both surfaces filter to the active hub's allowed set.

## What ships

- **``features/hubs/use-allowed-providers.js``** — new hook. Returns the catalog entries for the active hub's ``allowedIntegrations``, in ``PROVIDER_IDS`` order. Unknown ids on the registry side are silently filtered out (defensive). Falls back to ALL providers when no hub is active (loading window or non-hub page) — backwards-compatible default.
- **``features/settings/tabs/integrations-tab.jsx``** — renders ``useAllowedProviders()`` instead of ``Object.values(PROVIDERS)``. When the filter hides 1+ providers, a dashed hint explains: *"X provider is hidden in the {Hub label} — switch to a hub that uses them to manage their tokens."* Connections from other hubs persist; they're just not surfaced here.
- **``features/dashboard/tiles/integrations-tile.jsx``** — same filter. Tile label denominator becomes the hub's allowed count (``2 / 3`` on Dev, ``1 / 2`` on QA); row list restricted to those providers. Connected count computed against the hub-filtered set so the ratio reads as "for this hub", not "globally".

## Behaviour today

| Hub | Settings card list | Tile label |
| --- | --- | --- |
| Dev | github, gitlab, jira (no hint) | ``Integrations · 0 / 3`` (or whatever's connected) |
| QA | gitlab, jira + hint about 1 hidden | ``Integrations · 0 / 2`` |

## Test plan

- [x] ``npm run build:web`` — passes
- [ ] Visit ``/dev/settings`` → all 3 provider cards
- [ ] Visit ``/qa/settings`` → 2 provider cards + dashed hint explaining the missing one
- [ ] Connect ``github`` on Dev, switch to QA → github not visible; switch back to Dev → still connected, still shown
- [ ] Dev dashboard ``IntegrationsTile`` shows the right ratio

## Drive-by

Same two external WIP edits (``components/ui/grain.jsx``, ``app/[hub]/settings/page.jsx``) still on the working tree; intentionally left out of this commit.

## Unblocks

- **M10.5** Admin overrides — the integration filter becomes the first knob the admin config UI can toggle (org-level override of ``hub.allowedIntegrations``). The shared registry stays the default; an override row in ``hub_configs`` takes precedence at ``/api/v1/hubs/me`` resolution time.