### PR TITLE
M10.5: hub_configs collection + admin overrides on /hubs/me

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -39,6 +39,7 @@ import { gradingVerdictsRouter } from "./modules/grading-verdicts/routes.js";
 import { integrationsRouter } from "./modules/integrations/routes.js";
 import { migrateRouter } from "./modules/migrate/routes.js";
 import { hubsRouter } from "./modules/hubs/routes.js";
+import { hubConfigsRouter } from "./modules/hub-configs/routes.js";
 
 /**
  * Cast a connect-style middleware to Express's RequestHandler. helmet,
@@ -129,6 +130,7 @@ export function buildApp(): Application {
   app.use("/api/v1/integrations", integrationsRouter);
   app.use("/api/v1/migrate", migrateRouter);
   app.use("/api/v1/hubs", hubsRouter);
+  app.use("/api/v1/hub-configs", hubConfigsRouter);
 
   // ─── tail handlers ─────────────────────────────────────────────────
   app.use(notFoundHandler);

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -24,6 +24,7 @@ import type {
   GoalSpecRecord,
   GoalTree,
   GradingVerdict,
+  HubConfig,
   Integration,
   Org,
   Session,
@@ -104,6 +105,11 @@ export async function getIntegrationsCollection(): Promise<
 > {
   const db = await getDb();
   return db.collection<Integration>("integrations");
+}
+
+export async function getHubConfigsCollection(): Promise<Collection<HubConfig>> {
+  const db = await getDb();
+  return db.collection<HubConfig>("hub_configs");
 }
 
 // ─── bootstrap: validators + indexes ─────────────────────────────────
@@ -352,8 +358,22 @@ async function ensureIndexes(): Promise<void> {
     },
   );
 
+  // ─── M10.5 collection ─────────────────────────────────────────────
+
+  const hubConfigs = await getHubConfigsCollection();
+  await hubConfigs.createIndex(
+    { orgId: 1, hubId: 1 },
+    {
+      unique: true,
+      name: "hub_configs_org_hub_uniq",
+      // One override row per (orgId, hubId). Upsert semantics on the
+      // PUT endpoint; missing row means "use shared registry default
+      // for everything".
+    },
+  );
+
   logger.debug(
-    "[db] indexes ensured for orgs, users, sessions, audit_log, auth_tokens, goals, goal_specs, goal_context, goal_inputs, snapshots, grading_verdicts, integrations",
+    "[db] indexes ensured for orgs, users, sessions, audit_log, auth_tokens, goals, goal_specs, goal_context, goal_inputs, snapshots, grading_verdicts, integrations, hub_configs",
   );
 }
 

--- a/apps/api/src/db/schemas/hub-configs.schema.ts
+++ b/apps/api/src/db/schemas/hub-configs.schema.ts
@@ -1,0 +1,57 @@
+/**
+ * hub_configs collection — Mongo $jsonSchema validator.
+ *
+ * Per-(orgId, hubId) overrides on top of the shared registry defaults
+ * in @espace-devhub/shared/hubs. Each override field is optional;
+ * absent fields fall through to the registry default at resolution
+ * time (see modules/hubs/controller.ts).
+ *
+ * Semantics
+ *   enabled              — when explicitly false, the hub is HIDDEN
+ *                          from every user in the org (filtered out
+ *                          of /hubs/me). When absent or true, the hub
+ *                          shows as normal.
+ *   label / description  — string overrides for UI labelling.
+ *   allowedIntegrations  — REPLACES (not merges) the registry default.
+ *                          Empty array is a valid value ("this hub has
+ *                          no integrations").
+ *   pages                — PARTIAL merge: only the slot ids present in
+ *                          this override are touched. A value of `null`
+ *                          on a slot REMOVES it from the effective pages
+ *                          map (hides the page in this hub). Any slot
+ *                          not present passes through from defaults.
+ *   departments          — REPLACES the registry default (since the
+ *                          orchestrator routes a user via this list,
+ *                          partial-merge semantics would be confusing).
+ */
+
+import type { Document } from "mongodb";
+
+export const hubConfigsValidator: Document = {
+  $jsonSchema: {
+    bsonType: "object",
+    required: ["orgId", "hubId", "updatedAt"],
+    additionalProperties: true,
+    properties: {
+      _id: { bsonType: "objectId" },
+      orgId: { bsonType: "objectId" },
+      hubId: { bsonType: "string", minLength: 1, maxLength: 64 },
+      enabled: { bsonType: ["bool", "null"] },
+      label: { bsonType: ["string", "null"], maxLength: 200 },
+      description: { bsonType: ["string", "null"], maxLength: 500 },
+      allowedIntegrations: {
+        bsonType: ["array", "null"],
+        items: { bsonType: "string", minLength: 1, maxLength: 64 },
+        maxItems: 64,
+      },
+      pages: { bsonType: ["object", "null"] },
+      departments: {
+        bsonType: ["array", "null"],
+        items: { bsonType: "string", minLength: 1, maxLength: 200 },
+        maxItems: 256,
+      },
+      updatedBy: { bsonType: ["objectId", "null"] },
+      updatedAt: { bsonType: "date" },
+    },
+  },
+};

