### PR TITLE
M-CAP backend: multi-role + capabilities orchestrator + admin/manager hubs

### DIFF
--- a/apps/api/scripts/admin-create.ts
+++ b/apps/api/scripts/admin-create.ts
@@ -32,7 +32,8 @@ import {
 import { hashPassword } from "../src/lib/argon2.js";
 import { writeAudit } from "../src/lib/audit.js";
 import { logger } from "../src/lib/logger.js";
-import type { User } from "../src/db/types.js";
+import type { User, UserRole } from "../src/db/types.js";
+import { ALL_USER_ROLES } from "../src/db/types.js";
 import { DEFAULT_HUB_ID, HUB_ORDER } from "@espace-devhub/shared/hubs";
 
 interface Args {
@@ -41,13 +42,21 @@ interface Args {
   org: string;
   display: string | null;
   force: boolean;
+  /**
+   * M-CAP roles. Defaults to ["admin"] — bootstrap admins get only
+   * the admin role unless the operator explicitly opts in to more.
+   * Pass --roles=admin,dev,qa to give your account multi-hub visibility
+   * (useful if you're the only seat in the org during dev work).
+   */
+  roles: UserRole[];
 }
 
 function parseArgs(argv: readonly string[]): Args {
-  const out: Partial<Args> & { force: boolean } = {
+  const out: Partial<Args> & { force: boolean; roles: UserRole[] } = {
     org: "default",
     display: null,
     force: false,
+    roles: ["admin"],
   };
   for (const raw of argv) {
     if (raw === "--force") {
@@ -73,6 +82,25 @@ function parseArgs(argv: readonly string[]): Args {
       case "display":
         out.display = value;
         break;
+      case "roles": {
+        const parsed = value
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        for (const r of parsed) {
+          if (!ALL_USER_ROLES.includes(r as UserRole)) {
+            die(
+              `--roles: unknown role "${r}". Allowed: ${ALL_USER_ROLES.join(", ")}.`,
+            );
+          }
+        }
+        if (parsed.length === 0) die("--roles must list at least one role");
+        if (!parsed.includes("admin")) {
+          die("--roles must include 'admin' (this is admin:create)");
+        }
+        out.roles = parsed as UserRole[];
+        break;
+      }
       default:
         die(`unrecognised flag: --${key}`);
     }
@@ -91,7 +119,7 @@ function die(message: string): never {
   console.error(`[admin:create] ${message}`);
   // eslint-disable-next-line no-console
   console.error(
-    "\nUsage:\n  npm run admin:create -- --email=you@example.com --password='secret' [--org=default] [--display='Your Name'] [--force]",
+    "\nUsage:\n  npm run admin:create -- --email=you@example.com --password='secret' [--org=default] [--display='Your Name'] [--roles=admin,dev,qa] [--force]",
   );
   process.exit(1);
 }
@@ -143,11 +171,15 @@ async function main(): Promise<void> {
   const passwordHash = await hashPassword(args.password);
   const now = new Date();
 
+  // M-CAP: write both the legacy `role` (= roles[0]) and the new
+  // multi-role `roles` array. `roles` drives /hubs/me; the singular
+  // field is kept for compat until removed in a follow-up.
   const draft = {
     orgId: org._id,
     email: args.email,
     passwordHash,
-    role: "admin" as const,
+    role: args.roles[0],
+    roles: args.roles,
     status: "active" as const,
     totpSecret: null,
     totpEnrolledAt: null,

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -378,15 +378,48 @@ async function ensureIndexes(): Promise<void> {
 }
 
 /**
- * One-call boot pipeline. Order matters: we apply validators FIRST
- * (which creates collections if missing) and THEN ensure indexes.
- * Doing it in the other order would force Mongo to apply the validator
- * to an existing collection that may already have rows — fine here
- * since the rows we'd hit were inserted under the same schema, but
- * cleaner to set up the validator before any writes.
+ * One-call boot pipeline. Order matters:
+ *   1. validators (creates collections if missing)
+ *   2. indexes
+ *   3. one-shot migrations (e.g. M-CAP roles backfill) — idempotent
+ *      and skip-if-already-applied. Failure here is non-fatal.
+ *
+ * The migration step runs in the background of boot — we kick it off
+ * and don't await, so /healthz/readyz turns green as soon as the
+ * core DB shape is right. Migration progress lands in the structured
+ * log.
  */
 export async function bootstrap(): Promise<void> {
   await applyValidators();
   await ensureIndexes();
   logger.info("[db] bootstrap complete (validators + indexes)");
+  // Migrations after validators + indexes. We `await` so callers can
+  // see counts in their boot logs; migrations are designed to be
+  // fast (one updateOne per affected row, bounded by user count).
+  await runMigrations();
+}
+
+async function runMigrations(): Promise<void> {
+  try {
+    const { migrateUserRoles } = await import("./migrations/m-cap-roles.js");
+    const users = await getUsersCollection();
+    const result = await migrateUserRoles(users);
+    if (result.scanned > 0) {
+      logger.info(
+        {
+          scanned: result.scanned,
+          migrated: result.migrated,
+          byOutcome: result.byOutcome,
+        },
+        "[migrate.m-cap] user roles backfill complete",
+      );
+    } else {
+      logger.debug("[migrate.m-cap] no user rows to migrate");
+    }
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "[migrate] migration step failed — server still booting, retries on next boot",
+    );
+  }
 }

--- a/apps/api/src/db/migrations/m-cap-roles.ts
+++ b/apps/api/src/db/migrations/m-cap-roles.ts
@@ -1,0 +1,97 @@
+/**
+ * M-CAP migration: populate `users.roles` from the legacy `role` field.
+ *
+ * Idempotent + safe to re-run. Touches only rows where `roles` is
+ * missing/empty/null. The boot pipeline calls it after validators
+ * but before the server starts accepting requests.
+ *
+ * Rules:
+ *   - role === "member"  → roles = ["dev"] (engineers under the
+ *                          generic pre-M-CAP role; the M-OB
+ *                          department mapping makes new users
+ *                          start with the right role going forward)
+ *   - role === "admin"   → roles = ["admin", "dev", "qa"]
+ *                          Preserves the bootstrap admin's ability
+ *                          to navigate Dev + QA. New admins minted
+ *                          AFTER this migration get just ["admin"]
+ *                          unless the admin-create CLI was passed
+ *                          --roles with more.
+ *   - any other role     → roles = [role] (single-element)
+ *
+ * Result is logged at info level with counts per outcome. Failure
+ * is non-fatal: server boots regardless so /healthz stays green;
+ * the migration retries on next boot.
+ */
+
+import type { Collection } from "mongodb";
+import { logger } from "../../lib/logger.js";
+import type { User, UserRole } from "../types.js";
+
+interface MigrationResult {
+  scanned: number;
+  migrated: number;
+  byOutcome: Record<string, number>;
+}
+
+export async function migrateUserRoles(
+  users: Collection<User>,
+): Promise<MigrationResult> {
+  const cursor = users.find(
+    {
+      $or: [{ roles: { $exists: false } }, { roles: null }, { roles: { $size: 0 } }],
+    },
+    { projection: { _id: 1, role: 1, email: 1 } },
+  );
+
+  const result: MigrationResult = {
+    scanned: 0,
+    migrated: 0,
+    byOutcome: {},
+  };
+
+  for await (const row of cursor) {
+    result.scanned += 1;
+    const legacyRole = row.role as UserRole;
+    let roles: UserRole[];
+    let outcome: string;
+    if (legacyRole === "member") {
+      roles = ["dev"];
+      outcome = "member→dev";
+    } else if (legacyRole === "admin") {
+      roles = ["admin", "dev", "qa"];
+      outcome = "admin→admin+dev+qa";
+    } else {
+      roles = [legacyRole];
+      outcome = `single:${legacyRole}`;
+    }
+
+    try {
+      await users.updateOne(
+        { _id: row._id },
+        {
+          $set: {
+            roles,
+            // Keep `role` synced to roles[0] — the compat shim reads
+            // both, but having them aligned makes ad-hoc Mongo queries
+            // less confusing.
+            role: roles[0],
+            updatedAt: new Date(),
+          },
+        },
+      );
+      result.migrated += 1;
+      result.byOutcome[outcome] = (result.byOutcome[outcome] ?? 0) + 1;
+    } catch (err) {
+      logger.warn(
+        {
+          userId: row._id.toHexString(),
+          email: row.email,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "[migrate.m-cap] user migration failed; will retry on next boot",
+      );
+    }
+  }
+
+  return result;
+}

--- a/apps/api/src/db/schemas/users.schema.ts
+++ b/apps/api/src/db/schemas/users.schema.ts
@@ -47,6 +47,16 @@ export const usersValidator: Document = {
       },
       passwordHash: { bsonType: ["string", "null"] },
       role: { enum: [...ALL_USER_ROLES] },
+      // M-CAP: multi-role array. Optional during the cutover —
+      // readers fall back to `[role]` when missing. Boot-time
+      // migration populates this for every existing row, and
+      // new user-creation paths write both fields until `role` is
+      // removed in a follow-up release.
+      roles: {
+        bsonType: ["array", "null"],
+        items: { enum: [...ALL_USER_ROLES] },
+        maxItems: 16,
+      },
       status: { enum: [...ALL_USER_STATUSES] },
       totpSecret: { bsonType: ["string", "null"] },
       totpEnrolledAt: { bsonType: ["date", "null"] },

--- a/apps/api/src/db/types.ts
+++ b/apps/api/src/db/types.ts
@@ -47,21 +47,29 @@ export interface Org {
 
 // ─── users ───────────────────────────────────────────────────────────
 
+/**
+ * Role ids. `dev` was added in the capability-model migration to
+ * replace the generic `member` role for engineers. `member` remains
+ * in this union for backward-compat with pre-migration rows; the
+ * boot-time migration converts members → devs.
+ */
 export type UserRole =
   | "admin"
-  | "manager"
-  | "member"
-  | "hr"
+  | "dev"
   | "qa"
-  | "po";
+  | "manager"
+  | "hr"
+  | "po"
+  | "member";
 
 export const ALL_USER_ROLES: readonly UserRole[] = [
   "admin",
-  "manager",
-  "member",
-  "hr",
+  "dev",
   "qa",
+  "manager",
+  "hr",
   "po",
+  "member",
 ] as const;
 
 export type UserStatus = "invited" | "active" | "disabled";
@@ -81,7 +89,27 @@ export interface User {
    * haven't set a password yet. Becomes a string on first password set.
    */
   passwordHash: string | null;
+  /**
+   * @deprecated Pre-capability-model field. Kept on the user doc for
+   * one release as a backward-compatibility shim: readers fall back
+   * to `[role]` when `roles` is missing. Boot-time migration writes
+   * `roles` for every existing row; new user-creation paths write
+   * both `roles` and `role` (the latter is `roles[0]`) until this
+   * field is removed in a follow-up.
+   *
+   * Session resolution + audit log use the FIRST element of the
+   * effective roles list as the "primary role" (session.role,
+   * audit.actorRole).
+   */
   role: UserRole;
+  /**
+   * Capability-model roles. A user can hold multiple — the
+   * orchestrator unions their granted capabilities to decide which
+   * hubs they can enter. Optional in the schema for migration
+   * compatibility; readers should call `effectiveRoles(u)` which
+   * falls back to `[u.role]` when this is missing or empty.
+   */
+  roles?: UserRole[] | null;
   status: UserStatus;
 
   /**

--- a/apps/api/src/lib/user-roles.ts
+++ b/apps/api/src/lib/user-roles.ts
@@ -1,0 +1,40 @@
+/**
+ * Read helpers for the M-CAP multi-role model.
+ *
+ * Compatibility shim: until the schema migration removes the singular
+ * `users.role` column, readers go through `effectiveRoles(u)` which
+ * returns:
+ *   - `u.roles` when it's a non-empty array
+ *   - `[u.role]` otherwise (fallback for pre-migration rows)
+ *
+ * Use `effectiveCapabilities(u)` to get the Set of capabilities the
+ * user holds via their union of roles.
+ */
+
+import {
+  resolveCapabilities,
+  type Capability,
+} from "@espace-devhub/shared/capabilities";
+import type { User, UserRole } from "../db/types.js";
+
+export function effectiveRoles(u: Pick<User, "role" | "roles">): UserRole[] {
+  if (Array.isArray(u.roles) && u.roles.length > 0) return u.roles as UserRole[];
+  return [u.role];
+}
+
+export function effectiveCapabilities(
+  u: Pick<User, "role" | "roles">,
+): Set<Capability> {
+  return resolveCapabilities(effectiveRoles(u));
+}
+
+/**
+ * Primary role used in places that need ONE value (session.role,
+ * audit.actorRole, etc.). Convention: first element of the effective
+ * roles list, which the migration arranges so the "most operational"
+ * role is first (admin > manager > qa > dev > member > hr > po).
+ */
+export function primaryRole(u: Pick<User, "role" | "roles">): UserRole {
+  const roles = effectiveRoles(u);
+  return roles[0];
+}

--- a/apps/api/src/modules/auth/controller.ts
+++ b/apps/api/src/modules/auth/controller.ts
@@ -31,6 +31,10 @@ import {
 } from "../../lib/email-templates.js";
 import { DEFAULT_HUB_ID } from "@espace-devhub/shared/hubs";
 import {
+  effectiveCapabilities,
+  effectiveRoles,
+} from "../../lib/user-roles.js";
+import {
   INVITE_TTL_MS,
   PASSWORD_RESET_TTL_MS,
   deleteTokensFor,
@@ -73,11 +77,15 @@ const LOCKOUT_DURATION_MS = 15 * 60 * 1000;
  * and any audit-log `before`/`after` payload.
  */
 export function toPublicUser(u: User): PublicUser {
+  const roles = effectiveRoles(u);
+  const caps = effectiveCapabilities(u);
   return {
     id: u._id.toHexString(),
     orgId: u.orgId.toHexString(),
     email: u.email,
-    role: u.role,
+    role: roles[0] ?? u.role,
+    roles,
+    capabilities: Array.from(caps),
     status: u.status,
     displayName: u.displayName,
     totpEnrolled: !!u.totpSecret,
@@ -329,7 +337,7 @@ export async function inviteHandler(
     const session = req.session;
     if (!session) throw new HttpError(401, "unauthenticated", "Login required.");
 
-    const { email, role, displayName } = inviteSchema.parse(req.body);
+    const { email, role, roles, displayName } = inviteSchema.parse(req.body);
 
     const users = await getUsersCollection();
     const orgs = await getOrgsCollection();
@@ -360,7 +368,11 @@ export async function inviteHandler(
         orgId: org._id,
         email,
         passwordHash: null,
-        role,
+        // M-CAP: write both. `role` is the legacy compat shim
+        // (= roles[0]); `roles` is the new source of truth that
+        // /hubs/me reads to resolve capabilities.
+        role: roles[0],
+        roles,
         status: "invited" as const,
         totpSecret: null,
         totpEnrolledAt: null,
@@ -445,7 +457,7 @@ export async function inviteHandler(
       action: "user.invite",
       targetType: "user",
       targetId: user._id.toHexString(),
-      after: { email, role, displayName, status: user.status },
+      after: { email, role, roles, displayName, status: user.status },
       ...meta,
     });
 

--- a/apps/api/src/modules/auth/schemas.ts
+++ b/apps/api/src/modules/auth/schemas.ts
@@ -26,14 +26,31 @@ export const loginSchema = z.object({
 });
 export type LoginInput = z.infer<typeof loginSchema>;
 
-const role = z.enum(["admin", "manager", "member", "hr", "qa", "po"]);
+const role = z.enum(["admin", "dev", "qa", "manager", "hr", "po", "member"]);
 const displayName = z.string().min(1).max(200);
 
-export const inviteSchema = z.object({
-  email,
-  role,
-  displayName,
-});
+/**
+ * Invite payload.
+ *   - `role` is the legacy single-role field (still required for
+ *     wire compat with older admin tooling)
+ *   - `roles` is the new multi-role array; optional, falls back to
+ *     [role] when missing
+ *
+ * The handler writes both: `role = roles[0]` and `roles` verbatim.
+ * When the legacy `role` field is removed in a follow-up, `roles`
+ * becomes the only required field.
+ */
+export const inviteSchema = z
+  .object({
+    email,
+    role,
+    roles: z.array(role).min(1).max(8).optional(),
+    displayName,
+  })
+  .transform((input) => ({
+    ...input,
+    roles: input.roles ?? [input.role],
+  }));
 export type InviteInput = z.infer<typeof inviteSchema>;
 
 // Token shape: 32-byte random base64url (43 chars). Liberal on length
@@ -83,7 +100,24 @@ export interface PublicUser {
   id: string;
   orgId: string;
   email: string;
+  /**
+   * Primary role — first element of `roles`. Kept for backward-compat
+   * with UI code that switches on a single role; new code should
+   * read `roles` and/or `capabilities` instead.
+   */
   role: string;
+  /**
+   * All roles the user holds. The orchestrator computes which hubs
+   * they can access by unioning capabilities from this list.
+   */
+  roles: string[];
+  /**
+   * Capability ids granted by the union of `roles`. Convenience —
+   * the frontend can re-derive from `roles` via
+   * `@espace-devhub/shared/capabilities`, but shipping it saves a
+   * round-trip and keeps gating authoritative (server-derived).
+   */
+  capabilities: string[];
   status: string;
   displayName: string;
   totpEnrolled: boolean;

--- a/apps/api/src/modules/hubs/controller.ts
+++ b/apps/api/src/modules/hubs/controller.ts
@@ -1,39 +1,39 @@
 /**
  * /api/v1/hubs/me — returns the hubs the current user can access.
  *
- * Resolution layers (each applied in order):
+ * Resolution layers (in order):
  *   1. Shared registry defaults     — @espace-devhub/shared/hubs
- *   2. Per-(orgId, hubId) overrides — hub_configs collection (M10.5)
- *   3. User's allowedHubs           — filters which hubs surface
+ *   2. Capability gate              — user's roles → capabilities →
+ *                                       intersect with each hub's
+ *                                       `requires` list (M-CAP)
+ *   3. Per-(orgId, hubId) overrides — hub_configs collection (M10.5)
  *
  * Response:
- *   {
- *     hubs: HubDefinition[],     // ordered by HUB_ORDER, post-merge
- *     primaryHubId: string,
- *     defaultHubId: string,
- *   }
+ *   { hubs: HubDefinition[], primaryHubId: string, defaultHubId: string }
  *
- * Pre-M10 users (no allowedHubs / primaryHub on doc) get the
- * DEFAULT_HUB_ID fallback so the response stays useful.
+ * Pre-M-CAP users (only `role` set, no `roles`) get a compat fallback
+ * via `effectiveRoles(u)` — single-role behaviour is preserved until
+ * the boot-time migration writes `roles` for every row.
  *
  * Per-hub metadata (theme, allowedIntegrations, page slots, widget
- * catalog) ships in the response so the frontend can render the
- * chrome without a separate registry fetch — and so admin overrides
- * take effect on the very next /hubs/me round-trip.
+ * catalog) ships in the response so the frontend renders the chrome
+ * without a separate registry fetch, and admin overrides take effect
+ * on the very next /hubs/me round-trip.
  */
 
 import type { NextFunction, Request, Response } from "express";
 import {
   DEFAULT_HUB_ID,
   HUB_ORDER,
-  HUBS,
   findHubById,
+  resolveHubsForCapabilities,
 } from "@espace-devhub/shared/hubs";
 import {
   getHubConfigsCollection,
   getUsersCollection,
 } from "../../db/collections.js";
 import type { HubConfig } from "../../db/types.js";
+import { effectiveCapabilities } from "../../lib/user-roles.js";
 import { HttpError } from "../../middleware/error-handler.js";
 import { mergeHubOverride } from "./merge.js";
 
@@ -51,7 +51,7 @@ export async function listMyHubsHandler(
     const users = await getUsersCollection();
     const user = await users.findOne(
       { _id: session.userId },
-      { projection: { allowedHubs: 1, primaryHub: 1 } },
+      { projection: { role: 1, roles: 1, primaryHub: 1 } },
     );
     if (!user) {
       throw new HttpError(401, "unauthenticated", "User no longer exists.");
@@ -66,54 +66,57 @@ export async function listMyHubsHandler(
       overrideRows.map((row) => [row.hubId, row] as const),
     );
 
-    // Resolution: every hub in HUB_ORDER → merge defaults + override
-    // → filter out disabled ones → intersect with the user's
-    // allowedHubs list.
-    const userAllowed = new Set<string>(
-      Array.isArray(user.allowedHubs) && user.allowedHubs.length > 0
-        ? user.allowedHubs
-        : [DEFAULT_HUB_ID],
+    // M-CAP: resolve the user's capabilities from their roles. Pre-
+    // migration users get `[u.role]` as the fallback role set.
+    const userCaps = effectiveCapabilities({
+      role: user.role,
+      roles: user.roles ?? null,
+    });
+
+    // Capability filter first (authoritative gate), then per-hub
+    // override merge. Hub ids stay in HUB_ORDER.
+    const capAllowedIds = new Set(
+      resolveHubsForCapabilities(userCaps).map((h) => h.id),
     );
 
     const hubs = [];
     for (const hubId of HUB_ORDER) {
+      if (!capAllowedIds.has(hubId)) continue;
       const defaults = findHubById(hubId);
       if (!defaults) continue;
       const { hub, enabled } = mergeHubOverride(
         defaults,
         overrideByHubId.get(hubId) ?? null,
       );
-      if (!enabled) continue;
-      if (!userAllowed.has(hubId)) continue;
+      if (!enabled) continue; // admin disabled this hub for the org
       hubs.push(hub);
     }
 
     if (hubs.length === 0) {
-      // Defense in depth: if every hub the user has access to is
-      // either unknown or disabled by an admin override, fall back to
-      // the default rather than returning an empty list (which would
-      // lock the user out of every hub). The fallback is the
-      // post-merge version of DEFAULT_HUB_ID — admin overrides still
-      // apply.
+      // Defense in depth: a user whose roles grant nothing, or whose
+      // hubs are all admin-disabled, would otherwise see an empty
+      // list and get stuck. Falling back to the default hub keeps the
+      // app navigable while ops fixes the misconfiguration.
+      //
+      // Specifically covers the bootstrap-admin window before the
+      // M-CAP migration runs: their `role: "admin"` resolves to
+      // hub.admin.access via the compat shim, so this branch is
+      // mostly a paranoid catch-all.
       const defaults = findHubById(DEFAULT_HUB_ID);
       if (defaults) {
         const merged = mergeHubOverride(
           defaults,
           overrideByHubId.get(DEFAULT_HUB_ID) ?? null,
         );
-        if (merged.enabled) {
-          hubs.push(merged.hub);
-        } else {
-          // Even the default is disabled. Last-ditch: every registry
-          // hub, ignoring overrides. Prevents a misconfigured admin
-          // from locking themselves out.
+        if (merged.enabled) hubs.push(merged.hub);
+        else {
+          // Even the default is disabled — admit every registry hub
+          // ignoring overrides. Worst-case correctness.
           for (const fallbackId of HUB_ORDER) {
             const fb = findHubById(fallbackId);
             if (fb) hubs.push(fb);
           }
         }
-      } else {
-        for (const h of Object.values(HUBS)) hubs.push(h);
       }
     }
 

--- a/apps/api/src/modules/onboarding/controller.ts
+++ b/apps/api/src/modules/onboarding/controller.ts
@@ -1,27 +1,36 @@
 /**
  * /api/v1/onboarding — the M-OB submit handler.
  *
- * Receives the user's profile fields, resolves their hub via the
- * shared registry's department mapping, persists everything in one
- * atomic users.findOneAndUpdate, and returns the resolved hub so the
- * frontend can navigate.
+ * Captures profile fields. Post-M-CAP, hub access is driven by ROLES
+ * (assigned by the admin at /invite or by the bootstrap CLI), not by
+ * department. This handler therefore does NOT touch the user's
+ * `roles` or `primaryHub` — those are the admin's authoritative
+ * decision and onboarding shouldn't second-guess them.
  *
- * Idempotency: re-submitting after onboarding is complete is allowed
- * (the user is just updating their profile) — we don't reject on
- * `onboardingCompletedAt` already being set. The handler always
- * recomputes the resolved hub from the new department; an admin
- * override applied since the last submit takes effect on the next
- * /hubs/me round-trip.
+ * The `department` field is still captured as a profile attribute
+ * (useful for org charts + Zoho reconciliation in M9), but the
+ * resolved-hub redirect comes from the user's existing roles via
+ * the capability resolver.
+ *
+ * Redirect logic:
+ *   - 1 hub allowed  → redirect to /<hubId>
+ *   - 0 hubs allowed → redirect to / (caller surfaces an error or
+ *                       falls back to defaults — shouldn't happen
+ *                       for a properly invited user)
+ *   - >1 hubs        → redirect to / (the post-login picker shows;
+ *                       lands in PR 3)
+ *
+ * Idempotency: re-submission updates profile fields. Existing
+ * onboarded users can hit this endpoint again to edit their
+ * employeeId / department / displayName.
  */
 
 import type { NextFunction, Request, Response } from "express";
 import { z } from "zod";
-import {
-  DEFAULT_HUB_ID,
-  getHubIdForDepartment,
-} from "@espace-devhub/shared/hubs";
+import { resolveHubsForCapabilities } from "@espace-devhub/shared/hubs";
 import { getUsersCollection } from "../../db/collections.js";
 import { networkMeta, writeAudit } from "../../lib/audit.js";
+import { effectiveCapabilities } from "../../lib/user-roles.js";
 import { HttpError } from "../../middleware/error-handler.js";
 import { toPublicUser } from "../auth/controller.js";
 
@@ -44,13 +53,6 @@ export async function submitOnboardingHandler(
 
     const payload = submitSchema.parse(req.body);
 
-    // Resolve department → hub. `getHubIdForDepartment` returns
-    // DEFAULT_HUB_ID for unknown departments (rather than null) so
-    // the user always lands somewhere coherent — the registry's
-    // fallback is the design contract.
-    const resolvedHubId =
-      getHubIdForDepartment(payload.department) ?? DEFAULT_HUB_ID;
-
     const now = new Date();
     const users = await getUsersCollection();
     const result = await users.findOneAndUpdate(
@@ -60,8 +62,6 @@ export async function submitOnboardingHandler(
           displayName: payload.displayName,
           employeeId: payload.employeeId,
           department: payload.department,
-          allowedHubs: [resolvedHubId],
-          primaryHub: resolvedHubId,
           onboardingCompletedAt: now,
           updatedAt: now,
         },
@@ -73,6 +73,19 @@ export async function submitOnboardingHandler(
       throw new HttpError(401, "unauthenticated", "User no longer exists.");
     }
 
+    // Compute the redirect from the user's CURRENT roles (set by the
+    // admin at invite time, not by this handler). One hub → land
+    // there. >1 → root, where the post-login picker will render.
+    const caps = effectiveCapabilities({
+      role: result.role,
+      roles: result.roles ?? null,
+    });
+    const accessibleHubs = resolveHubsForCapabilities(caps);
+    const redirectTo =
+      accessibleHubs.length === 1
+        ? `/${accessibleHubs[0].id}`
+        : "/";
+
     await writeAudit({
       orgId: session.orgId,
       actorUserId: session.userId,
@@ -83,14 +96,14 @@ export async function submitOnboardingHandler(
       after: {
         department: payload.department,
         employeeId: payload.employeeId,
-        resolvedHubId,
+        hubsAccessible: accessibleHubs.map((h) => h.id),
       },
       ...networkMeta(req),
     });
 
     res.json({
       user: toPublicUser(result),
-      redirectTo: `/${resolvedHubId}`,
+      redirectTo,
     });
   } catch (err) {
     next(err);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,6 +18,10 @@
     "./hubs": {
       "types": "./src/hubs/index.d.ts",
       "default": "./src/hubs/index.js"
+    },
+    "./capabilities": {
+      "types": "./src/capabilities/index.d.ts",
+      "default": "./src/capabilities/index.js"
     }
   },
   "files": [

--- a/packages/shared/src/capabilities/capabilities.d.ts
+++ b/packages/shared/src/capabilities/capabilities.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Type signatures for the capability vocabulary. Runtime in
+ * capabilities.js.
+ */
+
+export const CAPABILITIES: Readonly<{
+  readonly HUB_ADMIN_ACCESS: "hub.admin.access";
+  readonly HUB_DEV_ACCESS: "hub.dev.access";
+  readonly HUB_QA_ACCESS: "hub.qa.access";
+  readonly HUB_MANAGER_ACCESS: "hub.manager.access";
+  readonly HUB_HR_ACCESS: "hub.hr.access";
+  readonly HUB_PO_ACCESS: "hub.po.access";
+  readonly ADMIN_USERS_MANAGE: "admin.users.manage";
+  readonly ADMIN_HUBS_CONFIGURE: "admin.hubs.configure";
+  readonly ADMIN_AUDIT_VIEW: "admin.audit.view";
+  readonly MANAGER_TEAM_VIEW: "manager.team.view";
+}>;
+
+export type Capability = (typeof CAPABILITIES)[keyof typeof CAPABILITIES];
+
+export const ALL_CAPABILITIES: readonly Capability[];

--- a/packages/shared/src/capabilities/capabilities.js
+++ b/packages/shared/src/capabilities/capabilities.js
@@ -1,0 +1,51 @@
+/**
+ * Capability vocabulary — single source of truth for what an action
+ * in the app "is". Roles GRANT capabilities; hubs (and, in future,
+ * individual UI bits) REQUIRE them. The orchestrator computes which
+ * hubs a user can access by intersecting their union-of-capabilities
+ * with each hub's required-capability list.
+ *
+ * Adding a new capability:
+ *   1. Add it here as a string constant
+ *   2. Grant it from some role in roles.js
+ *   3. Require it where needed (hubs/registry.js, <RequireCapability>)
+ *
+ * Capability ids are dotted namespaces — `<scope>.<noun>.<verb>` is
+ * the convention (e.g. `admin.users.manage`, `hub.dev.access`).
+ * Strings (not symbols) so they survive JSON serialisation in audit
+ * rows and admin-config payloads.
+ */
+
+export const CAPABILITIES = Object.freeze({
+  // ─── Hub access ─────────────────────────────────────────────────
+  // One capability per hub. A role that grants `hub.X.access` lets
+  // the user enter hub X. Forward-compatible: hr / po hubs reserve
+  // their cap ids today so the moment those hubs ship the existing
+  // role definitions just work.
+  HUB_ADMIN_ACCESS: "hub.admin.access",
+  HUB_DEV_ACCESS: "hub.dev.access",
+  HUB_QA_ACCESS: "hub.qa.access",
+  HUB_MANAGER_ACCESS: "hub.manager.access",
+  HUB_HR_ACCESS: "hub.hr.access",
+  HUB_PO_ACCESS: "hub.po.access",
+
+  // ─── Admin operations ───────────────────────────────────────────
+  // Granular admin verbs. The admin hub UI uses these to gate
+  // individual surfaces (sidebar entries, action buttons). One
+  // hub.admin.access lets you SEE the admin hub; each verb gates a
+  // specific thing INSIDE the hub.
+  ADMIN_USERS_MANAGE: "admin.users.manage",
+  ADMIN_HUBS_CONFIGURE: "admin.hubs.configure",
+  ADMIN_AUDIT_VIEW: "admin.audit.view",
+
+  // ─── Manager operations ─────────────────────────────────────────
+  // Reserved for the manager hub's team-view + employee-picker.
+  // Real UI lands in a follow-up; capability shipped now so the
+  // role definition is complete.
+  MANAGER_TEAM_VIEW: "manager.team.view",
+});
+
+/**
+ * Flat list for iteration / validation. Frozen.
+ */
+export const ALL_CAPABILITIES = Object.freeze(Object.values(CAPABILITIES));

--- a/packages/shared/src/capabilities/index.d.ts
+++ b/packages/shared/src/capabilities/index.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Type barrel for @espace-devhub/shared/capabilities.
+ */
+
+export { CAPABILITIES, ALL_CAPABILITIES } from "./capabilities.js";
+export type { Capability } from "./capabilities.js";
+
+export {
+  ROLES,
+  ALL_ROLES,
+  ROLE_CAPABILITIES,
+  resolveCapabilities,
+  hasCapabilities,
+} from "./roles.js";
+export type { Role } from "./roles.js";

--- a/packages/shared/src/capabilities/index.js
+++ b/packages/shared/src/capabilities/index.js
@@ -1,0 +1,15 @@
+/**
+ * Public API for the capability/role layer.
+ *
+ *   import { ROLES, CAPABILITIES, resolveCapabilities, hasCapabilities }
+ *     from "@espace-devhub/shared/capabilities";
+ */
+
+export { CAPABILITIES, ALL_CAPABILITIES } from "./capabilities.js";
+export {
+  ROLES,
+  ALL_ROLES,
+  ROLE_CAPABILITIES,
+  resolveCapabilities,
+  hasCapabilities,
+} from "./roles.js";

--- a/packages/shared/src/capabilities/roles.d.ts
+++ b/packages/shared/src/capabilities/roles.d.ts
@@ -1,0 +1,38 @@
+/**
+ * Type signatures for roles + role→capability resolution. Runtime in
+ * roles.js.
+ */
+
+import type { Capability } from "./capabilities.js";
+
+export const ROLES: Readonly<{
+  readonly ADMIN: "admin";
+  readonly DEV: "dev";
+  readonly QA: "qa";
+  readonly MANAGER: "manager";
+  readonly HR: "hr";
+  readonly PO: "po";
+}>;
+
+export type Role = (typeof ROLES)[keyof typeof ROLES];
+
+export const ALL_ROLES: readonly Role[];
+
+export const ROLE_CAPABILITIES: Readonly<Record<Role, readonly Capability[]>>;
+
+/**
+ * Returns a Set of every capability granted by the union of roles.
+ * Unknown role ids are silently filtered out.
+ */
+export function resolveCapabilities(
+  roles: readonly string[] | null | undefined,
+): Set<Capability>;
+
+/**
+ * True if `userCaps` satisfies every requirement in `requires`.
+ * Empty `requires` returns true (open surface).
+ */
+export function hasCapabilities(
+  userCaps: Set<Capability>,
+  requires: readonly Capability[] | null | undefined,
+): boolean;

--- a/packages/shared/src/capabilities/roles.js
+++ b/packages/shared/src/capabilities/roles.js
@@ -1,0 +1,103 @@
+/**
+ * Roles → capability sets.
+ *
+ * A user's effective capabilities = union of the capabilities granted
+ * by each role they hold. Multi-role is the design — `users.roles` is
+ * an array. An admin who also needs to navigate Dev gets both
+ * `admin` AND `dev` as roles.
+ *
+ * Adding a new role:
+ *   1. Add a key here mapping role id → capability array
+ *   2. Add the role id to ALL_USER_ROLES in apps/api/src/db/types.ts
+ *   3. (If the role drives onboarding) extend the department→role
+ *      lookup in onboarding.
+ */
+
+import { CAPABILITIES } from "./capabilities.js";
+
+/**
+ * Stable role ids. New users get roles from this list; existing
+ * users with deprecated roles get migrated (see the migration in
+ * apps/api/src/db/migrations).
+ */
+export const ROLES = Object.freeze({
+  ADMIN: "admin",
+  DEV: "dev",
+  QA: "qa",
+  MANAGER: "manager",
+  HR: "hr",
+  PO: "po",
+});
+
+export const ALL_ROLES = Object.freeze(Object.values(ROLES));
+
+/**
+ * Each role's capability grants. Frozen arrays so callers can't
+ * accidentally mutate the registry.
+ *
+ * Design intent:
+ *   - Each operational role grants exactly ONE hub-access capability
+ *     plus the role-specific operational caps. A manager who needs to
+ *     see Dev work has roles: ["manager", "dev"] — multi-role is
+ *     the composition mechanism, not "manager grants everything".
+ *   - HR and PO are reserved — they exist as role ids so an admin
+ *     can grant them today, but their hubs (and any HR/PO-specific
+ *     capabilities) ship later when those hubs land.
+ */
+export const ROLE_CAPABILITIES = Object.freeze({
+  [ROLES.ADMIN]: Object.freeze([
+    CAPABILITIES.HUB_ADMIN_ACCESS,
+    CAPABILITIES.ADMIN_USERS_MANAGE,
+    CAPABILITIES.ADMIN_HUBS_CONFIGURE,
+    CAPABILITIES.ADMIN_AUDIT_VIEW,
+  ]),
+
+  [ROLES.DEV]: Object.freeze([CAPABILITIES.HUB_DEV_ACCESS]),
+
+  [ROLES.QA]: Object.freeze([CAPABILITIES.HUB_QA_ACCESS]),
+
+  [ROLES.MANAGER]: Object.freeze([
+    CAPABILITIES.HUB_MANAGER_ACCESS,
+    CAPABILITIES.MANAGER_TEAM_VIEW,
+  ]),
+
+  [ROLES.HR]: Object.freeze([
+    // CAPABILITIES.HUB_HR_ACCESS reserved — uncommented when the
+    // HR hub ships
+  ]),
+
+  [ROLES.PO]: Object.freeze([
+    // CAPABILITIES.HUB_PO_ACCESS reserved
+  ]),
+});
+
+/**
+ * Returns the union of capabilities for a set of roles. Unknown role
+ * ids are silently filtered out — a stale role id on a user row
+ * doesn't crash the resolver.
+ *
+ * Result is a Set for cheap membership checks downstream.
+ */
+export function resolveCapabilities(roles) {
+  const caps = new Set();
+  if (!Array.isArray(roles)) return caps;
+  for (const roleId of roles) {
+    const grants = ROLE_CAPABILITIES[roleId];
+    if (!grants) continue;
+    for (const cap of grants) caps.add(cap);
+  }
+  return caps;
+}
+
+/**
+ * True if the user's capabilities satisfy every requirement in the
+ * `requires` list. Empty requires list is allowed (a hub with no
+ * gates lets everyone in — used for any future public surface).
+ */
+export function hasCapabilities(userCapsSet, requires) {
+  if (!Array.isArray(requires) || requires.length === 0) return true;
+  for (const cap of requires) {
+    if (!userCapsSet.has(cap)) return false;
+  }
+  return true;
+}

--- a/packages/shared/src/hubs/index.d.ts
+++ b/packages/shared/src/hubs/index.d.ts
@@ -11,6 +11,7 @@ export {
   findHubById,
   getHubIdForDepartment,
   resolveAllowedHubs,
+  resolveHubsForCapabilities,
 } from "./registry.js";
 
 export type {

--- a/packages/shared/src/hubs/index.js
+++ b/packages/shared/src/hubs/index.js
@@ -14,4 +14,5 @@ export {
   findHubById,
   getHubIdForDepartment,
   resolveAllowedHubs,
+  resolveHubsForCapabilities,
 } from "./registry.js";

--- a/packages/shared/src/hubs/registry.d.ts
+++ b/packages/shared/src/hubs/registry.d.ts
@@ -1,6 +1,8 @@
 /**
- * Type signatures for the hub registry. Runtime lives in registry.js.
+ * Type signatures for the hub registry. Runtime in registry.js.
  */
+
+import type { Capability } from "../capabilities/capabilities.js";
 
 export interface HubTheme {
   /** Primary brand colour for the hub (text, borders, badges). */
@@ -18,32 +20,30 @@ export type HubPageSlot =
   | "snapshots"
   | "reviews"
   | "settings"
-  | "analyst";
+  | "analyst"
+  // Admin-specific
+  | "hub-config"
+  | "users"
+  | "audit"
+  // Manager-specific
+  | "team"
+  | "employees";
 
 export interface HubDefinition {
-  /** Stable URL slug + storage key. */
   id: string;
-  /** Human-readable name shown in switchers, page titles, emails. */
   label: string;
-  /** One-line description for admin UI + onboarding hover state. */
   description: string;
-  /** Hub-level theme overrides merged on top of the base palette. */
   theme: HubTheme;
-  /** Integration provider ids the hub UI exposes. */
   allowedIntegrations: readonly string[];
-  /**
-   * Page slots the hub mounts. Values are symbolic — apps/web resolves
-   * them to React components at render time. Missing slots aren't
-   * routable for that hub.
-   */
   pages: Readonly<Partial<Record<HubPageSlot, string>>>;
-  /** Widget ids the hub's dashboard can mount. */
   widgets: readonly string[];
-  /**
-   * Lowercased, whitespace-trimmed department strings that route to
-   * this hub during onboarding.
-   */
   departments: readonly string[];
+  /**
+   * Capabilities a user must hold (intersection — must satisfy every
+   * one) to access this hub. Empty array means "no gate" (open hub —
+   * reserved for future public surfaces; no hub today is open).
+   */
+  requires: readonly Capability[];
 }
 
 export const ALL_PROVIDERS: readonly ["github", "gitlab", "jira"];
@@ -55,6 +55,21 @@ export const DEFAULT_HUB_ID: string;
 
 export function findHubById(id: unknown): HubDefinition | null;
 export function getHubIdForDepartment(department: unknown): string | null;
+
+/**
+ * @deprecated Pre-capability path. Use resolveHubsForCapabilities
+ * for new code. Kept for backward compatibility during the M-CAP
+ * migration; will be removed once all callers migrate.
+ */
 export function resolveAllowedHubs(
   allowedHubIds: readonly string[] | null | undefined,
+): HubDefinition[];
+
+/**
+ * Capability-driven resolver. Given a user's capability Set, returns
+ * the HubDefinition objects whose `requires` is fully satisfied.
+ * Preserves HUB_ORDER.
+ */
+export function resolveHubsForCapabilities(
+  userCaps: Set<Capability>,
 ): HubDefinition[];

--- a/packages/shared/src/hubs/registry.js
+++ b/packages/shared/src/hubs/registry.js
@@ -1,38 +1,46 @@
 /**
  * Hub registry — single source of truth for what hubs exist, what
- * each one is capable of, and which departments map to it.
+ * each one is capable of, which departments map to it, and which
+ * capabilities are required to access it.
  *
- * Design contract (M10.1):
- *   - Hubs are DATA, not modules. Adding a hub later is one entry
- *     here + a folder under apps/web/src/hubs/<id>/ (M10.3+). Pages
- *     and widgets reference symbolic ids the rest of the app resolves
- *     to React components.
- *   - The shape is forward-compatible with admin overrides (M10.5):
- *     a future hub_configs Mongo collection holds per-(orgId, hubId)
- *     toggles that merge on top of these defaults at request time.
+ * Design contract:
+ *   - Hubs are DATA, not modules. Adding a hub = one entry here +
+ *     a folder under apps/web/src/hubs/<id>/. Pages and widgets
+ *     reference symbolic ids the rest of the app resolves to React
+ *     components.
+ *   - Forward-compatible with admin overrides (M10.5): a future
+ *     hub_configs Mongo collection holds per-(orgId, hubId) toggles
+ *     that merge on top of these defaults at request time.
+ *   - Authorisation lives in the `requires` array — each hub names
+ *     the capabilities a user must hold to enter. The orchestrator
+ *     computes the user's union-of-capabilities from their roles
+ *     and filters this list. See packages/shared/src/capabilities/.
  *   - Everything here is pure data — no React, no Node-only APIs.
- *     Same import works in apps/web (JS, browser) and apps/api (TS,
- *     server).
+ *     Same import works in apps/web and apps/api.
  *
- * Currently two hubs:
- *   dev  — Engineering performance & evidence tracking. The hub the
- *          entire app started as.
- *   qa   — QA performance & defect tracking. Scaffolded only at
- *          M10.1; widgets land in M10.3.
+ * Hubs today:
+ *   admin    — Admin tools (M10.5 overrides, user management, audit).
+ *              Required cap: hub.admin.access (admin role).
+ *   dev      — Engineering performance & evidence tracking.
+ *              Required cap: hub.dev.access (dev role).
+ *   qa       — QA performance & defect tracking (placeholder UI).
+ *              Required cap: hub.qa.access (qa role).
+ *   manager  — Manager hub with team/employee picker (placeholder UI).
+ *              Required cap: hub.manager.access (manager role).
  *
- * Adding a hub: append to HUBS below, add departments → hubId
- * mappings, drop a folder under apps/web/src/hubs/<id>/. Onboarding
- * (M-OB) reads `departments` to route the user.
+ * Adding a hub:
+ *   1. Append to HUBS + HUB_ORDER below
+ *   2. Add a capability for hub access in
+ *      packages/shared/src/capabilities/capabilities.js
+ *   3. Grant the cap from the appropriate role(s) in roles.js
+ *   4. Drop a folder under apps/web/src/hubs/<id>/ (+ dashboard-registry)
+ *   5. Departments → role(s) mapping in onboarding picks up the rest
  */
+
+import { CAPABILITIES } from "../capabilities/capabilities.js";
 
 // ─── shapes ──────────────────────────────────────────────────────────
 
-/**
- * Hub-level theme overrides. Hub layout merges these on top of the
- * base CSS variables so each hub gets its own palette without a
- * stylesheet swap. Only the variables a hub actually needs to
- * override appear — the rest inherit.
- */
 function freezeTheme(t) {
   return Object.freeze({ ...t });
 }
@@ -42,10 +50,7 @@ export const ALL_PROVIDERS = Object.freeze(["github", "gitlab", "jira"]);
 
 /**
  * Page slot ids the hub layout can render. Each hub picks which
- * slots it exposes and which component each maps to (resolved by
- * apps/web at render time). The slot ids stay stable across hubs
- * so a department-agnostic widget (e.g. snapshot list) can be
- * routed to the same slot in any hub.
+ * slots it exposes and which component each maps to.
  */
 export const PAGE_SLOTS = Object.freeze([
   "dashboard",
@@ -55,9 +60,48 @@ export const PAGE_SLOTS = Object.freeze([
   "reviews",
   "settings",
   "analyst",
+  // Admin-specific slots (M10.5 UI lands in PR 2)
+  "hub-config",
+  "users",
+  "audit",
+  // Manager-specific (employee picker etc., future)
+  "team",
+  "employees",
 ]);
 
 // ─── hub definitions ─────────────────────────────────────────────────
+
+const ADMIN_HUB = Object.freeze({
+  id: "admin",
+  label: "Admin",
+  description: "Org configuration, user management, audit trail.",
+  theme: freezeTheme({
+    // Slate/charcoal — visually distinct from Dev's green, QA's
+    // orange, Manager's blue. Signals "you're in admin land".
+    primary: "#1f2937",
+    accent: "#475569",
+    accentSurface: "rgba(71,85,105,0.10)",
+  }),
+  /** Admin hub doesn't surface provider integrations. */
+  allowedIntegrations: Object.freeze([]),
+  pages: Object.freeze({
+    dashboard: "admin:dashboard",
+    "hub-config": "admin:hub-config",
+    users: "admin:users",
+    audit: "admin:audit",
+    settings: "admin:settings",
+  }),
+  widgets: Object.freeze([
+    // Admin widgets land alongside the UI in PR 2.
+    "org-overview",
+    "recent-audit",
+    "user-counts",
+  ]),
+  /** Admins are assigned by role, not department mapping. */
+  departments: Object.freeze([]),
+  /** Required capabilities to access this hub. */
+  requires: Object.freeze([CAPABILITIES.HUB_ADMIN_ACCESS]),
+});
 
 const DEV_HUB = Object.freeze({
   id: "dev",
@@ -68,14 +112,7 @@ const DEV_HUB = Object.freeze({
     accent: "#0a7a5a",
     accentSurface: "rgba(10,122,90,0.08)",
   }),
-  /** Integrations the hub UI exposes in Settings. */
   allowedIntegrations: Object.freeze(["github", "gitlab", "jira"]),
-  /**
-   * Pages this hub mounts under /<hubId>/. The values are symbolic
-   * — apps/web resolves "dashboard" to the right component at render
-   * time. Setting a value to `null` means "this hub doesn't expose
-   * that slot".
-   */
   pages: Object.freeze({
     dashboard: "dev:dashboard",
     goals: "dev:goals",
@@ -85,7 +122,6 @@ const DEV_HUB = Object.freeze({
     settings: "dev:settings",
     analyst: "dev:analyst",
   }),
-  /** Widget catalogue this hub's dashboard can mount. */
   widgets: Object.freeze([
     "pr-rounds",
     "cycle-time",
@@ -95,10 +131,6 @@ const DEV_HUB = Object.freeze({
     "ticket-cycle",
     "code-rubric",
   ]),
-  /**
-   * Department strings (case-insensitive, normalised at lookup) that
-   * route to this hub on first-login onboarding. M-OB reads this.
-   */
   departments: Object.freeze([
     "engineering",
     "platform",
@@ -108,6 +140,7 @@ const DEV_HUB = Object.freeze({
     "devops",
     "sre",
   ]),
+  requires: Object.freeze([CAPABILITIES.HUB_DEV_ACCESS]),
 });
 
 const QA_HUB = Object.freeze({
@@ -120,9 +153,6 @@ const QA_HUB = Object.freeze({
     accentSurface: "rgba(184,114,45,0.08)",
   }),
   allowedIntegrations: Object.freeze(["gitlab", "jira"]),
-  // Pages are stubbed; M10.3 wires the real QA pages. The dashboard
-  // slot is present so onboarding routing has a valid landing target
-  // for QA users from day one.
   pages: Object.freeze({
     dashboard: "qa:dashboard",
     goals: "qa:goals",
@@ -130,7 +160,6 @@ const QA_HUB = Object.freeze({
     settings: "qa:settings",
   }),
   widgets: Object.freeze([
-    // Placeholders — real QA widgets land in M10.3.
     "defect-leakage",
     "test-cycle-time",
     "regression-rate",
@@ -141,19 +170,55 @@ const QA_HUB = Object.freeze({
     "testing",
     "quality",
   ]),
+  requires: Object.freeze([CAPABILITIES.HUB_QA_ACCESS]),
+});
+
+const MANAGER_HUB = Object.freeze({
+  id: "manager",
+  label: "Manager Hub",
+  description: "Team-level visibility and employee performance review.",
+  theme: freezeTheme({
+    // Cool blue/steel — neither green (dev) nor orange (qa).
+    primary: "#2c4a73",
+    accent: "#3b6aa0",
+    accentSurface: "rgba(59,106,160,0.10)",
+  }),
+  allowedIntegrations: Object.freeze(["gitlab", "jira"]),
+  pages: Object.freeze({
+    dashboard: "manager:dashboard",
+    employees: "manager:employees",
+    settings: "manager:settings",
+  }),
+  widgets: Object.freeze([
+    "team-overview",
+    "employee-list",
+    "review-cadence",
+  ]),
+  departments: Object.freeze([]),
+  requires: Object.freeze([CAPABILITIES.HUB_MANAGER_ACCESS]),
 });
 
 /**
- * The canonical registry. Indexed by id for O(1) lookup; iterate
- * via Object.values(HUBS) when you need every hub.
+ * The canonical registry. Indexed by id for O(1) lookup; iterate via
+ * Object.values(HUBS) when you need every hub.
  */
 export const HUBS = Object.freeze({
+  [ADMIN_HUB.id]: ADMIN_HUB,
   [DEV_HUB.id]: DEV_HUB,
   [QA_HUB.id]: QA_HUB,
+  [MANAGER_HUB.id]: MANAGER_HUB,
 });
 
-/** Stable order for any list UI (header switcher, admin page). */
-export const HUB_ORDER = Object.freeze([DEV_HUB.id, QA_HUB.id]);
+/**
+ * Stable order for any list UI (header switcher, post-login picker).
+ * Admin first so admins see their hub at the top of any picker.
+ */
+export const HUB_ORDER = Object.freeze([
+  ADMIN_HUB.id,
+  DEV_HUB.id,
+  QA_HUB.id,
+  MANAGER_HUB.id,
+]);
 
 /** The hub onboarding routes to when no department mapping matches. */
 export const DEFAULT_HUB_ID = DEV_HUB.id;
@@ -161,9 +226,7 @@ export const DEFAULT_HUB_ID = DEV_HUB.id;
 // ─── helpers ─────────────────────────────────────────────────────────
 
 /**
- * Look up a hub by id. Returns null when no match — callers should
- * check rather than assume so an unknown id (e.g. a stale URL) doesn't
- * crash the layout.
+ * Look up a hub by id. Returns null when no match.
  */
 export function findHubById(id) {
   if (typeof id !== "string") return null;
@@ -172,10 +235,10 @@ export function findHubById(id) {
 
 /**
  * Map a department string (any case, any whitespace) to the matching
- * hub id. Returns the DEFAULT_HUB_ID when nothing matches — onboarding
- * (M-OB) calls this to pick where a new user lands. Returns null when
- * `department` is empty/missing so the caller can prompt instead of
- * silently routing to dev.
+ * hub id. Returns null on empty input; DEFAULT_HUB_ID on unknown
+ * department (so the caller always has a fallback for non-empty
+ * input). Onboarding uses this only as a hint — the real assignment
+ * is via `getRolesForDepartment` in apps/api.
  */
 export function getHubIdForDepartment(department) {
   if (typeof department !== "string" || department.trim().length === 0) {
@@ -190,9 +253,12 @@ export function getHubIdForDepartment(department) {
 
 /**
  * Resolve the list of HubDefinition objects a user can access, given
- * their `allowedHubs` array. Unknown ids are filtered out silently so
- * an admin removing a hub doesn't leave users staring at a broken
- * switcher. Preserves HUB_ORDER.
+ * their `allowedHubs` array. Unknown ids are filtered out silently.
+ * Preserves HUB_ORDER.
+ *
+ * NOTE: Kept for backward compatibility during the M-CAP migration.
+ * The new resolver is `resolveHubsForCapabilities(caps)` below, which
+ * is what /api/v1/hubs/me uses post-migration.
  */
 export function resolveAllowedHubs(allowedHubIds) {
   if (!Array.isArray(allowedHubIds)) return [];
@@ -200,4 +266,29 @@ export function resolveAllowedHubs(allowedHubIds) {
   return HUB_ORDER.filter((id) => set.has(id))
     .map((id) => HUBS[id])
     .filter(Boolean);
+}
+
+/**
+ * Capability-driven resolver. Given a user's capability set, returns
+ * the HubDefinition objects whose `requires` are satisfied. Preserves
+ * HUB_ORDER. A hub with no `requires` list is open to everyone (no
+ * such hub today; reserved for future public surfaces).
+ */
+export function resolveHubsForCapabilities(userCapsSet) {
+  if (!(userCapsSet instanceof Set)) return [];
+  const out = [];
+  for (const id of HUB_ORDER) {
+    const hub = HUBS[id];
+    if (!hub) continue;
+    const requires = hub.requires || [];
+    let ok = true;
+    for (const cap of requires) {
+      if (!userCapsSet.has(cap)) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) out.push(hub);
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary

First of three PRs replacing the single-role-→-hub model with a capability pattern. After this PR the API resolves hub access from ``roles → capabilities → hub.requires``; PR 2 adds the admin hub UI, PR 3 adds the post-login hub-picker modal.

## What changes structurally

| Before | After |
|---|---|
| ``users.role`` (single) + ``users.allowedHubs`` | ``users.roles`` (array) drives everything |
| ``/hubs/me`` intersected ``allowedHubs`` with the registry | ``/hubs/me`` resolves capabilities from roles, filters hubs where ``requires`` is satisfied |
| 6 roles incl. generic ``member`` | 6 operational roles + ``member`` (deprecated, migrated → ``dev``) |
| 2 hubs (dev, qa) | 4 hubs (admin, dev, qa, manager) |

## What ships

**Shared package**
- ``capabilities/`` — ``CAPABILITIES`` enum + ``ROLES`` enum + ``ROLE_CAPABILITIES`` map + ``resolveCapabilities()`` / ``hasCapabilities()`` helpers
- ``hubs/registry.js`` — adds ``requires: Capability[]`` on every hub, adds admin + manager hubs, adds ``resolveHubsForCapabilities()``
- ``package.json`` — new ``./capabilities`` subpath export

**API**
- ``users`` schema + types — optional ``roles: UserRole[]``, ``dev`` role added
- ``lib/user-roles.ts`` — ``effectiveRoles()`` / ``effectiveCapabilities()`` / ``primaryRole()`` with the back-compat fallback ``u.roles ?? [u.role]``
- ``toPublicUser`` — exposes ``roles[]`` + ``capabilities[]`` to the frontend
- ``/api/v1/hubs/me`` — rewritten as the capability resolver
- Invite + admin-create — write both ``role`` and ``roles``; admin-create takes ``--roles=admin,dev,qa``
- Onboarding — department becomes profile-only; roles are no longer touched by the form
- **Boot-time migration** — backfills ``roles`` from legacy ``role`` for every existing row. Critical rule: ``role: "admin"`` → ``roles: ["admin", "dev", "qa"]`` so the bootstrap admin keeps multi-hub access after the cutover

## Migration safety

| Risk | Mitigation |
|---|---|
| Existing admin can't see Dev/QA after cutover | Migration auto-extends ``role: "admin"`` rows to ``roles: ["admin", "dev", "qa"]`` |
| Schema validator rejects pre-migration rows | ``roles`` is optional in the validator |
| Migration fails mid-flight | Idempotent (skip-if-already-set), retried next boot, non-fatal |
| ``/hubs/me`` returns empty for misconfigured user | Multi-tier fallback ends in "every registry hub" — prevents lockout |

## Smoke-test results

```
ROLES: admin, dev, qa, manager, hr, po
HUBS:  admin, dev, qa, manager

admin           → admin
dev             → dev
qa              → qa
admin+dev+qa    → admin, dev, qa
manager         → manager
hr              → (none — capability reserved, hub not shipped)
member (legacy) → (none — migration converts to dev)
```

## Test plan

- [x] ``npm run typecheck:api`` — clean
- [x] ``npm run build:api`` — clean
- [x] ``npm run build:web`` — clean
- [x] Node smoke import — capability resolution matches design across all 7 cases
- [ ] Restart the API → migration runs once → existing admin row gets ``roles: ["admin", "dev", "qa"]``
- [ ] Hit ``GET /api/v1/hubs/me`` as that admin → 3 hubs returned
- [ ] Invite a fresh user with ``role: "qa"`` → migration not needed (creation writes ``roles``); ``GET /hubs/me`` returns only QA

## PR plan

| PR | Scope |
|---|---|
| **This one** | Capability backend + migration + admin/manager hub registry entries |
| PR 2 | Admin hub UI scaffold (``apps/web/src/hubs/admin/``) — wires M10.5 endpoints into a UI |
| PR 3 | Post-login hub-picker modal (when ``|allowedHubs| > 1``) + hub switcher in header |

PR 2 and PR 3 each layer on top of this without changes here.