### PR TITLE
hotfix(web): break snapshot pull → mirror feedback loop

### DIFF
--- a/apps/web/src/features/snapshots/index.js
+++ b/apps/web/src/features/snapshots/index.js
@@ -1,5 +1,10 @@
 export { useSnapshots, useSnapshotNow } from "./use-snapshots";
-export { readSnapshots, saveSnapshot, clearSnapshots } from "./snapshots-store";
+export {
+  readSnapshots,
+  saveSnapshot,
+  applyPulledSnapshot,
+  clearSnapshots,
+} from "./snapshots-store";
 export { SnapshotsPage } from "./snapshots-page";
 export { useAutoSnapshot } from "./use-auto-snapshot";
 export { captureGoalReadings } from "./capture-readings";

--- a/apps/web/src/features/snapshots/snapshots-store.js
+++ b/apps/web/src/features/snapshots/snapshots-store.js
@@ -130,6 +130,39 @@ export function updateSnapshotNote(week, note) {
   void mirrorPatchSnapshotNote(week, note);
 }
 
+/**
+ * No-mirror save path. Used by the pull-on-session sync (M7.3) so
+ * server-sourced snapshots don't trigger a mirror back to the server —
+ * which would cause a feedback loop:
+ *   pull → saveSnapshot (writes + POSTs back) → server writes again
+ *        → next pull fetches them again → repeat.
+ *
+ * Same conflict-resolution rules as saveSnapshot (manual wins over
+ * auto for the same week). Single difference: skips the mirror call.
+ *
+ * Other mirror-mode stores (goals, grading, goal-specs, goal-context,
+ * goal-inputs) all expose an equivalent no-mirror path. Snapshots
+ * missed it until the loop manifested in a busy session.
+ */
+export function applyPulledSnapshot(snapshot) {
+  const incoming = normaliseSnapshot(snapshot);
+  if (!incoming || !incoming.week) return;
+  const all = readSnapshots();
+  const existing = all.find((s) => s.week === incoming.week);
+  if (
+    existing &&
+    existing.capturedBy === "manual" &&
+    incoming.capturedBy === "auto"
+  ) {
+    return;
+  }
+  const filtered = all.filter((s) => s.week !== incoming.week);
+  const next = [incoming, ...filtered]
+    .sort((a, b) => b.week.localeCompare(a.week))
+    .slice(0, 60);
+  writeAll(next);
+}
+
 export function clearSnapshots() {
   writeAll([]);
 }

--- a/apps/web/src/features/snapshots/snapshots-sync-mount.jsx
+++ b/apps/web/src/features/snapshots/snapshots-sync-mount.jsx
@@ -3,21 +3,28 @@
 /**
  * <SnapshotsSync /> — mounts once at the root layout (inside
  * SessionProvider). Pulls /api/v1/snapshots on session establishment
- * and merges into localStorage via the local saveSnapshot, which
- * applies normaliseSnapshot + the manual-wins rule for each row.
+ * and merges into localStorage via `applyPulledSnapshot` — the
+ * no-mirror path.
+ *
+ * Pre-hotfix this used `saveSnapshot`, which mirrors every write
+ * back via POST /snapshots. With ~17 server-side snapshots that
+ * meant 17 mirror writes on every session pull — observed as a
+ * tight POST /snapshots loop in the API log AND likely starving
+ * the SWR fetchers for /integrations/proxy/* (continuous renders
+ * from each writeAll's dispatchEvent kept the dashboard churning).
  *
  * Same idempotency guard as <GradingSync /> — a ref tracks the last
  * synced user.id so re-renders don't re-fire.
  *
- * The local store caps at 60 snapshots. Pulling 250 from the API into
- * a full local buffer is safe because saveSnapshot sorts by week
- * descending and slices to 60 — older API rows that wouldn't fit get
- * silently dropped.
+ * The local store caps at 60 snapshots. Pulling 250 from the API
+ * into a full local buffer is safe because applyPulledSnapshot
+ * sorts by week descending and slices to 60 — older API rows that
+ * wouldn't fit get silently dropped.
  */
 
 import { useEffect, useRef } from "react";
 import { useSession } from "@/features/auth";
-import { saveSnapshot } from "./snapshots-store";
+import { applyPulledSnapshot } from "./snapshots-store";
 import { pullSnapshotsFromApi } from "./snapshots-sync";
 
 export function SnapshotsSync() {
@@ -28,7 +35,7 @@ export function SnapshotsSync() {
     if (loading || !user) return;
     if (lastSyncedUserId.current === user.id) return;
     lastSyncedUserId.current = user.id;
-    void pullSnapshotsFromApi(saveSnapshot).then((count) => {
+    void pullSnapshotsFromApi(applyPulledSnapshot).then((count) => {
       if (count > 0) {
         // eslint-disable-next-line no-console
         console.info(`[snapshots-sync] merged ${count} snapshots from API`);


### PR DESCRIPTION
## Summary
- `<SnapshotsSync />` was passing `saveSnapshot` (the mirror-mode writer) to `pullSnapshotsFromApi`, so every server-sourced snapshot POSTed itself back. Observed in the API log as 15+ `POST /api/v1/snapshots` calls inside ~500ms on every page load.
- Adds `applyPulledSnapshot()` — the no-mirror variant — to `snapshots-store.js`, matching the convention already used by the goals / grading / goal-specs / goal-context / goal-inputs stores.
- Swaps `<SnapshotsSync />` over to the new path.

## Why this matters
This loop is harmless functionally (server idempotently overwrites the same row) but in practice:
1. Floods the API with redundant writes — observed during the proxy debug session as drowning out actual GitHub/Jira proxy traffic in the log.
2. Each `writeAll()` dispatches a `storage` event → dashboard components re-render mid-loop, which made SWR look like it was thrashing.

After this PR, a session pull is a single GET. Edits in the UI still mirror via `saveSnapshot` as designed.

## Test plan
- [ ] Sign in, open dashboard, watch API log — expect one `GET /snapshots` and zero `POST /snapshots` until the user actually saves one
- [ ] Manually save a snapshot in the UI → verify the POST still fires
- [ ] Sign out, sign in as a different user → snapshots still pull cleanly
- [ ] Conflict rule still holds: manual snapshot on local takes precedence over an auto snapshot pulled from server for the same week

🤖 Generated with [Claude Code](https://claude.com/claude-code)