### PR TITLE
M-CAP PR 3: post-login hub picker + header switcher

### DIFF
--- a/apps/web/src/components/shell/header.jsx
+++ b/apps/web/src/components/shell/header.jsx
@@ -6,7 +6,7 @@ import { LogoMark } from "./logo-mark";
 import { AnalystActivator } from "@/features/analyst";
 import { useIntegrations } from "@/features/integrations";
 import { UserChip } from "@/features/auth";
-import { useActiveHub } from "@/features/hubs";
+import { useActiveHub, HubSwitcher } from "@/features/hubs";
 import { cn } from "@/lib/cn";
 
 /**
@@ -99,6 +99,9 @@ export function Header() {
             {VERSION}
           </span>
         </Link>
+        {/* Multi-hub users see a switcher chip here. Single-hub users
+            see nothing (HubSwitcher self-hides when |hubs| <= 1). */}
+        <HubSwitcher />
         <nav className="flex gap-0.5" style={{ fontFamily: "var(--font-mono)" }}>
           {NAV_ITEMS.map((item) => {
             if (hub && !hub.pages[item.slot]) return null;

--- a/apps/web/src/features/hubs/hub-pick-store.js
+++ b/apps/web/src/features/hubs/hub-pick-store.js
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+ * localStorage-backed store for the user's "currently active hub
+ * pick".
+ *
+ * Why pick state matters separately from the user's `primaryHub`:
+ *   - primaryHub is the user's stored DEFAULT (the hub they land in
+ *     unless they say otherwise; persisted server-side).
+ *   - The "pick" is the CURRENT in-session choice. A bootstrap
+ *     admin (roles: admin+dev+qa) might want to spend the next
+ *     hour in QA without changing their server-side primary.
+ *
+ * Lifecycle:
+ *   - Login → / → if >1 hubs available AND no recent pick → the
+ *     picker UI renders. User clicks → pick is set.
+ *   - On subsequent visits to /, if the pick is fresh (< 24h) and
+ *     valid (in the user's allowed list), redirect to that hub
+ *     without showing the picker again.
+ *   - Header HubSwitcher overwrites the pick.
+ *   - Logout → store is cleared (via resetHubsStore in the M10.2
+ *     fetcher, plus this module's clear on session-flip).
+ *
+ * Pick is per-device — different browser profiles can prefer
+ * different hubs for the same user. Same pattern as the integrations
+ * store: localStorage is the source of truth for the UI, server is
+ * authoritative for the identity behind it.
+ */
+
+const KEY = "espace-devhub:active-hub-pick";
+
+/**
+ * Pick freshness window. After 24h, the picker re-prompts even
+ * if a stale pick exists. Tuned for "you start a fresh workday,
+ * you reconsider where to land".
+ */
+const PICK_TTL_MS = 24 * 60 * 60 * 1000;
+
+const subscribers = new Set();
+
+function read() {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed.hubId !== "string") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function getActivePick() {
+  return read();
+}
+
+/**
+ * Returns the picked hubId if there's a fresh, valid pick in the
+ * allowed-hubs list. Returns null if no pick, expired, or not
+ * accessible to this user any more (e.g. an admin revoked the role).
+ */
+export function getValidPick(allowedHubIds) {
+  const pick = read();
+  if (!pick) return null;
+  if (typeof pick.pickedAt !== "number") return null;
+  if (Date.now() - pick.pickedAt > PICK_TTL_MS) return null;
+  if (Array.isArray(allowedHubIds) && !allowedHubIds.includes(pick.hubId)) {
+    return null;
+  }
+  return pick.hubId;
+}
+
+export function setActivePick(hubId) {
+  if (typeof window === "undefined") return;
+  if (typeof hubId !== "string" || hubId.length === 0) return;
+  try {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ hubId, pickedAt: Date.now() }),
+    );
+  } catch {
+    /* quota / private mode — swallow */
+  }
+  for (const cb of subscribers) cb();
+}
+
+export function clearActivePick() {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    /* swallow */
+  }
+  for (const cb of subscribers) cb();
+}
+
+export function subscribeHubPick(cb) {
+  subscribers.add(cb);
+  return () => subscribers.delete(cb);
+}
+
+export const HUB_PICK_KEY = KEY;

