### PR TITLE
hotfix(api): stop forwarding content-encoding from integration proxy

### DIFF
--- a/apps/api/src/modules/integrations/proxy.ts
+++ b/apps/api/src/modules/integrations/proxy.ts
@@ -18,10 +18,20 @@
  * inflating memory.
  *
  * Header pass-through is allowlist-only. We forward content-type,
- * content-encoding, pagination, and rate-limit signals; we DROP
- * set-cookie / www-authenticate / server / etc. — the upstream's
- * cookies aren't ours to relay, and the client doesn't need its
- * Server fingerprint.
+ * pagination, and rate-limit signals; we DROP set-cookie /
+ * www-authenticate / server / etc. — the upstream's cookies aren't
+ * ours to relay.
+ *
+ * IMPORTANT: We do NOT pass through `content-encoding` or
+ * `content-length`. Node's fetch (undici) automatically decompresses
+ * gzipped/brotli upstream responses before exposing `response.body`
+ * to our code, so the bytes we stream to the client are already
+ * plaintext. Forwarding the original `content-encoding: gzip` header
+ * would tell the browser "decompress me" → browser tries to gunzip
+ * plaintext JSON → fails. content-length is similarly stale because
+ * the decompressed length differs from the on-the-wire compressed
+ * length. Node sets `transfer-encoding: chunked` automatically when
+ * we pipe a stream, which is the correct framing.
  *
  * Methods: GET + POST only, matching the localStorage-era Next.js
  * proxy. PUT/PATCH/DELETE aren't used by any current call site;
@@ -38,11 +48,20 @@ import {
   markIntegrationUsed,
 } from "./controller.js";
 
-/** Headers we forward from upstream → client. Everything else is
- *  dropped (defensive — never echo Set-Cookie, never leak Server). */
+/**
+ * Headers we forward from upstream → client. Everything else is
+ * dropped (defensive — never echo Set-Cookie, never leak Server).
+ *
+ * Deliberately NOT in this list:
+ *   content-encoding / content-length — undici decompresses upstream
+ *     gzipped responses before we see them. The bytes we stream to
+ *     the client are plaintext; passing the original gzip header
+ *     would tell the browser to decompress already-decompressed data
+ *     and fail. Node's response sets transfer-encoding: chunked
+ *     automatically when we pipe a stream.
+ */
 const PASSTHROUGH_RESPONSE_HEADERS = new Set([
   "content-type",
-  "content-encoding",
   "content-language",
   "etag",
   "last-modified",


### PR DESCRIPTION
## Summary
- Dev/QA dashboards showed "Couldn't load rounds/linkage/merged" tile errors even though the server-side integration proxy returned `200 OK` with the full upstream JSON (verified via direct curl).
- Root cause: Node's fetch (undici) auto-decompresses gzipped/brotli upstream responses before exposing `response.body`. The proxy's response-header allowlist still included `content-encoding`, so we forwarded GitHub's original `content-encoding: gzip` header alongside the now-plaintext body. Browser tried to gunzip plaintext JSON → parse failed → SWR error → tiles stuck on failure state.
- Fix: drop `content-encoding` from `PASSTHROUGH_RESPONSE_HEADERS` in `apps/api/src/modules/integrations/proxy.ts`. Node sets `transfer-encoding: chunked` automatically when we pipe a `Readable`, which is the correct framing for the decompressed bytes.

## Why this matters
Without this fix, **every** GitHub / GitLab / Jira call that comes back gzipped (i.e., effectively all of them) is unparseable in the browser. The server logs look healthy (200s, no errors), which is what made this hard to spot.

## Test plan
- [x] `tsc --noEmit` clean on `apps/api`
- [x] Direct curl with `Accept-Encoding: gzip,deflate,br` against `/api/v1/integrations/proxy/github/search/issues` no longer echoes `content-encoding: gzip`
- [ ] After deploy + hard refresh, Dev dashboard tiles populate (Merged, Linkage, Rounds)
- [ ] QA dashboard tiles populate where Jira is connected
- [ ] Pagination still works (verify `Link` header still passes through on multi-page GitHub responses)
- [ ] Rate-limit headers still visible in DevTools (verify `x-ratelimit-*` still passes through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)