### PR TITLE
M-CAP PR 2: admin hub UI scaffold + RequireCapability component

### DIFF
--- a/apps/web/src/app/[hub]/audit/page.jsx
+++ b/apps/web/src/app/[hub]/audit/page.jsx
@@ -1,0 +1,25 @@
+"use client";
+
+/**
+ * /[hub]/audit — admin audit-log viewer.
+ *
+ * Currently only the `admin` hub exposes this slot. Slot guard
+ * redirects users on other hubs back to their dashboard.
+ */
+
+import { AppShell } from "@/components/shell/app-shell";
+import { useHubSlotGuard } from "@/features/hubs";
+import { getAdminSlotComponent } from "@/hubs/dashboard-registry";
+
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+  const exposed = useHubSlotGuard("audit");
+  if (!exposed) return null;
+  const Component = getAdminSlotComponent("audit");
+  return (
+    <AppShell>
+      {Component ? <Component /> : null}
+    </AppShell>
+  );
+}

--- a/apps/web/src/app/[hub]/hub-config/page.jsx
+++ b/apps/web/src/app/[hub]/hub-config/page.jsx
@@ -1,0 +1,25 @@
+"use client";
+
+/**
+ * /[hub]/hub-config — admin hub-config editor.
+ *
+ * Currently only the `admin` hub exposes this slot. Slot guard
+ * redirects users on other hubs back to their dashboard.
+ */
+
+import { AppShell } from "@/components/shell/app-shell";
+import { useHubSlotGuard } from "@/features/hubs";
+import { getAdminSlotComponent } from "@/hubs/dashboard-registry";
+
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+  const exposed = useHubSlotGuard("hub-config");
+  if (!exposed) return null;
+  const Component = getAdminSlotComponent("hub-config");
+  return (
+    <AppShell>
+      {Component ? <Component /> : null}
+    </AppShell>
+  );
+}

--- a/apps/web/src/app/[hub]/users/page.jsx
+++ b/apps/web/src/app/[hub]/users/page.jsx
@@ -1,0 +1,25 @@
+"use client";
+
+/**
+ * /[hub]/users — admin user management.
+ *
+ * Currently only the `admin` hub exposes this slot. Slot guard
+ * redirects users on other hubs back to their dashboard.
+ */
+
+import { AppShell } from "@/components/shell/app-shell";
+import { useHubSlotGuard } from "@/features/hubs";
+import { getAdminSlotComponent } from "@/hubs/dashboard-registry";
+
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+  const exposed = useHubSlotGuard("users");
+  if (!exposed) return null;
+  const Component = getAdminSlotComponent("users");
+  return (
+    <AppShell>
+      {Component ? <Component /> : null}
+    </AppShell>
+  );
+}

--- a/apps/web/src/components/shell/header.jsx
+++ b/apps/web/src/components/shell/header.jsx
@@ -10,21 +10,59 @@ import { useActiveHub } from "@/features/hubs";
 import { cn } from "@/lib/cn";
 
 /**
- * Nav slots. Each entry maps to a hub `pages.<slot>` symbolic id;
- * the link href is computed from the active hub's prefix at render
- * time. Slots a hub doesn't expose (missing from its `pages` map)
- * are silently hidden.
+ * Slot → nav label + subpath. Drives the header's nav rendering.
+ * The active hub's `pages` map decides which slots actually appear
+ * (slots not in `hub.pages` are silently hidden).
  *
- * `dashboard` is the home of each hub. We highlight it on the
- * drill-down routes (reviews, snapshots) as well, mirroring the
- * pre-M10.2 behaviour for Dev Hub.
+ * Order here is the order on screen. Admin slots come after the
+ * generic ones; the admin hub's nav reads naturally as
+ *   Dashboard · Hubs · Users · Audit · Settings
+ *
+ * Adding a slot to a hub now means: register it in the shared hub
+ * registry (`pages.<slot>`) + add a route file + add an entry here
+ * (or below in DASHBOARD_LABELS if it needs a hub-specific label).
  */
 const NAV_ITEMS = [
-  { slot: "dashboard", label: "Performance", subpath: "" },
-  { slot: "goals", label: "Goals", subpath: "/goals" },
-  { slot: "evidence", label: "Evidence", subpath: "/evidence" },
-  { slot: "settings", label: "Settings", subpath: "/settings" },
+  { slot: "dashboard", subpath: "" },
+  { slot: "goals", subpath: "/goals" },
+  { slot: "evidence", subpath: "/evidence" },
+  { slot: "hub-config", subpath: "/hub-config" },
+  { slot: "users", subpath: "/users" },
+  { slot: "audit", subpath: "/audit" },
+  { slot: "settings", subpath: "/settings" },
 ];