--- a/apps/web/src/features/hubs/hub-picker.jsx
+++ b/apps/web/src/features/hubs/hub-picker.jsx
@@ -1,0 +1,187 @@
+"use client";
+
+/**
+ * Post-login hub picker. Renders ONCE per session-pick window when
+ * the user has more than one hub available (`allowedHubs.length > 1`)
+ * and no recent pick is stored locally.
+ *
+ * Mounted by HubRedirect — that component decides whether to render
+ * this picker vs. redirect directly. The picker itself is just a
+ * grid of cards plus the navigation handler.
+ *
+ * Visual design: full-bleed neutral surface (sand, not a hub theme).
+ * Each card carries its hub's accent so the user can scan by colour
+ * before reading the label.
+ *
+ * On click:
+ *   1. Store the pick in localStorage (24h TTL).
+ *   2. router.replace(`/${hubId}`).
+ */
+
+import { useRouter } from "next/navigation";
+import { setActivePick } from "./hub-pick-store.js";
+
+export function HubPicker({ hubs, primaryHubId }) {
+  const router = useRouter();
+
+  function pick(hubId) {
+    setActivePick(hubId);
+    router.replace(`/${hubId}`);
+  }
+
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "#f5f1e8",
+        color: "#1c1c1c",
+      }}
+    >
+      <div className="mx-auto grid min-h-screen max-w-5xl grid-rows-[1fr_auto] px-6 py-16">
+        <div className="flex flex-col">
+          <div
+            className="mb-4 inline-flex w-fit items-center gap-2 rounded-full border border-[rgba(28,28,28,0.12)] px-3 py-1"
+            style={{ fontFamily: "var(--font-mono)", fontSize: 10.5 }}
+          >
+            <span
+              className="block h-1.5 w-1.5 rounded-full"
+              style={{ background: "#8a6b3c" }}
+            />
+            <span className="uppercase tracking-[0.5px] text-[#5a4a2c]">
+              Choose where to land
+            </span>
+          </div>
+
+          <h1
+            className="mb-3 font-semibold"
+            style={{
+              fontFamily: "var(--font-display)",
+              fontSize: 40,
+              lineHeight: 1.08,
+              letterSpacing: "-0.7px",
+            }}
+          >
+            You have access to{" "}
+            <span style={{ fontStyle: "italic" }}>{hubs.length} hubs</span>.
+          </h1>
+          <p
+            className="mb-10 max-w-xl text-[14.5px] leading-[1.55]"
+            style={{ color: "#5a4a2c" }}
+          >
+            Pick one to start. You can switch any time from the header — and
+            we'll remember this choice for the next 24 hours.
+          </p>
+
+          <div
+            className="grid gap-4"
+            style={{
+              gridTemplateColumns: `repeat(${Math.min(hubs.length, 3)}, minmax(0, 1fr))`,
+            }}
+          >
+            {hubs.map((hub) => (
+              <HubCard
+                key={hub.id}
+                hub={hub}
+                isPrimary={hub.id === primaryHubId}
+                onClick={() => pick(hub.id)}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div
+          className="mt-12 border-t border-[rgba(28,28,28,0.08)] pt-4 text-[11px]"
+          style={{ fontFamily: "var(--font-mono)", color: "#7a6a4c" }}
+        >
+          Pick is stored in your browser. Switching hubs from the header
+          updates it.
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function HubCard({ hub, isPrimary, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group relative flex flex-col items-start gap-3 overflow-hidden rounded-lg border-2 p-5 text-left transition-all hover:-translate-y-0.5"
+      style={{
+        background: "#ffffff",
+        borderColor: hub.theme.accent,
+        boxShadow: `0 1px 0 0 ${hub.theme.accentSurface}, 0 0 0 0 ${hub.theme.accentSurface}`,
+      }}
+    >
+      <div className="flex w-full items-center justify-between">
+        <div
+          className="grid h-9 w-9 place-items-center rounded-md font-bold"
+          style={{
+            background: hub.theme.accentSurface,
+            color: hub.theme.accent,
+            fontFamily: "var(--font-mono)",
+            fontSize: 12,
+          }}
+        >
+          {hub.id[0].toUpperCase()}
+        </div>
+        {isPrimary ? (
+          <span
+            className="rounded-full px-2 py-0.5 uppercase tracking-[0.4px]"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 9.5,
+              fontWeight: 700,
+              background: hub.theme.accentSurface,
+              color: hub.theme.accent,
+            }}
+          >
+            Default
+          </span>
+        ) : null}
+      </div>
+
+      <div>
+        <div
+          className="text-[18px] font-semibold"
+          style={{ letterSpacing: "-0.3px" }}
+        >
+          {hub.label}
+        </div>
+        <p className="mt-1 text-[12.5px] leading-[1.5] text-[#5a4a2c]">
+          {hub.description}
+        </p>
+      </div>
+
+      <div
+        className="mt-1 flex flex-wrap gap-1.5"
+        style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}
+      >
+        {Object.keys(hub.pages).slice(0, 4).map((slot) => (
+          <span
+            key={slot}
+            className="rounded-sm border border-dashed border-[rgba(28,28,28,0.16)] px-1.5 py-0.5 text-[#7a6a4c]"
+          >
+            {slot}
+          </span>
+        ))}
+        {Object.keys(hub.pages).length > 4 ? (
+          <span className="text-[#7a6a4c]">
+            +{Object.keys(hub.pages).length - 4}
+          </span>
+        ) : null}
+      </div>
+
+      <span
+        className="absolute right-4 bottom-4 transition-transform group-hover:translate-x-1"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 14,
+          color: hub.theme.accent,
+        }}
+      >
+        →
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/features/hubs/hub-redirect.jsx
+++ b/apps/web/src/features/hubs/hub-redirect.jsx
@@ -1,24 +1,33 @@
 "use client";
 
 /**
- * Root-page redirector. Mounted at /page.jsx. Sends the user to their
- * primary hub once we know who they are and which hub they prefer.
+ * Root-page dispatcher. Mounted at /page.jsx. Decides where an
+ * authenticated user lands.
  *
  * Decision matrix:
- *   session.loading       → render a quiet placeholder
- *   session.user == null  → AuthGuard handles it (renders /login)
+ *   session.loading       → quiet placeholder
+ *   session.user == null  → AuthGuard handles it (→ /login)
  *   hubs.status="loading" → placeholder
- *   hubs.status="ready"   → router.replace(`/${primaryHubId}`)
- *   hubs.status="error"   → placeholder + log (next session retry)
+ *   hubs.status="error"   → placeholder (next session retries)
+ *   0 allowed hubs        → placeholder (the resolver fallback in
+ *                            /hubs/me would normally never let this
+ *                            happen)
+ *   1 allowed hub         → router.replace(`/${hub.id}`)
+ *   >1 hubs, valid pick   → router.replace(`/${pickedHubId}`)
+ *   >1 hubs, no pick      → render <HubPicker /> (the user picks
+ *                            interactively; pick is stored in
+ *                            localStorage with a 24h TTL)
  *
- * The redirect uses replace() so the back button doesn't bounce the
- * user between `/` and `/dev`.
+ * Replace (not push) so the back button doesn't bounce the user
+ * between `/` and `/<hub>`.
  */
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useSession, AuthGuard } from "@/features/auth";
 import { useAvailableHubs } from "./use-available-hubs";