--- a/apps/api/src/db/schemas/index.ts
+++ b/apps/api/src/db/schemas/index.ts
@@ -16,6 +16,7 @@ import { goalInputsValidator } from "./goal-inputs.schema.js";
 import { snapshotsValidator } from "./snapshots.schema.js";
 import { gradingVerdictsValidator } from "./grading-verdicts.schema.js";
 import { integrationsValidator } from "./integrations.schema.js";
+import { hubConfigsValidator } from "./hub-configs.schema.js";
 import type { Document } from "mongodb";
 
 export interface CollectionDef {
@@ -36,4 +37,5 @@ export const COLLECTION_DEFS: readonly CollectionDef[] = [
   { name: "snapshots", validator: snapshotsValidator },
   { name: "grading_verdicts", validator: gradingVerdictsValidator },
   { name: "integrations", validator: integrationsValidator },
+  { name: "hub_configs", validator: hubConfigsValidator },
 ] as const;

--- a/apps/api/src/db/types.ts
+++ b/apps/api/src/db/types.ts
@@ -513,3 +513,37 @@ export interface AuditLogEntry {
   ua: string | null;
   ts: Date;
 }
+
+// ─── hub configs (M10.5) ─────────────────────────────────────────────
+
+/**
+ * Per-(orgId, hubId) override that merges on top of the shared
+ * registry defaults in @espace-devhub/shared/hubs at resolution time.
+ *
+ * Every override field is OPTIONAL. Absent fields fall through to
+ * the registry default. See modules/hubs/controller.ts for the merge
+ * semantics (replace vs partial-replace per field).
+ *
+ * `null` on a scalar field means "no value" (passes through to the
+ * default). `null` on a `pages.<slot>` ENTRY means "remove this slot
+ * from the effective pages map".
+ */
+export interface HubConfig {
+  _id: ObjectId;
+  orgId: ObjectId;
+  hubId: string;
+  /** When false, the hub is filtered out of /hubs/me entirely. */
+  enabled?: boolean | null;
+  label?: string | null;
+  description?: string | null;
+  /** Replaces the registry default. Empty array is meaningful ("no
+   *  integrations for this hub"). Null falls through. */
+  allowedIntegrations?: string[] | null;
+  /** Partial merge — only listed slot ids override. Null entries
+   *  remove the slot from the effective map. */
+  pages?: Record<string, string | null> | null;
+  /** Replaces the registry default. */
+  departments?: string[] | null;
+  updatedBy: ObjectId | null;
+  updatedAt: Date;
+}

--- a/apps/api/src/modules/hub-configs/controller.ts
+++ b/apps/api/src/modules/hub-configs/controller.ts
@@ -1,0 +1,196 @@
+/**
+ * Hub-config controller — admin-only CRUD over per-(orgId, hubId)
+ * overrides on top of the shared registry defaults.
+ *
+ *   GET    /api/v1/hub-configs           list every override for the org
+ *   GET    /api/v1/hub-configs/:hubId    one override (or 404 if absent)
+ *   PUT    /api/v1/hub-configs/:hubId    upsert; body shape in schemas.ts
+ *   DELETE /api/v1/hub-configs/:hubId    revert to registry default
+ *
+ * Validation of the hubId path param: must be a known hub in the
+ * shared registry. We refuse to write an override for a hub the app
+ * doesn't ship with — that row would just be dead weight.
+ *
+ * Audit: every mutation writes a `hub_config.upsert` /
+ * `hub_config.delete` row.
+ */
+
+import type { NextFunction, Request, Response } from "express";
+import { findHubById, HUB_ORDER } from "@espace-devhub/shared/hubs";
+import { getHubConfigsCollection } from "../../db/collections.js";
+import type { HubConfig } from "../../db/types.js";
+import { networkMeta, writeAudit } from "../../lib/audit.js";
+import { HttpError } from "../../middleware/error-handler.js";
+import { upsertHubConfigSchema } from "./schemas.js";
+
+function requireHubId(req: Request): string {
+  const { hubId } = req.params as { hubId?: string };
+  if (typeof hubId !== "string" || hubId.length === 0) {
+    throw new HttpError(400, "validation_error", "Missing hubId.");
+  }
+  if (!findHubById(hubId)) {
+    throw new HttpError(
+      404,
+      "unknown_hub",
+      `Hub "${hubId}" is not registered. Known hubs: ${HUB_ORDER.join(", ")}.`,
+    );
+  }
+  return hubId;
+}
+
+function toPublic(row: HubConfig): Record<string, unknown> {
+  const { _id, orgId, updatedBy, ...rest } = row;
+  return {
+    id: _id.toHexString(),
+    orgId: orgId.toHexString(),
+    updatedBy: updatedBy ? updatedBy.toHexString() : null,
+    ...rest,
+  };
+}
+
+// ─── GET /api/v1/hub-configs ─────────────────────────────────────────
+
+export async function listHubConfigsHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) throw new HttpError(401, "unauthenticated", "Login required.");
+    const col = await getHubConfigsCollection();
+    const rows = await col.find({ orgId: session.orgId }).toArray();
+    res.json({ configs: rows.map(toPublic) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── GET /api/v1/hub-configs/:hubId ──────────────────────────────────
+
+export async function getHubConfigHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) throw new HttpError(401, "unauthenticated", "Login required.");
+    const hubId = requireHubId(req);
+    const col = await getHubConfigsCollection();
+    const row = await col.findOne({ orgId: session.orgId, hubId });
+    if (!row) {
+      throw new HttpError(
+        404,
+        "not_found",
+        `No override for hub "${hubId}" — using registry defaults.`,
+      );
+    }
+    res.json({ config: toPublic(row) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── PUT /api/v1/hub-configs/:hubId ──────────────────────────────────
+
+export async function upsertHubConfigHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) throw new HttpError(401, "unauthenticated", "Login required.");
+    const hubId = requireHubId(req);
+    const payload = upsertHubConfigSchema.parse(req.body);
+
+    const now = new Date();
+    const col = await getHubConfigsCollection();
+
+    // Build the $set patch from only the fields the client supplied.
+    // Undefined fields are LEFT ALONE on an existing row — partial
+    // PATCH semantics on PUT. Clients that want to clear a field
+    // explicitly send `null`.
+    const set: Record<string, unknown> = {
+      updatedAt: now,
+      updatedBy: session.userId,
+    };
+    if (payload.enabled !== undefined) set.enabled = payload.enabled;
+    if (payload.label !== undefined) set.label = payload.label;
+    if (payload.description !== undefined) set.description = payload.description;
+    if (payload.allowedIntegrations !== undefined)
+      set.allowedIntegrations = payload.allowedIntegrations;
+    if (payload.pages !== undefined) set.pages = payload.pages;
+    if (payload.departments !== undefined) set.departments = payload.departments;
+
+    const result = await col.findOneAndUpdate(
+      { orgId: session.orgId, hubId },
+      {
+        $set: set,
+        $setOnInsert: {
+          orgId: session.orgId,
+          hubId,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+
+    const row = result;
+    if (!row) {
+      throw new HttpError(500, "internal_error", "Upsert returned no document.");
+    }
+
+    await writeAudit({
+      orgId: session.orgId,
+      actorUserId: session.userId,
+      actorRole: session.role,
+      action: "hub_config.upsert",
+      targetType: "hub",
+      targetId: hubId,
+      after: payload,
+      ...networkMeta(req),
+    });
+
+    res.json({ config: toPublic(row) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── DELETE /api/v1/hub-configs/:hubId ───────────────────────────────
+
+export async function deleteHubConfigHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) throw new HttpError(401, "unauthenticated", "Login required.");
+    const hubId = requireHubId(req);
+    const col = await getHubConfigsCollection();
+    const result = await col.deleteOne({ orgId: session.orgId, hubId });
+
+    if (result.deletedCount === 0) {
+      // Idempotent — deleting a missing override is a no-op, not an
+      // error. The post-delete state is identical either way.
+      res.json({ ok: true, deleted: false });
+      return;
+    }
+
+    await writeAudit({
+      orgId: session.orgId,
+      actorUserId: session.userId,
+      actorRole: session.role,
+      action: "hub_config.delete",
+      targetType: "hub",
+      targetId: hubId,
+      ...networkMeta(req),
+    });
+
+    res.json({ ok: true, deleted: true });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/apps/api/src/modules/hub-configs/routes.ts
+++ b/apps/api/src/modules/hub-configs/routes.ts
@@ -1,0 +1,49 @@
+/**
+ * /api/v1/hub-configs/* router.
+ *
+ *   GET    /                 admin: list every override for the org
+ *   GET    /:hubId           admin: one override (or 404)
+ *   PUT    /:hubId           admin: upsert
+ *   DELETE /:hubId           admin: revert to registry default
+ *
+ * The list/get reads are admin-only too — overrides aren't sensitive
+ * but admin is the audience that needs them, and exposing the routes
+ * to non-admin sessions just bloats the public surface.
+ */
+
+import { Router } from "express";
+import { requireAuth } from "../../middleware/require-auth.js";
+import { requireRole } from "../../middleware/require-role.js";
+import {
+  deleteHubConfigHandler,
+  getHubConfigHandler,
+  listHubConfigsHandler,
+  upsertHubConfigHandler,
+} from "./controller.js";
+
+export const hubConfigsRouter: Router = Router();
+
+hubConfigsRouter.get(
+  "/",
+  requireAuth(),
+  requireRole("admin"),
+  listHubConfigsHandler,
+);
+hubConfigsRouter.get(
+  "/:hubId",
+  requireAuth(),
+  requireRole("admin"),
+  getHubConfigHandler,
+);
+hubConfigsRouter.put(
+  "/:hubId",
+  requireAuth(),
+  requireRole("admin"),
+  upsertHubConfigHandler,
+);
+hubConfigsRouter.delete(
+  "/:hubId",
+  requireAuth(),
+  requireRole("admin"),
+  deleteHubConfigHandler,
+);

--- a/apps/api/src/modules/hub-configs/schemas.ts
+++ b/apps/api/src/modules/hub-configs/schemas.ts
@@ -1,0 +1,35 @@
+/**
+ * Zod schemas for /api/v1/hub-configs/* request bodies.
+ *
+ * Mirrors the HubConfig interface in db/types.ts but stops at the
+ * fields a client is allowed to set. `_id`, `orgId`, `updatedBy`,
+ * `updatedAt` are server-managed.
+ */
+
+import { z } from "zod";
+
+const slotValueSchema = z
+  .union([z.string().min(1).max(200), z.null()])
+  .optional();
+
+export const upsertHubConfigSchema = z.object({
+  enabled: z.union([z.boolean(), z.null()]).optional(),
+  label: z.union([z.string().max(200), z.null()]).optional(),
+  description: z.union([z.string().max(500), z.null()]).optional(),
+  allowedIntegrations: z
+    .union([z.array(z.string().min(1).max(64)).max(64), z.null()])
+    .optional(),
+  /**
+   * Partial map. Keys are page-slot ids ("dashboard", "goals", …);
+   * values are either a non-empty symbolic component id (override),
+   * or `null` (REMOVE the slot from the effective map).
+   */
+  pages: z
+    .union([z.record(z.string().min(1).max(64), slotValueSchema), z.null()])
+    .optional(),
+  departments: z
+    .union([z.array(z.string().min(1).max(200)).max(256), z.null()])
+    .optional(),
+});
+
+export type UpsertHubConfigInput = z.infer<typeof upsertHubConfigSchema>;

--- a/apps/api/src/modules/hubs/controller.ts
+++ b/apps/api/src/modules/hubs/controller.ts
@@ -1,34 +1,41 @@
 /**
  * /api/v1/hubs/me — returns the hubs the current user can access.
  *
- * Reads the user's `allowedHubs` + `primaryHub` from the session-
- * referenced user doc, resolves them against the shared registry,
- * and returns:
+ * Resolution layers (each applied in order):
+ *   1. Shared registry defaults     — @espace-devhub/shared/hubs
+ *   2. Per-(orgId, hubId) overrides — hub_configs collection (M10.5)
+ *   3. User's allowedHubs           — filters which hubs surface
  *
+ * Response:
  *   {
- *     hubs: HubDefinition[],     // ordered by HUB_ORDER
- *     primaryHubId: string,      // member of hubs[*].id
- *     defaultHubId: string,      // the registry's overall default
+ *     hubs: HubDefinition[],     // ordered by HUB_ORDER, post-merge
+ *     primaryHubId: string,
+ *     defaultHubId: string,
  *   }
  *
- * Pre-M10 users have neither field on their doc; we apply the
- * DEFAULT_HUB_ID fallback so the response stays useful while we
- * roll out the schema (no migration required).
+ * Pre-M10 users (no allowedHubs / primaryHub on doc) get the
+ * DEFAULT_HUB_ID fallback so the response stays useful.
  *
- * Public per-hub metadata (theme, allowedIntegrations, page slots,
- * widget catalog) ships in the response so the frontend can render
- * the chrome without a separate registry fetch.
+ * Per-hub metadata (theme, allowedIntegrations, page slots, widget
+ * catalog) ships in the response so the frontend can render the
+ * chrome without a separate registry fetch — and so admin overrides
+ * take effect on the very next /hubs/me round-trip.
  */
 
 import type { NextFunction, Request, Response } from "express";
 import {
   DEFAULT_HUB_ID,
+  HUB_ORDER,
   HUBS,
   findHubById,
-  resolveAllowedHubs,
 } from "@espace-devhub/shared/hubs";
-import { getUsersCollection } from "../../db/collections.js";
+import {
+  getHubConfigsCollection,
+  getUsersCollection,
+} from "../../db/collections.js";
+import type { HubConfig } from "../../db/types.js";
 import { HttpError } from "../../middleware/error-handler.js";
+import { mergeHubOverride } from "./merge.js";
 
 export async function listMyHubsHandler(
   req: Request,
@@ -47,25 +54,67 @@ export async function listMyHubsHandler(
       { projection: { allowedHubs: 1, primaryHub: 1 } },
     );
     if (!user) {
-      // Session referenced a deleted user — let the existing auth
-      // path surface this as an unauthenticated state.
       throw new HttpError(401, "unauthenticated", "User no longer exists.");
     }
 
-    // Resolve allowed hubs through the registry. Unknown ids on the
-    // user doc are silently filtered out so a hub removed from the
-    // registry doesn't leave the user staring at a broken switcher.
-    const allowedIds =
+    // Load the org's overrides once, keyed by hubId for O(1) merge.
+    const hubConfigs = await getHubConfigsCollection();
+    const overrideRows = await hubConfigs
+      .find({ orgId: session.orgId })
+      .toArray();
+    const overrideByHubId = new Map<string, HubConfig>(
+      overrideRows.map((row) => [row.hubId, row] as const),
+    );
+
+    // Resolution: every hub in HUB_ORDER → merge defaults + override
+    // → filter out disabled ones → intersect with the user's
+    // allowedHubs list.
+    const userAllowed = new Set<string>(
       Array.isArray(user.allowedHubs) && user.allowedHubs.length > 0
         ? user.allowedHubs
-        : [DEFAULT_HUB_ID];
-    let hubs = resolveAllowedHubs(allowedIds);
+        : [DEFAULT_HUB_ID],
+    );
+
+    const hubs = [];
+    for (const hubId of HUB_ORDER) {
+      const defaults = findHubById(hubId);
+      if (!defaults) continue;
+      const { hub, enabled } = mergeHubOverride(
+        defaults,
+        overrideByHubId.get(hubId) ?? null,
+      );
+      if (!enabled) continue;
+      if (!userAllowed.has(hubId)) continue;
+      hubs.push(hub);
+    }
+
     if (hubs.length === 0) {
-      // Defense in depth: if the user's allowedHubs all reference
-      // unknown ids, fall back to the default rather than returning
-      // an empty list (which would lock the user out of every hub).
-      const fallback = findHubById(DEFAULT_HUB_ID);
-      hubs = fallback ? [fallback] : Object.values(HUBS);
+      // Defense in depth: if every hub the user has access to is
+      // either unknown or disabled by an admin override, fall back to
+      // the default rather than returning an empty list (which would
+      // lock the user out of every hub). The fallback is the
+      // post-merge version of DEFAULT_HUB_ID — admin overrides still
+      // apply.
+      const defaults = findHubById(DEFAULT_HUB_ID);
+      if (defaults) {
+        const merged = mergeHubOverride(
+          defaults,
+          overrideByHubId.get(DEFAULT_HUB_ID) ?? null,
+        );
+        if (merged.enabled) {
+          hubs.push(merged.hub);
+        } else {
+          // Even the default is disabled. Last-ditch: every registry
+          // hub, ignoring overrides. Prevents a misconfigured admin
+          // from locking themselves out.
+          for (const fallbackId of HUB_ORDER) {
+            const fb = findHubById(fallbackId);
+            if (fb) hubs.push(fb);
+          }
+        }
+      } else {
+        for (const h of Object.values(HUBS)) hubs.push(h);
+      }
     }
 
     const primaryHubId =

--- a/apps/api/src/modules/hubs/merge.ts
+++ b/apps/api/src/modules/hubs/merge.ts
@@ -1,0 +1,84 @@
+/**
+ * Hub-config merge layer.
+ *
+ * Applies per-(orgId, hubId) overrides on top of the shared registry
+ * defaults. Pure function — no I/O. Called by the /hubs/me handler
+ * after it fetches the raw override rows.
+ *
+ * Merge rules (also documented in the HubConfig interface):
+ *   enabled              when explicitly false → caller filters
+ *                        the hub out entirely. true/null/missing
+ *                        leave the hub visible.
+ *   label, description   nullable scalar overrides; null/missing
+ *                        falls through to the registry default.
+ *   allowedIntegrations  REPLACES the registry default in full.
+ *                        Empty array is meaningful ("no integrations
+ *                        for this hub"). null/missing falls through.
+ *   pages                PARTIAL merge: only the slot ids present in
+ *                        the override are touched. A value of `null`
+ *                        on a slot REMOVES it from the effective map
+ *                        (hides the page in this hub). Slots not in
+ *                        the override pass through from defaults.
+ *   departments          REPLACES the registry default in full.
+ *                        Department lookup is order-irrelevant so
+ *                        partial-merge semantics would be confusing.
+ *
+ * The function returns a NEW object — never mutates the registry
+ * default in place.
+ */
+
+import type { HubDefinition } from "@espace-devhub/shared/hubs";
+import type { HubConfig } from "../../db/types.js";
+
+export interface HubMergeResult {
+  hub: HubDefinition;
+  /** False when an override disabled this hub. Callers should drop it. */
+  enabled: boolean;
+}
+
+export function mergeHubOverride(
+  defaultHub: HubDefinition,
+  override: HubConfig | null,
+): HubMergeResult {
+  if (!override) {
+    return { hub: defaultHub, enabled: true };
+  }
+
+  const enabled = override.enabled === false ? false : true;
+
+  // Pages: partial merge with null-removal semantics.
+  let pages: Record<string, string> = { ...defaultHub.pages };
+  if (override.pages && typeof override.pages === "object") {
+    for (const [slot, value] of Object.entries(override.pages)) {
+      if (value === null) {
+        delete pages[slot];
+      } else if (typeof value === "string" && value.length > 0) {
+        pages[slot] = value;
+      }
+      // Any other value type (undefined/number/etc) is ignored —
+      // schema validator rejects them at write time so this branch
+      // is defensive.
+    }
+  }
+
+  const hub: HubDefinition = {
+    ...defaultHub,
+    label:
+      typeof override.label === "string" && override.label.length > 0
+        ? override.label
+        : defaultHub.label,
+    description:
+      typeof override.description === "string" && override.description.length > 0
+        ? override.description
+        : defaultHub.description,
+    allowedIntegrations: Array.isArray(override.allowedIntegrations)
+      ? override.allowedIntegrations
+      : defaultHub.allowedIntegrations,
+    pages,
+    departments: Array.isArray(override.departments)
+      ? override.departments
+      : defaultHub.departments,
+  };
+
+  return { hub, enabled };
+}


### PR DESCRIPTION
## Summary

Closes the M10 arc. The shared registry is now the **default**, not the final word. Admins override per-(orgId, hubId) settings via four CRUD endpoints; the merge layer applies the override at ``/hubs/me`` resolution time. Non-engineers can reconfigure a hub's integrations, pages, departments — or hide it entirely — without a code change.

## What ships

**Schema + collection**
- ``db/schemas/hub-configs.schema.ts`` — ``$jsonSchema`` validator, every field optional
- ``db/types.ts`` — ``HubConfig`` interface, merge semantics inline on each field
- ``db/collections.ts`` — accessor + unique ``(orgId, hubId)`` index
- ``db/schemas/index.ts`` — registers in ``COLLECTION_DEFS``

**Merge layer**
- ``modules/hubs/merge.ts`` — pure ``mergeHubOverride(defaultHub, override)``. Per-field semantics:
  | Field | Semantics |
  | --- | --- |
  | ``enabled`` | bool flag; caller filters disabled hubs |
  | ``label`` / ``description`` | scalar nullable override |
  | ``allowedIntegrations`` | REPLACES (empty array meaningful) |
  | ``pages`` | PARTIAL merge; ``null`` entry REMOVES a slot |
  | ``departments`` | REPLACES |
- ``modules/hubs/controller.ts`` — ``/hubs/me`` loads org overrides, merges per-hub, drops disabled, intersects with user's allowedHubs. Multi-layer fallback so a misconfigured admin can't lock themselves out.

**Admin CRUD**
- ``modules/hub-configs/`` — ``schemas.ts`` (Zod), ``controller.ts`` (list / get / upsert / delete + audit), ``routes.ts``. All gated behind ``requireRole("admin")``.
- ``app.ts`` — mounts at ``/api/v1/hub-configs``.

## How to use today (admin curl)

```bash
# see current overrides
curl --cookie "$COOKIE" /api/v1/hub-configs

# hide QA org-wide
curl --cookie "$COOKIE" -X PUT /api/v1/hub-configs/qa \
     -H 'Content-Type: application/json' \
     -d '{"enabled": false}'

# remove "reviews" slot from Dev hub
curl --cookie "$COOKIE" -X PUT /api/v1/hub-configs/dev \
     -d '{"pages": {"reviews": null}}'

# revert
curl --cookie "$COOKIE" -X DELETE /api/v1/hub-configs/dev
```

## Test plan

- [x] ``npm run typecheck:api`` — clean
- [x] ``npm run build:api`` — clean
- [x] Node smoke import — merge helper exercised through five cases (null / disabled / replace / null-slot / override-slot); all behave as designed
- [ ] Boot API, hit ``GET /api/v1/hub-configs`` as admin → empty list
- [ ] ``PUT /api/v1/hub-configs/qa {enabled: false}`` → ``/api/v1/hubs/me`` no longer includes QA
- [ ] ``PUT /api/v1/hub-configs/dev {pages: {reviews: null}}`` → header nav drops the Reviews tab on Dev
- [ ] ``DELETE`` reverts both

## What's NOT in this PR

- **Admin UI at ``/admin/hubs``** — backend-only delivery. Endpoints are fully usable today via curl / API client. The React admin page lands in a follow-up so M10.5 stays right-sized and the UI design lands separately.

## M10 complete

```
M10.1   Primitives                            ✓
M10.2   /[hub]/... route group + Dev migration ✓
M10.3   QA Hub scaffold                       ✓
M10.4   Per-hub integration filter            ✓
M10.5   Admin overrides                        ✓ this PR
M10.x   Admin UI (follow-up)
```

A non-engineer can now configure any hub entirely via the API.