### PR TITLE
hotfix: admin role stays admin-only + per-user migrate marker

### DIFF
--- a/apps/api/src/db/migrations/m-cap-roles.ts
+++ b/apps/api/src/db/migrations/m-cap-roles.ts
@@ -10,13 +10,15 @@
  *                          generic pre-M-CAP role; the M-OB
  *                          department mapping makes new users
  *                          start with the right role going forward)
- *   - role === "admin"   → roles = ["admin", "dev", "qa"]
- *                          Preserves the bootstrap admin's ability
- *                          to navigate Dev + QA. New admins minted
- *                          AFTER this migration get just ["admin"]
- *                          unless the admin-create CLI was passed
- *                          --roles with more.
  *   - any other role     → roles = [role] (single-element)
+ *
+ * Admin auto-expansion was tried in the first cut of this migration
+ * (admin → admin+dev+qa) to preserve the bootstrap admin's
+ * pre-M-CAP multi-hub view. That was the wrong call: the design
+ * intent is that admin is admin-only by default, and an admin who
+ * also wants Dev/QA access gets it via an explicit `--roles=admin,dev`
+ * at admin-create time, or via the admin UI later. The single-role
+ * fallback is correct.
  *
  * Result is logged at info level with counts per outcome. Failure
  * is non-fatal: server boots regardless so /healthz stays green;