+
+/**
+ * Default labels per slot. Hub-specific overrides live in
+ * HUB_SLOT_LABEL_OVERRIDES below — Dev's dashboard reads as
+ * "Performance" (its longstanding name); admin's reads as "Overview";
+ * everyone else falls back to "Dashboard".
+ */
+const DEFAULT_LABELS = {
+  dashboard: "Dashboard",
+  goals: "Goals",
+  evidence: "Evidence",
+  "hub-config": "Hubs",
+  users: "Users",
+  audit: "Audit",
+  settings: "Settings",
+  reviews: "Reviews",
+  snapshots: "Snapshots",
+};
+
+const HUB_SLOT_LABEL_OVERRIDES = {
+  dev: { dashboard: "Performance" },
+  admin: { dashboard: "Overview" },
+  qa: { dashboard: "Overview" },
+  manager: { dashboard: "Team" },
+};
+
+function labelFor(slot, hubId) {
+  const hubOverride = HUB_SLOT_LABEL_OVERRIDES[hubId];
+  return (
+    (hubOverride && hubOverride[slot]) ?? DEFAULT_LABELS[slot] ?? slot
+  );
+}
 
 const VERSION = "v0.3.1";
 
@@ -34,9 +72,8 @@ export function Header() {
   const isLive = connectedProviders.length > 0;
   const hub = useActiveHub();
 
-  // Build the hub-prefixed link for each nav slot. If we don't have an
-  // active hub (very brief loading window, or a top-level non-hub page
-  // somehow renders the header), fall back to root — the redirect at
+  // Build the hub-prefixed link for each nav slot. Without an active
+  // hub (brief loading window) fall back to root — the redirect at
   // `/` will route the user back to their primary hub.
   const hubPrefix = hub ? `/${hub.id}` : "";
 
@@ -64,16 +101,11 @@ export function Header() {
         </Link>
         <nav className="flex gap-0.5" style={{ fontFamily: "var(--font-mono)" }}>
           {NAV_ITEMS.map((item) => {
-            // Hide nav items the active hub doesn't expose. The dev
-            // hub exposes all four; QA in M10.1 only exposes dashboard
-            // / goals / evidence / settings so this is a no-op for
-            // both current hubs, but ready for future hubs that
-            // restrict their nav.
             if (hub && !hub.pages[item.slot]) return null;
-
+            const label = labelFor(item.slot, hub?.id);
             const href = `${hubPrefix}${item.subpath}` || "/";
             // Dashboard slot is the home tab — highlight on its
-            // drill-downs too.
+            // drill-downs too (reviews/snapshots for Dev).
             const dashboardHome = `${hubPrefix}` || "/";
             const active =
               item.slot === "dashboard"
@@ -92,7 +124,7 @@ export function Header() {
                     : "text-muted-fg hover:bg-accent-dim/60",
                 )}
               >
-                {item.label}
+                {label}
               </Link>
             );
           })}
