### PR TITLE
accept-invite: UI page so invites are actually redeemable

### DIFF
--- a/apps/web/src/app/accept-invite/page.jsx
+++ b/apps/web/src/app/accept-invite/page.jsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * /accept-invite?token=… — invite redemption page.
+ *
+ * Mirrors /login's structure: top-level route, no AppShell, no hub
+ * theme. The form is the only thing on the page. AcceptInviteForm
+ * reads the token from the query string and POSTs to
+ * /api/v1/auth/accept-invite, which mints a session cookie on
+ * success — the user lands logged-in without bouncing through
+ * /login again. The AuthGuard then routes them to /onboarding via
+ * the M-OB gate.
+ *
+ * No AuthGuard wrapping here — accept-invite is the entry-point
+ * for users who DON'T yet have a session, and wrapping would
+ * bounce them to /login (creating a loop with the invite email
+ * link).
+ *
+ * useSearchParams() forces a client-side render bailout, so the
+ * form is mounted inside a Suspense boundary the same way the
+ * /login page handles its `?next=` param.
+ */
+
+import { Suspense } from "react";
+import { AcceptInviteForm } from "@/features/auth";
+
+export const dynamic = "force-dynamic";
+
+export default function AcceptInvitePage() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "var(--bg)",
+        color: "var(--fg)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Suspense fallback={null}>
+        <AcceptInviteForm />
+      </Suspense>
+    </main>
+  );
+}

--- a/apps/web/src/features/auth/accept-invite-form.jsx
+++ b/apps/web/src/features/auth/accept-invite-form.jsx
@@ -1,0 +1,242 @@
+"use client";
+
+/**
+ * Invite-redemption form. Mounted at /accept-invite.
+ *
+ * Reads the token from the URL, captures a password + confirmation,
+ * POSTs to /api/v1/auth/accept-invite. The server:
+ *   1. Redeems the single-use token.
+ *   2. argon2id-hashes the password + flips status to "active".
+ *   3. Mints a session cookie (totpVerified: true) so the user lands
+ *      logged-in without bouncing through /login again.
+ *
+ * Post-accept the AuthGuard sees `onboardingCompletedAt: null` and
+ * routes the user to /onboarding for the M-OB 3-field form.
+ *
+ * Errors surfaced from the API:
+ *   invalid_token   → "Invite link is invalid or expired."
+ *   validation_*    → field-level message
+ *   network_error   → generic "couldn't reach the server"
+ */
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { apiPost } from "@/lib/api-client";
+import { useSession } from "./use-session.js";
+
+const MIN_PASSWORD_LENGTH = 12;
+
+export function AcceptInviteForm({ onSuccess }) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const { refresh } = useSession();
+  const token = params.get("token") || "";
+
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  if (!token) {
+    return (
+      <ErrorPanel
+        title="Missing invite token."
+        body="Your invite link is incomplete. Open it again from the email you received, or ask whoever invited you to resend."
+      />
+    );
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(
+        `Password needs at least ${MIN_PASSWORD_LENGTH} characters. Pick something long.`,
+      );
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords don't match.");
+      return;
+    }
+
+    setSubmitting(true);
+    const r = await apiPost("/auth/accept-invite", { token, password });
+    setSubmitting(false);
+    if (!r.ok) {
+      setError(humanise(r.error));
+      return;
+    }
+
+    // Cookie's already set by the API. Refresh the session store so
+    // useSession() sees the new user, then bubble up.
+    await refresh();
+    onSuccess?.(r.data?.user);
+    // Default destination: /onboarding. AuthGuard would route here
+    // anyway since `onboardingCompletedAt` is null on the fresh user,
+    // but doing it explicitly avoids one navigation tick.
+    router.replace("/onboarding");
+  }
+
+  return (
+    <div className="mx-auto flex max-w-sm flex-col gap-5 py-12">
+      <div>
+        <h1
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display, var(--font-inter-tight))",
+            fontSize: 28,
+            letterSpacing: "-0.8px",
+          }}
+        >
+          Activate your account
+        </h1>
+        <p
+          className="mt-1 text-muted-fg"
+          style={{ fontSize: 13.5, lineHeight: 1.5 }}
+        >
+          Pick a password. We'll set up your profile in the next step.
+        </p>
+      </div>
+
+      <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
+        <PasswordField
+          label="Password"
+          value={password}
+          onChange={setPassword}
+          autoFocus
+          autoComplete="new-password"
+          disabled={submitting}
+        />
+        <PasswordField
+          label="Confirm password"
+          value={confirm}
+          onChange={setConfirm}
+          autoComplete="new-password"
+          disabled={submitting}
+        />
+        <p
+          className="text-muted-fg"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10.5,
+            letterSpacing: "0.3px",
+          }}
+        >
+          {MIN_PASSWORD_LENGTH}+ characters · stored as an argon2id hash
+        </p>
+
+        {error ? (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11.5,
+              color: "var(--bad)",
+            }}
+          >
+            {error}
+          </div>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={!password || !confirm || submitting}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: "0.5px",
+            textTransform: "uppercase",
+            background: "var(--accent)",
+            color: "var(--accent-on, #fff)",
+            border: 0,
+            borderRadius: "var(--radius-sub, 3px)",
+            padding: "12px 16px",
+            cursor: submitting ? "wait" : "pointer",
+            opacity: password && confirm && !submitting ? 1 : 0.6,
+          }}
+        >
+          {submitting ? "Activating…" : "Activate account"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+function PasswordField({
+  label,
+  value,
+  onChange,
+  autoFocus,
+  autoComplete,
+  disabled,
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          letterSpacing: "0.5px",
+          color: "var(--muted-fg)",
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </span>
+      <input
+        type="password"
+        autoComplete={autoComplete}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        required
+        autoFocus={autoFocus}
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 13,
+          padding: "10px 14px",
+          background: "var(--card)",
+          border: "1px solid var(--border-strong)",
+          borderRadius: "var(--radius-sub, 3px)",
+          outline: "none",
+        }}
+      />
+    </label>
+  );
+}
+
+function ErrorPanel({ title, body }) {
+  return (
+    <div className="mx-auto flex max-w-sm flex-col gap-3 py-12">
+      <h1
+        className="font-semibold"
+        style={{
+          fontFamily: "var(--font-display, var(--font-inter-tight))",
+          fontSize: 24,
+          letterSpacing: "-0.6px",
+        }}
+      >
+        {title}
+      </h1>
+      <p
+        className="text-muted-fg"
+        style={{ fontSize: 13.5, lineHeight: 1.5 }}
+      >
+        {body}
+      </p>
+    </div>
+  );
+}
+
+function humanise(err) {
+  if (!err) return "Something went wrong. Try again.";
+  if (err.code === "invalid_token")
+    return "Invite link is invalid or expired. Ask for a new invite.";
+  if (err.code === "validation_error")
+    return err.message || "Check the fields and try again.";
+  if (err.code === "network_error")
+    return "Couldn't reach the server. Check your connection and try again.";
+  return err.message || "Something went wrong. Try again.";
+}