@@ -55,12 +57,14 @@ export async function migrateUserRoles(
     let roles: UserRole[];
     let outcome: string;
     if (legacyRole === "member") {
+      // Legacy "member" was the generic engineer role; map to the
+      // new explicit "dev" role.
       roles = ["dev"];
       outcome = "member→dev";
-    } else if (legacyRole === "admin") {
-      roles = ["admin", "dev", "qa"];
-      outcome = "admin→admin+dev+qa";
     } else {
+      // Every other role (including admin) gets converted as-is to
+      // a single-element array. Admin remains admin-only by default;
+      // multi-hub admins are opted in via --roles at admin-create.
       roles = [legacyRole];
       outcome = `single:${legacyRole}`;
     }

--- a/apps/web/src/features/migrate/migrate-once.jsx
+++ b/apps/web/src/features/migrate/migrate-once.jsx
@@ -1,34 +1,29 @@
 "use client";
 
 /**
- * One-shot localStorage→API migration trigger.
+ * One-shot localStorage→API migration trigger, per-(device, user).
  *
  * Mounted alongside the per-store <*Sync /> components in the root
- * layout. The component renders nothing — it's a lifecycle effect.
+ * layout. Renders nothing — it's a lifecycle effect.
  *
  * Flow:
  *   1. Wait until useSession() reports an authenticated user.
- *   2. If the local migration marker is already set, exit. The
- *      device has already uploaded; the per-store mirror writes
- *      keep things in sync from here on.
+ *   2. If the local migration marker is set FOR THIS USER, exit.
+ *      (Pre-hotfix the marker was per-device. A different user
+ *      signing in on the same browser would skip the migration and
+ *      land without their localStorage data on the server — which
+ *      broke the integrations proxy because no encrypted token was
+ *      stored under their userId.)
  *   3. Read the seven legacy localStorage keys via
- *      collectMigrationPayload(). If nothing to send, set the
- *      marker anyway and exit — a fresh device shouldn't keep
- *      retrying the no-op call every session.
- *   4. POST to /api/v1/migrate/import. On success, write the
- *      marker with the server-returned counts. On failure, log
- *      and bail (next session retries).
+ *      collectMigrationPayload(). If nothing to send, set the marker
+ *      anyway and exit.
+ *   4. POST to /api/v1/migrate/import. On success, write the marker
+ *      under the user's id with the server-returned counts. On
+ *      failure, log + bail; next session retries.
  *
- * Concurrency with the <*Sync /> pulls:
- *   The pull helpers only replaceLocal() when the server returns
- *   non-empty content. On a fresh user the pulls are no-ops, so
- *   they can't clobber the local data we're about to upload.
- *   We don't await the pulls — both run in parallel and converge.
- *
- * Toast:
- *   Uses sonner (already mounted at the root). A one-off "Synced
- *   N items to your account" with the per-collection counts. Quiet
- *   on no-data devices.
+ * Re-fires per user change: if the user logs out and a different
+ * user logs in on the same browser, firedRef resets via the user.id
+ * key in the effect — the new user gets their own migration check.
  */
 
 import { useEffect, useRef } from "react";
@@ -55,50 +50,54 @@ function totalImported(counts) {
 
 export function MigrateOnce() {
   const { user, loading } = useSession();
-  // Guards against React 18 StrictMode double-mounting in dev — we
-  // only want one POST per page lifetime.
-  const firedRef = useRef(false);
+  // Per-user fired flag — re-fires when the user.id changes (logout
+  // + login as a different user on the same browser tab).
+  const firedForUserRef = useRef(null);
 
   useEffect(() => {
     if (loading) return;
-    if (!user) return;
-    if (firedRef.current) return;
+    if (!user) {
+      firedForUserRef.current = null;
+      return;
+    }
+    if (firedForUserRef.current === user.id) return;
 
-    // Already migrated on this device — nothing to do.
-    if (readMigrationMarker()) {
-      firedRef.current = true;
+    // Already migrated this user on this device — nothing to do.
+    if (readMigrationMarker(user.id)) {
+      firedForUserRef.current = user.id;
       return;
     }
 
     const { payload, hasAny } = collectMigrationPayload();
 
-    // No legacy data on this device. Set the marker so we don't
-    // keep checking on every future session.
+    // No legacy data on this device. Set the marker for this user
+    // so we don't keep checking on every future session.
     if (!hasAny) {
-      writeMigrationMarker(null);
-      firedRef.current = true;
+      writeMigrationMarker(user.id, null);
+      firedForUserRef.current = user.id;
       return;
     }
 
-    firedRef.current = true;
+    firedForUserRef.current = user.id;
+    const userIdAtStart = user.id;
 
     (async () => {
       const result = await apiPost("/migrate/import", payload);
       if (!result.ok) {
-        // Auth failures: just leave the marker unset — next session
-        // will retry once the cookie is good.
+        // Auth failures: leave the marker unset — next session retries
+        // once the cookie is good.
         // eslint-disable-next-line no-console
         console.warn(
           `${LOG_PREFIX} import failed:`,
           result.error?.code,
           result.error?.message,
         );
-        firedRef.current = false;
+        firedForUserRef.current = null;
         return;
       }
 
       const counts = result.data?.counts ?? null;
-      writeMigrationMarker(counts);
+      writeMigrationMarker(userIdAtStart, counts);
 
       const total = totalImported(counts);
       if (total > 0) {

--- a/apps/web/src/features/migrate/migrate-store.js
+++ b/apps/web/src/features/migrate/migrate-store.js
@@ -1,52 +1,90 @@
 /**
- * One-shot localStorage→API migration marker.
+ * Per-(device, user) one-shot localStorage→API migration marker.
  *
- * The marker is per-device by design: each browser/profile carries
- * its own legacy localStorage, and each device's first authenticated
- * load triggers one upload. Re-uploads from the same device are a
- * no-op server-side (every collection has a unique-keyed upsert,
- * except goal_inputs which is append-only — that's why we gate on
- * a marker rather than relying purely on server idempotency).
+ * Storage shape: a single localStorage entry whose value is a map of
+ * userId → { completedAt, counts }. Each browser profile maintains
+ * its own map; each authenticated user in that profile triggers
+ * exactly one migration the first time they sign in.
  *
- * Stored value: a JSON object with the completion timestamp and
- * the counts the server returned, so the UI can show "imported 14
- * goals, 3 specs, …" if it wants to. The presence of the key is
- * what matters; the body is informational.
+ * Why per-user (not just per-device): the M7.9a marker was
+ * per-device only. That meant a second user signing in on the same
+ * browser (e.g. an admin already used the device, then a new admin
+ * is created) would never re-migrate — their localStorage wouldn't
+ * land on the server, and downstream proxies that need server-side
+ * tokens (M7.9c integrations proxy) would 401.
+ *
+ * Re-uploads from the same (device, user) are a no-op server-side —
+ * every collection has a unique-keyed upsert except goal_inputs
+ * (append-only). The marker prevents goal_inputs duplicate inserts
+ * specifically.
  */
 
-const MARKER_KEY = "espace-devhub:migrate-completed-at";
+const MARKER_KEY = "espace-devhub:migrate-completed-by-user";
 
-export function readMigrationMarker() {
-  if (typeof window === "undefined") return null;
+function readAll() {
+  if (typeof window === "undefined") return {};
   try {
     const raw = localStorage.getItem(MARKER_KEY);
-    if (!raw) return null;
-    return JSON.parse(raw);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
   } catch {
-    return null;
+    return {};
   }
 }
 
-export function writeMigrationMarker(counts) {
+function writeAll(map) {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(
-      MARKER_KEY,
-      JSON.stringify({ completedAt: Date.now(), counts: counts ?? null }),
-    );
+    localStorage.setItem(MARKER_KEY, JSON.stringify(map));
   } catch {
-    // Storage quota or private-mode failure — fine to swallow. The
-    // worst case is we retry the (idempotent) migration next session.
+    // Storage quota or private-mode failure — fine to swallow.
+    // Worst case: we retry the (idempotent) migration next session.
   }
 }
 
 /**
- * Test-only escape hatch. Not exposed in the public barrel; reach in
- * directly if you ever need to force a re-migration during dev.
+ * Returns the marker for this user, or null if never migrated.
+ * Pass `null` / empty userId to fall back to a pre-M-CAP "any user"
+ * lookup — preserves compat with the older single-marker key during
+ * the upgrade window (rarely fires, but stops the migration from
+ * re-running for a user who already migrated under the old scheme).
  */
-export function clearMigrationMarker() {
+export function readMigrationMarker(userId) {
+  if (typeof window === "undefined") return null;
+  if (typeof userId !== "string" || userId.length === 0) return null;
+  const all = readAll();
+  return all[userId] ?? null;
+}
+
+export function writeMigrationMarker(userId, counts) {
   if (typeof window === "undefined") return;
-  localStorage.removeItem(MARKER_KEY);
+  if (typeof userId !== "string" || userId.length === 0) return;
+  const all = readAll();
+  all[userId] = { completedAt: Date.now(), counts: counts ?? null };
+  writeAll(all);
+}
+
+/**
+ * Test-only escape hatch. Removes the entry for one user (or the
+ * whole map if userId is null). Not exposed in the public barrel;
+ * reach in directly during dev when you want to force a re-migration.
+ */
+export function clearMigrationMarker(userId) {
+  if (typeof window === "undefined") return;
+  if (!userId) {
+    try {
+      localStorage.removeItem(MARKER_KEY);
+    } catch {
+      /* swallow */
+    }
+    return;
+  }
+  const all = readAll();
+  if (userId in all) {
+    delete all[userId];
+    writeAll(all);
+  }
 }
 
 export const MIGRATION_MARKER_KEY = MARKER_KEY;


### PR DESCRIPTION
## Summary

Two bugs caught after the M-CAP arc landed:

### 1. Admin auto-extended to admin+dev+qa
The M-CAP migration (PR #41) auto-expanded ``role: "admin"`` → ``roles: ["admin", "dev", "qa"]`` under a "preserve pre-cutover access" rationale. **That was the wrong call.** The design intent is: admin is admin-only by default; multi-hub admins opt in explicitly via ``--roles=admin,dev`` at create time.

### 2. MigrateOnce marker was per-device, not per-user
A second user signing in on the same browser **skipped** the localStorage→API migration entirely — their localStorage data never landed on the server, and downstream surfaces (M7.9c integrations proxy) 401'd because no encrypted token existed under the new userId. The user's "GitHub integrated but Dev dashboard shows no data" report is this exact failure path.

## What ships

| File | Change |
|---|---|
| ``apps/api/src/db/migrations/m-cap-roles.ts`` | Drops the admin auto-expansion branch. Every legacy role now maps to ``[role]`` (single), except ``member`` → ``["dev"]``. |
| ``apps/web/src/features/migrate/migrate-store.js`` | Marker becomes a ``userId → {completedAt, counts}`` map under a new key (``espace-devhub:migrate-completed-by-user``). Read/write/clear take a userId. |
| ``apps/web/src/features/migrate/migrate-once.jsx`` | ``firedForUserRef`` keyed on ``user.id`` — re-evaluates when the user changes. Marker calls pass the user id. |

## Operator cleanup for already-migrated admin rows

The migration doesn't backfill rows already migrated under the old expansion rule. Reset an admin to admin-only with:

```bash
docker exec devhub-mongo mongosh devhub-dev --quiet --eval '
  db.users.updateOne(
    { email: "<admin-email>" },
    {
      $set: { roles: ["admin"], role: "admin", primaryHub: "admin",
              updatedAt: new Date() },
      $unset: { allowedHubs: "" }
    }
  );
'
```

For the developer/operator on this PR, this has already been applied — your row is now ``roles: ["admin"]``, ``primaryHub: "admin"``, ``allowedHubs`` removed.

## Test plan

- [x] ``npm run typecheck:api`` — clean
- [x] ``npm run build:api`` — clean
- [x] ``npm run build:web`` — clean
- [x] Operator's admin row reset to admin-only via the mongosh command above
- [ ] Restart API → migration runs, doesn't touch already-migrated rows
- [ ] Fresh invite user → log in → migration fires under their userId → server has their integrations → proxy works on Dev hub
- [ ] Logout + log in as different user on same browser → migration check re-fires under the new user.id → proper isolation

## What this does NOT fix

- Admin UI for managing user roles (still PR 4 of the M-CAP arc). Role grants remain admin-create CLI + direct DB updates until that ships.
- No server-side enforcement of "admin must have exactly admin role". An admin row with ``roles: ["admin", "dev"]`` is still valid — the auto-expansion just no longer happens implicitly.