@@ -116,8 +148,7 @@ export function Header() {
         </div>
         {/* Inverse-themed activator — opens the accent-ground analyst page. */}
         <AnalystActivator />
-        {/* Session-aware chip with logout dropdown. Falls back to the
-            integrations-derived identity in pure-localStorage mode. */}
+        {/* Session-aware chip with logout dropdown. */}
         <UserChip />
       </div>
     </header>

--- a/apps/web/src/features/auth/index.js
+++ b/apps/web/src/features/auth/index.js
@@ -7,6 +7,8 @@
  *   <AcceptInviteForm>   — used by /accept-invite page
  *   <AuthGuard>          — wraps protected page contents
  *   <UserChip>           — header chip showing the session user + logout
+ *   <RequireCapability>  — gate child elements on a capability check
+ *   hasCapability/hasAllCapabilities — non-React reader helpers
  */
 
 export { useSession } from "./use-session.js";
@@ -15,3 +17,8 @@ export { LoginForm } from "./login-form.jsx";
 export { AcceptInviteForm } from "./accept-invite-form.jsx";
 export { AuthGuard } from "./auth-guard.jsx";
 export { UserChip } from "./user-chip.jsx";
+export {
+  RequireCapability,
+  hasCapability,
+  hasAllCapabilities,
+} from "./require-capability.jsx";

--- a/apps/web/src/features/auth/require-capability.jsx
+++ b/apps/web/src/features/auth/require-capability.jsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * Capability gate for UI elements.
+ *
+ * Usage:
+ *   <RequireCapability cap="admin.users.manage">
+ *     <Link href={link("/users")}>Manage users</Link>
+ *   </RequireCapability>
+ *
+ * Renders children only when the active session has the capability;
+ * otherwise renders null (or the optional `fallback`). The server is
+ * the authoritative gate — the session's `capabilities` array ships
+ * from /auth/me, computed server-side from the user's roles.
+ *
+ * Multiple required capabilities: pass `caps={["a", "b"]}`. The match
+ * is AND — every cap must be in the user's set.
+ *
+ * Loading state: when the session hasn't resolved yet, renders
+ * `fallback` (or null). This avoids a flash of gated content during
+ * the auth-hydration window.
+ */
+
+import { useSession } from "./use-session.js";
+
+export function RequireCapability({
+  cap,
+  caps,
+  fallback = null,
+  children,
+}) {
+  const { user, loading } = useSession();
+  const required = cap ? [cap] : Array.isArray(caps) ? caps : [];
+
+  if (loading) return fallback;
+  if (!user) return fallback;
+
+  const userCaps = Array.isArray(user.capabilities) ? user.capabilities : [];
+  for (const r of required) {
+    if (!userCaps.includes(r)) return fallback;
+  }
+  return children;
+}
+
+/**
+ * Non-React reader. Returns true if the user holds ALL of the
+ * required capabilities. Use inside event handlers or non-component
+ * code (e.g. command-palette commands that need to filter by cap).
+ */
+export function hasCapability(user, cap) {
+  if (!user || !Array.isArray(user.capabilities)) return false;
+  return user.capabilities.includes(cap);
+}
+
+export function hasAllCapabilities(user, caps) {
+  if (!user || !Array.isArray(user.capabilities)) return false;
+  if (!Array.isArray(caps) || caps.length === 0) return true;
+  return caps.every((c) => user.capabilities.includes(c));
+}

--- a/apps/web/src/hubs/admin/admin-dashboard.jsx
+++ b/apps/web/src/hubs/admin/admin-dashboard.jsx
@@ -1,0 +1,213 @@
+"use client";
+
+/**
+ * Admin Hub — overview page. Renders at /admin.
+ *
+ * Org-wide quick stats + entry points to the deeper admin pages
+ * (hub-config, users, audit). Designed to be the calm landing
+ * surface — three cards in a row, dense but readable, no spinners
+ * on the happy path.
+ *
+ * Data sources:
+ *   /api/v1/hubs/me           — what this org's hub map looks like
+ *                                after admin overrides
+ *   /api/v1/hub-configs       — list of override rows
+ *   (users / audit counts are TBD; placeholders for now)
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { apiGet } from "@/lib/api-client";
+import { useHubLink } from "@/features/hubs";
+import { useSession } from "@/features/auth";
+
+export function AdminDashboard() {
+  const link = useHubLink();
+  const { user } = useSession();
+  const [hubsState, setHubsState] = useState({ loading: true, hubs: [], err: null });
+  const [configsState, setConfigsState] = useState({ loading: true, configs: [], err: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const r = await apiGet("/hubs/me");
+      if (cancelled) return;
+      if (r.ok) {
+        setHubsState({ loading: false, hubs: r.data?.hubs ?? [], err: null });
+      } else {
+        setHubsState({ loading: false, hubs: [], err: r.error });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const r = await apiGet("/hub-configs");
+      if (cancelled) return;
+      if (r.ok) {
+        setConfigsState({
+          loading: false,
+          configs: r.data?.configs ?? [],
+          err: null,
+        });
+      } else {
+        setConfigsState({ loading: false, configs: [], err: r.error });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="relative z-[2] mx-auto max-w-6xl px-10 pb-14 pt-10">
+      <header className="mb-8">
+        <div
+          className="mb-2 uppercase tracking-[0.5px] text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+        >
+          Admin · overview
+        </div>
+        <h1
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: 32,
+            letterSpacing: "-0.6px",
+            lineHeight: 1.1,
+          }}
+        >
+          Org administration.
+        </h1>
+        <p className="mt-2 max-w-xl text-[14px] leading-[1.55] text-muted-fg">
+          Configure which hubs your org sees, manage member roles, and
+          audit privileged actions.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-3 gap-4">
+        <StatCard
+          label="Hubs visible to your org"
+          value={
+            hubsState.loading
+              ? "—"
+              : `${hubsState.hubs.length}`
+          }
+          sub={
+            hubsState.loading
+              ? "loading"
+              : hubsState.hubs.map((h) => h.label).join(" · ")
+          }
+        />
+        <StatCard
+          label="Active config overrides"
+          value={
+            configsState.loading
+              ? "—"
+              : `${configsState.configs.length}`
+          }
+          sub={
+            configsState.loading
+              ? "loading"
+              : configsState.configs.length === 0
+                ? "using registry defaults"
+                : configsState.configs
+                    .map((c) => c.hubId)
+                    .join(", ")
+          }
+        />
+        <StatCard
+          label="Your roles"
+          value={user?.roles?.length ?? 0}
+          sub={user?.roles?.join(" · ") || "—"}
+        />
+      </div>
+
+      <div className="mt-10 grid grid-cols-3 gap-4">
+        <NavCard
+          href={link("/hub-config")}
+          title="Hub configuration"
+          body="Toggle integrations, hide pages, override department mappings per hub. Backed by the M10.5 override layer."
+        />
+        <NavCard
+          href={link("/users")}
+          title="User management"
+          body="Manage roles + hub access per user. Full UI lands in a follow-up — the API endpoints are in flight."
+          comingSoon
+        />
+        <NavCard
+          href={link("/audit")}
+          title="Audit log"
+          body="Privileged-action history — invites, role changes, hub overrides, password resets. Viewer lands in a follow-up."
+          comingSoon
+        />
+      </div>
+    </main>
+  );
+}
+
+function StatCard({ label, value, sub }) {
+  return (
+    <div
+      className="rounded-md border border-border bg-card p-5"
+      style={{ borderColor: "var(--border-strong)" }}
+    >
+      <div
+        className="uppercase tracking-[0.4px] text-muted-fg"
+        style={{ fontFamily: "var(--font-mono)", fontSize: 10.5 }}
+      >
+        {label}
+      </div>
+      <div
+        className="mt-2 font-semibold"
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: 32,
+          letterSpacing: "-0.5px",
+        }}
+      >
+        {value}
+      </div>
+      <div
+        className="mt-1 text-[12px] text-muted-fg"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        {sub}
+      </div>
+    </div>
+  );
+}
+
+function NavCard({ href, title, body, comingSoon }) {
+  return (
+    <Link
+      href={href}
+      className="block rounded-md border border-border bg-card p-5 transition-colors hover:bg-accent-dim/40"
+      style={{ borderColor: "var(--border-strong)" }}
+    >
+      <div className="flex items-center justify-between">
+        <div className="text-[14px] font-semibold">{title}</div>
+        {comingSoon ? (
+          <span
+            className="rounded-full border border-dashed border-border px-2 py-0.5 text-dim-fg"
+            style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}
+          >
+            soon
+          </span>
+        ) : (
+          <span
+            className="text-accent"
+            style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+          >
+            →
+          </span>
+        )}
+      </div>
+      <p className="mt-2 text-[12.5px] leading-[1.5] text-muted-fg">{body}</p>
+    </Link>
+  );
+}

--- a/apps/web/src/hubs/admin/admin-hub-config.jsx
+++ b/apps/web/src/hubs/admin/admin-hub-config.jsx
@@ -1,0 +1,347 @@
+"use client";
+
+/**
+ * Admin Hub — hub-config editor. UI on top of the M10.5 endpoints:
+ *   GET    /api/v1/hub-configs           list overrides
+ *   PUT    /api/v1/hub-configs/:hubId    upsert
+ *   DELETE /api/v1/hub-configs/:hubId    revert to defaults
+ *
+ * Renders one expandable row per registry hub. Per row the admin can:
+ *   - Toggle `enabled` (hide the hub from the entire org)
+ *   - Toggle individual `allowedIntegrations`
+ *   - Toggle individual page slots (null = remove from effective map)
+ *
+ * Optimistic UI:
+ *   - PUT requests fire on every change
+ *   - The local state updates immediately
+ *   - On failure we toast + revert
+ *
+ * Loading state: shows "Loading…" until both /hubs/me and /hub-configs
+ * resolve. /hubs/me gives us the registry view (post-merge); /hub-configs
+ * gives the raw override rows we display alongside.
+ */
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { apiDelete, apiGet, apiPut } from "@/lib/api-client";
+import { useSession } from "@/features/auth";
+import { CAPABILITIES } from "@espace-devhub/shared/capabilities";
+
+const ALL_INTEGRATIONS = ["github", "gitlab", "jira"];
+
+export function AdminHubConfig() {
+  const { user } = useSession();
+  const [registryHubs, setRegistryHubs] = useState([]); // post-merge view from /hubs/me
+  const [configsByHub, setConfigsByHub] = useState({}); // raw override rows by hubId
+  const [loading, setLoading] = useState(true);
+  const [openHubId, setOpenHubId] = useState(null);
+  const [savingHubId, setSavingHubId] = useState(null);
+
+  // Gate the entire page on the capability — server-side enforcement
+  // already happens, but rendering this UI to a user who can't use
+  // it would be confusing.
+  const canConfigure = user?.capabilities?.includes(
+    CAPABILITIES.ADMIN_HUBS_CONFIGURE,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [hubsR, configsR] = await Promise.all([
+        apiGet("/hubs/me"),
+        apiGet("/hub-configs"),
+      ]);
+      if (cancelled) return;
+      if (hubsR.ok) {
+        setRegistryHubs(hubsR.data?.hubs ?? []);
+      }
+      if (configsR.ok) {
+        const map = {};
+        for (const c of configsR.data?.configs ?? []) {
+          map[c.hubId] = c;
+        }
+        setConfigsByHub(map);
+      }
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function saveOverride(hubId, patch) {
+    setSavingHubId(hubId);
+    const r = await apiPut(`/hub-configs/${hubId}`, patch);
+    setSavingHubId(null);
+    if (!r.ok) {
+      toast.error(r.error?.message || "Couldn't save override.");
+      return null;
+    }
+    setConfigsByHub((prev) => ({ ...prev, [hubId]: r.data?.config ?? null }));
+    toast.success(`Saved override for ${hubId}.`);
+    return r.data?.config;
+  }
+
+  async function revertOverride(hubId) {
+    setSavingHubId(hubId);
+    const r = await apiDelete(`/hub-configs/${hubId}`);
+    setSavingHubId(null);
+    if (!r.ok) {
+      toast.error(r.error?.message || "Couldn't revert override.");
+      return;
+    }
+    setConfigsByHub((prev) => {
+      const next = { ...prev };
+      delete next[hubId];
+      return next;
+    });
+    toast.success(`Reverted ${hubId} to registry defaults.`);
+  }
+
+  if (!canConfigure) {
+    return (
+      <main className="mx-auto max-w-3xl px-10 py-12">
+        <h1 className="mb-3 text-[24px] font-semibold">Not authorised.</h1>
+        <p className="text-[13px] text-muted-fg">
+          This view requires the {CAPABILITIES.ADMIN_HUBS_CONFIGURE}{" "}
+          capability. Ask your org admin to extend your roles.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="relative z-[2] mx-auto max-w-4xl px-10 pb-14 pt-10">
+      <header className="mb-8">
+        <div
+          className="mb-2 uppercase tracking-[0.5px] text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+        >
+          Admin · hub configuration
+        </div>
+        <h1
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: 28,
+            letterSpacing: "-0.5px",
+          }}
+        >
+          Per-hub overrides.
+        </h1>
+        <p className="mt-2 max-w-2xl text-[13.5px] leading-[1.55] text-muted-fg">
+          Toggle integrations and pages per hub for this org. Overrides
+          merge on top of registry defaults; an empty override means
+          "use defaults". Changes take effect on the next /hubs/me
+          round-trip (~one page load for each user).
+        </p>
+      </header>
+
+      {loading ? (
+        <div
+          className="text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+        >
+          Loading…
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {registryHubs.map((hub) => (
+            <HubRow
+              key={hub.id}
+              hub={hub}
+              override={configsByHub[hub.id] ?? null}
+              expanded={openHubId === hub.id}
+              onExpand={() => setOpenHubId(openHubId === hub.id ? null : hub.id)}
+              onSave={(patch) => saveOverride(hub.id, patch)}
+              onRevert={() => revertOverride(hub.id)}
+              saving={savingHubId === hub.id}
+            />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function HubRow({ hub, override, expanded, onExpand, onSave, onRevert, saving }) {
+  // Effective values — registry default with override applied. The
+  // /hubs/me response is already merged, so reading from `hub`
+  // directly gives us the post-merge view.
+  const enabled = override?.enabled === false ? false : true;
+  const hasOverride = !!override;
+
+  return (
+    <div
+      className="rounded-md border border-border bg-card"
+      style={{ borderColor: "var(--border-strong)" }}
+    >
+      <button
+        type="button"
+        onClick={onExpand}
+        className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-accent-dim/30"
+      >
+        <div className="flex items-center gap-3">
+          <span
+            className="block h-2 w-2 rounded-full"
+            style={{
+              background: enabled ? hub.theme.accent : "var(--dim-fg)",
+            }}
+          />
+          <div>
+            <div className="text-[14px] font-semibold">{hub.label}</div>
+            <div
+              className="text-muted-fg"
+              style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+            >
+              {hub.id} · {Object.keys(hub.pages).length} pages ·{" "}
+              {hub.allowedIntegrations.length} integrations
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {hasOverride ? (
+            <span
+              className="rounded-full border border-dashed border-border px-2 py-0.5 text-muted-fg"
+              style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}
+            >
+              custom
+            </span>
+          ) : null}
+          <span
+            className="text-muted-fg"
+            style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+          >
+            {expanded ? "−" : "+"}
+          </span>
+        </div>
+      </button>
+
+      {expanded ? (
+        <div
+          className="border-t px-5 py-4"
+          style={{ borderColor: "var(--border-strong)" }}
+        >
+          <ToggleRow
+            label="Visible to this org"
+            value={enabled}
+            disabled={saving}
+            onChange={(v) => onSave({ enabled: v })}
+          />
+
+          <FieldRow label="Integrations">
+            <div className="flex flex-wrap gap-1.5">
+              {ALL_INTEGRATIONS.map((p) => {
+                const on = hub.allowedIntegrations.includes(p);
+                return (
+                  <button
+                    key={p}
+                    type="button"
+                    disabled={saving}
+                    onClick={() => {
+                      const next = on
+                        ? hub.allowedIntegrations.filter((x) => x !== p)
+                        : [...hub.allowedIntegrations, p];
+                      onSave({ allowedIntegrations: next });
+                    }}
+                    className="rounded-full border px-2.5 py-1 transition-colors"
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 11,
+                      borderColor: on
+                        ? "var(--accent)"
+                        : "var(--border-strong)",
+                      background: on ? "var(--accent-dim)" : "transparent",
+                      color: on ? "var(--accent)" : "var(--muted-fg)",
+                      opacity: saving ? 0.5 : 1,
+                    }}
+                  >
+                    {p}
+                  </button>
+                );
+              })}
+            </div>
+          </FieldRow>
+
+          <FieldRow label="Page slots">
+            <div className="flex flex-wrap gap-1.5">
+              {Object.keys(hub.pages).map((slot) => (
+                <button
+                  key={slot}
+                  type="button"
+                  disabled={saving}
+                  onClick={() => {
+                    // Null out the slot in the override to remove it.
+                    onSave({ pages: { ...(override?.pages ?? {}), [slot]: null } });
+                  }}
+                  className="rounded-full border border-border px-2.5 py-1 transition-colors hover:border-red-300 hover:text-red-600"
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 11,
+                    opacity: saving ? 0.5 : 1,
+                  }}
+                  title={`Click to hide /${hub.id}/${slot} for this org`}
+                >
+                  {slot} ✕
+                </button>
+              ))}
+            </div>
+          </FieldRow>
+
+          {hasOverride ? (
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={onRevert}
+                disabled={saving}
+                className="text-[11px] font-bold uppercase tracking-[0.4px] text-red-600 hover:underline disabled:opacity-50"
+                style={{ fontFamily: "var(--font-mono)" }}
+              >
+                Revert to defaults
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ToggleRow({ label, value, disabled, onChange }) {
+  return (
+    <div className="flex items-center justify-between border-b border-dashed border-border py-2.5 last:border-b-0">
+      <div className="text-[13px]">{label}</div>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => onChange(!value)}
+        className="rounded-md border px-3 py-1 transition-colors"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          fontWeight: 700,
+          borderColor: value ? "var(--accent)" : "var(--border-strong)",
+          background: value ? "var(--accent-dim)" : "transparent",
+          color: value ? "var(--accent)" : "var(--muted-fg)",
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        {value ? "ON" : "OFF"}
+      </button>
+    </div>
+  );
+}
+
+function FieldRow({ label, children }) {
+  return (
+    <div className="border-b border-dashed border-border py-3 last:border-b-0">
+      <div
+        className="mb-2 uppercase tracking-[0.4px] text-muted-fg"
+        style={{ fontFamily: "var(--font-mono)", fontSize: 10.5 }}
+      >
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/hubs/admin/admin-placeholder.jsx
+++ b/apps/web/src/hubs/admin/admin-placeholder.jsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * Admin Hub — generic "coming soon" shell for slots that don't have
+ * their full UI yet (users, audit). Mirrors the QA placeholder
+ * pattern from M10.3.
+ *
+ * Surfaces the slot's purpose, the backend endpoints that need to
+ * land before the UI is real, and a back link to the admin
+ * dashboard.
+ */
+
+import Link from "next/link";
+import { useActiveHubStrict, useHubLink } from "@/features/hubs";
+
+const COPY = {
+  users: {
+    title: "User management",
+    body: "List every member of your org, edit their roles (multi-select), and manage hub access per user.",
+    pending: "Backend: GET /api/v1/admin/users + PATCH /api/v1/admin/users/:id",
+  },
+  audit: {
+    title: "Audit log",
+    body: "Filterable list of privileged actions — invites, role changes, hub overrides, password resets — with actor + IP + timestamp.",
+    pending: "Backend: GET /api/v1/admin/audit?since=…&limit=…",
+  },
+  default: {
+    title: "Coming soon",
+    body: "This admin surface is scaffolded — backend wiring lands next.",
+    pending: null,
+  },
+};
+
+export function AdminPlaceholder({ slot = "default" }) {
+  const hub = useActiveHubStrict();
+  const link = useHubLink();
+  const copy = COPY[slot] ?? COPY.default;
+
+  return (
+    <main className="relative z-[2] mx-auto max-w-2xl px-10 pb-14 pt-10">
+      <div
+        className="mb-2 uppercase tracking-[0.5px] text-muted-fg"
+        style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+      >
+        {hub.label} · {slot}
+      </div>
+      <h1
+        className="font-semibold"
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: 28,
+          letterSpacing: "-0.5px",
+        }}
+      >
+        {copy.title}
+      </h1>
+      <p className="mt-2 max-w-xl text-[14px] leading-[1.55] text-muted-fg">
+        {copy.body}
+      </p>
+
+      <div
+        className="mt-6 rounded-md border border-dashed border-border bg-card-alt p-4"
+        style={{ fontFamily: "var(--font-mono)", fontSize: 11.5 }}
+      >
+        <div className="mb-1 uppercase tracking-[0.4px] text-dim-fg">
+          Status
+        </div>
+        <div className="text-muted-fg">
+          UI scaffolded. {copy.pending ?? "Backend endpoint TBD."}
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <Link
+          href={link("")}
+          className="text-[11px] font-bold uppercase tracking-[0.5px] text-accent hover:underline"
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          ← Admin dashboard
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/hubs/admin/index.js
+++ b/apps/web/src/hubs/admin/index.js
@@ -1,0 +1,8 @@
+/**
+ * Admin Hub public surface. Page components mounted by the
+ * dashboard-registry + the slot route files.
+ */
+
+export { AdminDashboard } from "./admin-dashboard.jsx";
+export { AdminHubConfig } from "./admin-hub-config.jsx";
+export { AdminPlaceholder } from "./admin-placeholder.jsx";

--- a/apps/web/src/hubs/dashboard-registry.jsx
+++ b/apps/web/src/hubs/dashboard-registry.jsx
@@ -19,6 +19,11 @@
 
 import { DashboardPage } from "@/features/dashboard";
 import { QaPlaceholder } from "@/hubs/qa";
+import {
+  AdminDashboard,
+  AdminHubConfig,
+  AdminPlaceholder,
+} from "@/hubs/admin";
 
 /**
  * Map of hubId → React component for the dashboard slot.
@@ -27,6 +32,8 @@ import { QaPlaceholder } from "@/hubs/qa";
 const DASHBOARDS = {
   dev: DashboardPage,
   qa: () => <QaPlaceholder slot="dashboard" />,
+  admin: AdminDashboard,
+  manager: () => <QaPlaceholder slot="dashboard" />, // placeholder; real UI later
 };
 
 /**
@@ -43,4 +50,24 @@ function DefaultDashboardPlaceholder() {
 
 export function getDashboardComponent(hubId) {
   return DASHBOARDS[hubId] ?? DefaultDashboardPlaceholder;
+}
+
+/**
+ * Admin-specific page-slot resolver. The admin hub uses unique slot
+ * ids (hub-config, users, audit) that don't exist in other hubs.
+ * Pages files for those slots dispatch through this map.
+ *
+ * Other hubs keep their per-slot page wiring inline in the route
+ * files (e.g. app/[hub]/reviews/page.jsx hard-codes PrReviewsPage).
+ * The admin hub uses a registry pattern because it has more slots
+ * and benefits from a single dispatch table.
+ */
+const ADMIN_SLOT_COMPONENTS = {
+  "hub-config": AdminHubConfig,
+  users: () => <AdminPlaceholder slot="users" />,
+  audit: () => <AdminPlaceholder slot="audit" />,
+};
+
+export function getAdminSlotComponent(slot) {
+  return ADMIN_SLOT_COMPONENTS[slot] ?? null;
 }


### PR DESCRIPTION
## Summary

Second of three PRs. Builds the React surface for the admin hub that PR 1 wired into the registry. After this PR an admin who logs in has a clickable admin experience — overview, **hub-config editor** (full UI on top of M10.5 endpoints), placeholders for users + audit (backend lands separately).

## What ships

**Capability gate primitive**
- ``features/auth/require-capability.jsx`` — ``<RequireCapability cap="…">`` + ``hasCapability()`` / ``hasAllCapabilities()`` non-React helpers

**Admin hub pages** (`apps/web/src/hubs/admin/`)
- ``admin-dashboard.jsx`` — overview with three stat cards (hubs visible, override count, your roles) and three nav cards pointing at hub-config / users / audit
- ``admin-hub-config.jsx`` — **fully functional** override editor. Expandable row per hub, toggles for `enabled` + `allowedIntegrations` + page-slot removal. Optimistic UI with toast feedback. Self-gated by ``admin.hubs.configure``
- ``admin-placeholder.jsx`` — coming-soon shell for users + audit slots, names the pending backend endpoint

**Registry + routing**
- ``hubs/dashboard-registry.jsx`` — adds admin → AdminDashboard + ``getAdminSlotComponent(slot)`` dispatch table for hub-config / users / audit
- ``app/[hub]/{audit,hub-config,users}/page.jsx`` — three new route files. Each uses ``useHubSlotGuard`` so dev/qa users get redirected away from admin-only pages

**Header**
- Nav now derives from the active hub's ``pages`` map. Default labels per slot with per-hub overrides (Dev's dashboard reads "Performance"; admin/qa read "Overview"; manager reads "Team"). Adding a slot to any hub = entry in DEFAULT_LABELS + registry entry, nothing else

## End-to-end after this PR

```
Admin logs in → /hubs/me returns admin, dev, qa
→ AuthGuard sees onboardingCompletedAt=now (bootstrap admin)
→ Picker modal lands in PR 3; today they go to /dev
→ Click brand logo / type /admin → admin dashboard renders
→ Nav reads: Overview · Hubs · Users · Audit · Settings
→ Hubs page: full hub-config editor, click → expand → toggle →
  PUT /hub-configs/dev fires, toast confirms
→ Users + Audit: "coming soon" placeholders explaining the
  pending backend endpoints
```

## Test plan

- [x] ``npm run build:web`` — passes
- [x] Routing tree includes ``/[hub]/audit``, ``/[hub]/hub-config``, ``/[hub]/users``
- [ ] As admin, ``/admin/hub-config`` renders the editor; toggling `enabled` on QA fires ``PUT`` and toasts success
- [ ] As admin, hide GitHub from Dev → ``GET /hubs/me`` reflects the change on next page load
- [ ] As dev user, ``/dev/hub-config`` → slot guard redirects to ``/dev``
- [ ] As admin without ``admin.hubs.configure`` (shouldn't happen with current role map, but defensive) → "Not authorised" panel renders

## PR plan progress

| PR | Scope | Status |
|---|---|---|
| 1 | M-CAP backend (capabilities + roles + hubs/me rewrite + migration) | ✓ merged |
| **2 (this PR)** | Admin hub UI scaffold | open |
| 3 | Post-login hub-picker modal + header switcher | pending |
| 4 (split off) | ``/api/v1/admin/users`` + ``/api/v1/admin/audit`` endpoints + their UIs | pending |