--- a/apps/web/src/features/auth/index.js
+++ b/apps/web/src/features/auth/index.js
@@ -1,15 +1,17 @@
 /**
  * Barrel for the auth feature. Public API:
  *
- *   useSession()        — reactive session state + login/logout/refresh
- *   <SessionProvider>   — mount once at the root layout
- *   <LoginForm>         — used by /login page (and reusable elsewhere)
- *   <AuthGuard>         — wraps protected page contents
- *   <UserChip>          — header chip showing the session user + logout
+ *   useSession()         — reactive session state + login/logout/refresh
+ *   <SessionProvider>    — mount once at the root layout
+ *   <LoginForm>          — used by /login page (and reusable elsewhere)
+ *   <AcceptInviteForm>   — used by /accept-invite page
+ *   <AuthGuard>          — wraps protected page contents
+ *   <UserChip>           — header chip showing the session user + logout
  */
 
 export { useSession } from "./use-session.js";
 export { SessionProvider } from "./session-provider.jsx";
 export { LoginForm } from "./login-form.jsx";
+export { AcceptInviteForm } from "./accept-invite-form.jsx";
 export { AuthGuard } from "./auth-guard.jsx";
 export { UserChip } from "./user-chip.jsx";


### PR DESCRIPTION
## Summary

Closes the last gap in the invite flow. The API endpoint (``POST /api/v1/auth/accept-invite``) shipped in M2.3 and the email template's button has pointed at ``/accept-invite?token=…`` since M8.1+2, but the React page that consumes the link didn't exist. Without this PR an invited user clicked the link and saw the Next.js 404.

## What ships

- **``features/auth/accept-invite-form.jsx``** — ``AcceptInviteForm``. Reads token from ``useSearchParams``, captures password + confirmation (12+ chars, must match), POSTs to the endpoint, refreshes the session, and ``router.replace("/onboarding")`` so the M-OB flow takes over. Missing-token state renders an explainer panel.
- **``app/accept-invite/page.jsx``** — top-level route, no AppShell, no hub theme (mirrors ``/login``'s structure). Wraps the form in ``<Suspense>`` so ``useSearchParams`` doesn't break static prerendering.
- **``features/auth/index.js``** — adds ``AcceptInviteForm`` to the barrel.

## End-to-end QA-hire flow after this PR

```
1. Admin POST /invite { email, role: "qa" }
2. Email arrives (Resend sandbox); user clicks the button
3. /accept-invite?token=... renders the form
4. User picks a password → POST /accept-invite
   → server redeems token, hashes password, status=active,
      mints session cookie (totpVerified: true)
5. Frontend refresh() → useSession sees new user
6. router.replace("/onboarding")
7. AuthGuard sees onboardingCompletedAt: null → renders M-OB form
8. User fills displayName / employeeId / department
9. Server resolves department → hub, user lands on /<hub>
```

## Design choices

| Decision | Rationale |
| --- | --- |
| No ``AuthGuard`` wrapping the page | ``/accept-invite`` is the entry point for users without a session — wrapping would bounce to ``/login`` and loop with the email link |
| No displayName field on the form | Invite already carries the displayName from the admin's POST; profile edits land via a future ``/settings/profile`` |
| 12-char min password | Long over complex — matches the argon2id-hash-at-rest assumption the rest of the auth platform already makes |
| ``router.replace`` (not push) | Back-button shouldn't bounce the user between the (now-consumed) invite link and onboarding |

## Test plan

- [x] ``npm run build:web`` — passes; ``/accept-invite`` appears in the static-routes list
- [ ] Admin invites a fresh user → email arrives with link to ``/accept-invite?token=…``
- [ ] Click the link → form renders, accepts a 12+ char password
- [ ] Submit → land on ``/onboarding`` with session cookie set
- [ ] Complete onboarding → land on the resolved hub
- [ ] Click an expired/reused link → "Invite link is invalid or expired" error
- [ ] Open ``/accept-invite`` with no ``?token=`` → missing-token explainer panel