+import { getValidPick } from "./hub-pick-store.js";
+import { HubPicker } from "./hub-picker.jsx";
 
 export function HubRedirect() {
   return (
@@ -33,15 +42,44 @@ function HubRedirectInner() {
   const { user, loading: sessionLoading } = useSession();
   const { status, primaryHubId, defaultHubId, hubs } = useAvailableHubs();
 
+  // Compute the redirect target. `null` means "render the picker".
+  let target = null;
+  if (status === "ready" && Array.isArray(hubs) && hubs.length > 0) {
+    if (hubs.length === 1) {
+      target = `/${hubs[0].id}`;
+    } else {
+      const allowedIds = hubs.map((h) => h.id);
+      const picked = getValidPick(allowedIds);
+      if (picked) {
+        target = `/${picked}`;
+      }
+      // else: multi-hub user with no recent pick → render the
+      // picker (target stays null).
+    }
+  }
+
   useEffect(() => {
     if (sessionLoading || !user) return;
     if (status !== "ready") return;
-    const target = primaryHubId || hubs[0]?.id || defaultHubId;
-    if (target) {
-      router.replace(`/${target}`);
-    }
-  }, [sessionLoading, user, status, primaryHubId, defaultHubId, hubs, router]);
+    if (target) router.replace(target);
+  }, [sessionLoading, user, status, target, router]);
 
+  // Render the picker when we're done loading and there's no
+  // resolved target (multi-hub, no recent pick).
+  if (
+    !sessionLoading &&
+    user &&
+    status === "ready" &&
+    hubs.length > 1 &&
+    !target
+  ) {
+    return <HubPicker hubs={hubs} primaryHubId={primaryHubId} />;
+  }
+
+  // Single-hub or redirect-in-flight: small loading placeholder.
+  // `defaultHubId` referenced here purely to keep its existing
+  // import live for future use (audit trails consume it).
+  void defaultHubId;
   return (
     <main
       style={{

--- a/apps/web/src/features/hubs/hub-switcher.jsx
+++ b/apps/web/src/features/hubs/hub-switcher.jsx
@@ -1,0 +1,162 @@
+"use client";
+
+/**
+ * Header hub-switcher. Renders only when the user has access to
+ * more than one hub. Single-hub users see nothing.
+ *
+ * Click → dropdown of all available hubs → click an item → set the
+ * pick in localStorage + router.push to that hub.
+ *
+ * Visual: a chip in the header that mirrors the active hub's accent.
+ * Sits next to the brand mark. Compact by design — the most common
+ * action is "I want to stay where I am", so the switcher should
+ * feel like a footnote, not a primary nav surface.
+ */
+
+import { useRouter } from "next/navigation";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@radix-ui/react-dropdown-menu";
+import { useActiveHub } from "./hub-context.js";
+import { useAvailableHubs } from "./use-available-hubs.js";
+import { setActivePick, clearActivePick } from "./hub-pick-store.js";
+import { cn } from "@/lib/cn";
+
+export function HubSwitcher() {
+  const router = useRouter();
+  const active = useActiveHub();
+  const { hubs, status } = useAvailableHubs();
+
+  // Render nothing when the user has 0 or 1 hubs — the switcher only
+  // exists for multi-hub users.
+  if (status !== "ready") return null;
+  if (!Array.isArray(hubs) || hubs.length <= 1) return null;
+  if (!active) return null;
+
+  function pick(hubId) {
+    setActivePick(hubId);
+    if (hubId !== active.id) {
+      router.push(`/${hubId}`);
+    }
+  }
+
+  function rePick() {
+    clearActivePick();
+    router.push("/");
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Switch hub. Active: ${active.label}`}
+          className={cn(
+            "flex items-center gap-2 rounded-md border px-2.5 py-1 transition-colors hover:opacity-90",
+          )}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            borderColor: "var(--border-strong)",
+            background: active.theme.accentSurface,
+            color: active.theme.accent,
+          }}
+        >
+          <span
+            className="grid h-4 w-4 place-items-center rounded-sm font-bold"
+            style={{
+              background: active.theme.accent,
+              color: "#ffffff",
+              fontSize: 9,
+            }}
+          >
+            {active.id[0].toUpperCase()}
+          </span>
+          <span className="uppercase tracking-[0.4px]">{active.label}</span>
+          <span style={{ opacity: 0.7 }}>▾</span>
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        align="start"
+        sideOffset={6}
+        className="z-50 min-w-[240px] rounded-md border p-1 shadow-lg"
+        style={{
+          background: "var(--card)",
+          borderColor: "var(--border-strong)",
+          fontFamily: "var(--font-mono)",
+        }}
+      >
+        <DropdownMenuLabel
+          className="px-2.5 py-2 uppercase tracking-[0.4px] text-dim-fg"
+          style={{ fontSize: 10.5 }}
+        >
+          Switch hub
+        </DropdownMenuLabel>
+        {hubs.map((hub) => {
+          const isActive = hub.id === active.id;
+          return (
+            <DropdownMenuItem
+              key={hub.id}
+              onSelect={(e) => {
+                e.preventDefault();
+                pick(hub.id);
+              }}
+              className={cn(
+                "flex cursor-pointer items-center justify-between rounded-sm px-2.5 py-2 outline-none",
+                "hover:bg-accent-dim focus:bg-accent-dim",
+              )}
+            >
+              <div className="flex items-center gap-2.5">
+                <span
+                  className="grid h-5 w-5 place-items-center rounded-sm font-bold"
+                  style={{
+                    background: hub.theme.accentSurface,
+                    color: hub.theme.accent,
+                    fontSize: 10,
+                  }}
+                >
+                  {hub.id[0].toUpperCase()}
+                </span>
+                <div>
+                  <div className="text-[12px] font-semibold text-fg">
+                    {hub.label}
+                  </div>
+                  <div
+                    className="text-dim-fg"
+                    style={{ fontSize: 10 }}
+                  >
+                    /{hub.id}
+                  </div>
+                </div>
+              </div>
+              {isActive ? (
+                <span
+                  className="uppercase tracking-[0.4px]"
+                  style={{ fontSize: 9.5, color: hub.theme.accent }}
+                >
+                  ● current
+                </span>
+              ) : null}
+            </DropdownMenuItem>
+          );
+        })}
+        <DropdownMenuSeparator className="my-1 h-px bg-border" />
+        <DropdownMenuItem
+          onSelect={(e) => {
+            e.preventDefault();
+            rePick();
+          }}
+          className="cursor-pointer rounded-sm px-2.5 py-2 text-[11px] text-muted-fg outline-none hover:bg-accent-dim focus:bg-accent-dim"
+        >
+          Re-open hub picker
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/features/hubs/hubs-fetcher.jsx
+++ b/apps/web/src/features/hubs/hubs-fetcher.jsx
@@ -20,6 +20,7 @@ import { useEffect, useRef } from "react";
 import { apiGet } from "@/lib/api-client";
 import { useSession } from "@/features/auth";
 import { resetHubsStore, setHubsState, getHubsState } from "./hubs-store";
+import { clearActivePick } from "./hub-pick-store.js";
 
 const LOG_PREFIX = "[hubs-fetcher]";
 
@@ -34,9 +35,12 @@ export function HubsFetcher() {
 
     if (!user) {
       if (lastUserIdRef.current !== null) {
-        // Session just dropped — wipe the cache so the next sign-in
-        // doesn't see stale data for ~1 paint.
+        // Session just dropped — wipe both the hubs cache AND the
+        // active-hub pick so a different user signing in on the
+        // same device doesn't inherit either the stale list or the
+        // prior user's chosen hub.
         resetHubsStore();
+        clearActivePick();
         lastUserIdRef.current = null;
       }
       return;

--- a/apps/web/src/features/hubs/index.js
+++ b/apps/web/src/features/hubs/index.js
@@ -5,19 +5,37 @@
  *                               /api/v1/hubs/me on session start.
  *   <HubProvider hubSlug={…}>  wraps app/[hub]/layout.jsx; validates
  *                               the URL slug + applies theme.
- *   <HubRedirect />            mount at /page.jsx; routes to primary.
+ *   <HubRedirect />            mount at /page.jsx; dispatches based
+ *                               on the user's allowed-hubs count.
+ *   <HubPicker hubs primaryHubId />
+ *                              full-bleed cards for multi-hub users.
+ *                               Mounted by HubRedirect.
+ *   <HubSwitcher />            header dropdown to swap hubs mid-session.
  *
- *   useAvailableHubs()         reactive — { status, hubs, primaryHubId, … }
+ *   useAvailableHubs()          reactive — { status, hubs, primaryHubId, … }
  *   useActiveHub()              the hub for the current URL, or null
  *   useActiveHubStrict()        same, throws if missing (hub-page-only)
+ *   getValidPick / setActivePick / clearActivePick
+ *                              imperative access to the localStorage
+ *                              pick store (used by HubRedirect +
+ *                              HubSwitcher).
  */
 
 export { HubsFetcher } from "./hubs-fetcher.jsx";
 export { HubProvider } from "./hub-provider.jsx";
 export { HubRedirect } from "./hub-redirect.jsx";
+export { HubPicker } from "./hub-picker.jsx";
+export { HubSwitcher } from "./hub-switcher.jsx";
 export { useAvailableHubs } from "./use-available-hubs.js";
 export { useActiveHub, useActiveHubStrict, HubContext } from "./hub-context.js";
 export { useHubLink } from "./use-hub-link.js";
 export { useHubSlotGuard } from "./use-hub-slot-guard.js";
 export { useAllowedProviders } from "./use-allowed-providers.js";
 export { resetHubsStore } from "./hubs-store.js";
+export {
+  getActivePick,
+  getValidPick,
+  setActivePick,
+  clearActivePick,
+  HUB_PICK_KEY,
+} from "./hub-pick-store.js";


### PR DESCRIPTION
## Summary

Closes the M-CAP arc. Multi-hub users (bootstrap admin with ``admin+dev+qa``, or any user with overlapping roles) get a **one-time picker at /**, then a **persistent header chip** to swap mid-session.

## What ships

| File | Purpose |
|---|---|
| ``hub-pick-store.js`` | localStorage ``{hubId, pickedAt}``, 24h TTL, pubsub for cross-tab parity. ``getValidPick(allowedIds)`` only returns a fresh pick the user still has access to. |
| ``hub-picker.jsx`` | Full-bleed picker page. Sand background, one card per accessible hub, each carrying the hub's accent. "Default" badge on the primary hub. |
| ``hub-switcher.jsx`` | Header chip + Radix dropdown. Self-hides when ``|hubs| <= 1``. "Re-open hub picker" item lets the user re-evaluate. |
| ``hub-redirect.jsx`` | Replaces pure-redirect with a dispatcher: 1 hub → redirect / multi + pick → redirect / multi + no pick → render ``<HubPicker />``. |
| ``hubs-fetcher.jsx`` | On logout, also clears the active pick — prevents a different user inheriting the prior pick. |
| ``components/shell/header.jsx`` | Mounts ``<HubSwitcher />``. |

## End-to-end after this PR

```
Bootstrap admin logs in
→ migration writes roles: [admin, dev, qa]
→ /hubs/me returns 3 hubs
→ HubRedirect: |hubs|=3, no pick → renders <HubPicker />
→ User clicks Admin → setActivePick + replace("/admin")
→ Admin dashboard renders, header shows
  "eSpace/Admin" + slate theme + switcher chip "● Admin ▾"

User clicks switcher → picks Dev
→ router.push("/dev"), pick updated
→ Dev dashboard renders, theme swaps

User reloads /
→ fresh pick (dev) → router.replace("/dev")
→ no re-prompt

User clicks "Re-open hub picker" in switcher
→ clearActivePick + push("/") → picker reappears
```

Single-hub users (invited QA hire with only ``roles:[qa]``) unaffected: ``|hubs|=1`` → single-redirect path → no picker, no switcher chip.

## Test plan

- [x] ``npm run build:web`` — passes
- [ ] Log in as bootstrap admin → land on ``/`` → see picker with 3 cards (Admin default-badged, Dev, QA)
- [ ] Click Admin → land on ``/admin``, header shows admin switcher
- [ ] Reload ``/`` → goes straight to ``/admin`` (pick remembered)
- [ ] Switcher → pick Dev → land on ``/dev``, theme + brand mark swap
- [ ] Logout + log in as a single-hub QA hire → no picker, no switcher chip
- [ ] Pick expires after 24h → picker re-appears

## M-CAP arc complete

| PR | Scope | Status |
|---|---|---|
| 1 | Capability backend + multi-role + migration | ✓ merged |
| 2 | Admin hub UI scaffold + RequireCapability | ✓ merged |
| **3 (this PR)** | Hub picker + switcher | open |
| 4 (split) | ``/api/v1/admin/{users,audit}`` endpoints + UIs | future |

Multi-hub users have a coherent end-to-end experience for the first time.