### PR TITLE
hotfix(web): self-heal github username + settings backfill controls

### DIFF
--- a/apps/web/src/features/integrations/api-clients/github.js
+++ b/apps/web/src/features/integrations/api-clients/github.js
@@ -1,5 +1,51 @@
 import { proxyFetch } from "./proxy-fetch";
-import { readIntegrations } from "../integrations-store";
+import { readIntegrations, saveConnection } from "../integrations-store";
+
+/**
+ * Resolve the connected user's GitHub login.
+ *
+ * Reads from localStorage first (populated by the OAuth callback after a
+ * successful `/user` lookup). When it's missing — which happens for users
+ * who connected before the M-CAP content-encoding hotfix, because that bug
+ * silently broke the callback's profile fetch — we recover by calling
+ * `/user` here and back-filling the local cache so this branch only runs
+ * once per browser.
+ *
+ * The recovery promise is memoised at module scope so the dozen-ish tiles
+ * that hit `myEventsSince` in parallel on a fresh page load share a single
+ * `/user` round-trip instead of dog-piling the proxy. The promise is
+ * cleared on success so a later disconnect+reconnect can re-recover if
+ * needed.
+ */
+let _usernameRecoveryPromise = null;
+async function resolveGithubUsername() {
+  const stored = readIntegrations().github?.username;
+  if (stored) return stored;
+  if (!_usernameRecoveryPromise) {
+    _usernameRecoveryPromise = (async () => {
+      try {
+        const me = await proxyFetch("github", "user");
+        if (!me?.login) {
+          throw new Error(
+            "GitHub /user returned no login — reconnect required.",
+          );
+        }
+        // Persist locally + mirror to the server-side integrations row.
+        saveConnection("github", {
+          username: me.login,
+          displayName: me.name,
+          avatarUrl: me.avatar_url,
+        });
+        return me.login;
+      } finally {
+        // Don't pin a permanent reference — let a future disconnect or
+        // forced re-fetch re-enter this path.
+        _usernameRecoveryPromise = null;
+      }
+    })();
+  }
+  return _usernameRecoveryPromise;
+}
 
 export const githubApi = {
   me: () => proxyFetch("github", "user"),
@@ -33,12 +79,15 @@ export const githubApi = {
    * User's public event stream since isoDate. GitHub caps this at the last
    * ~300 events (90 days max) regardless of `since`, which is fine for the
    * dashboard's 30/90d windows.
+   *
+   * Self-heals the local `github.username` cache via `resolveGithubUsername`
+   * if it's missing — historically a user who connected before the
+   * content-encoding hotfix would have a token but no username, and every
+   * events-driven tile (Activity / Signal / Heatmap / Reviews) would
+   * silently return empty.
    */
-  myEventsSince: (_isoDate) => {
-    const username = readIntegrations().github?.username;
-    if (!username) {
-      throw new Error("GitHub username unknown — reconnect to populate it");
-    }
+  myEventsSince: async (_isoDate) => {
+    const username = await resolveGithubUsername();
     return proxyFetch(
       "github",
       `users/${encodeURIComponent(username)}/events/public?per_page=100`,

--- a/apps/web/src/features/settings/tabs/snapshots-prefs-tab.jsx
+++ b/apps/web/src/features/settings/tabs/snapshots-prefs-tab.jsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Card, Field, Input, Section } from "@/components/ui";
+import { Button, Card, Field, Input, MonoLabel, Section } from "@/components/ui";
+import { clearAutoSnapshots, useBackfill } from "@/features/snapshots";
 
 const EXPLICIT_NOT = [
   [
@@ -24,7 +25,10 @@ const EXPLICIT_NOT = [
 export function SnapshotsPrefsTab() {
   return (
     <>
-      <Section num="01 /" title="Snapshot schedule">
+      <Section num="01 /" title="Cycle history">
+        <BackfillCard />
+      </Section>
+      <Section num="02 /" title="Snapshot schedule">
         <Card className="p-6">
           <div className="grid grid-cols-2 gap-5">
             <Field
@@ -49,7 +53,7 @@ export function SnapshotsPrefsTab() {
           </div>
         </Card>
       </Section>
-      <Section num="02 /" title="What we explicitly do not do">
+      <Section num="03 /" title="What we explicitly do not do">
         <Card className="p-6">
           {EXPLICIT_NOT.map(([title, body]) => (
             <div
@@ -68,5 +72,105 @@ export function SnapshotsPrefsTab() {
         </Card>
       </Section>
     </>
+  );
+}
+
+/**
+ * Manual backfill control. The top-of-page BackfillBanner already
+ * surfaces this when `missingWeeks > 0`, but the banner self-hides
+ * once history is covered (and is easy to dismiss-by-scrolling-past).
+ * Settings is a more discoverable home for re-running the synthesis
+ * on demand, e.g. after a fresh GitHub reconnect that newly populated
+ * the events feed.
+ *
+ * The button is idempotent: with zero missing weeks the click is a
+ * no-op. We disable it explicitly in that state so the user doesn't
+ * wonder whether something fired silently.
+ */
+function BackfillCard() {
+  const { run, isRunning, progress, missingWeeks } = useBackfill();
+  const hasMissing = missingWeeks > 0;
+
+  // Reset path — wipes AUTO snapshots so a previous bad backfill (e.g.
+  // ran while a data source was returning empty) can be re-synthesised
+  // from scratch. Manual snapshots are preserved. The follow-up run()
+  // re-enumerates from a freshly-cleared store so every completed week
+  // re-enters the work queue.
+  const handleResetAndRebackfill = () => {
+    if (isRunning) return;
+    if (
+      !window.confirm(
+        "Delete all auto-captured snapshots and re-synthesise from your current connected data? Manual snapshots will be preserved.",
+      )
+    ) {
+      return;
+    }
+    clearAutoSnapshots();
+    void run();
+  };
+
+  return (
+    <Card className="p-6">
+      <div className="flex items-start justify-between gap-6">
+        <div className="max-w-[560px]">
+          <MonoLabel>
+            {hasMissing
+              ? `${missingWeeks} week${missingWeeks === 1 ? "" : "s"} missing`
+              : "All clear"}
+          </MonoLabel>
+          <div
+            className="mt-2 font-semibold"
+            style={{ fontFamily: "var(--font-display)", fontSize: 17 }}
+          >
+            Synthesise weekly snapshots from connected data
+          </div>
+          <p className="mt-2 text-[13px] leading-[1.55] text-muted-fg">
+            Walks every completed Sun → Thu week of the current year and
+            generates a snapshot for any that don&apos;t already have one,
+            using whatever your providers return for that window. Weeks older
+            than ~90 days are marked <em>partial</em> because the GitHub
+            events feed only reaches that far back — heatmap and reviews-given
+            numbers for those weeks will read as 0, flagged as unavailable
+            rather than zero-effort.
+          </p>
+          <p className="mt-2 text-[12px] leading-[1.5] text-dim-fg">
+            If a previous backfill ran while a provider was unreachable, the
+            saved weeks will be all-zero auto snapshots. Use{" "}
+            <span className="text-fg">Reset &amp; re-backfill</span> to wipe
+            those (manual snapshots are kept) and run again against the
+            current live data.
+          </p>
+          {isRunning && progress ? (
+            <div
+              className="mt-3 inline-flex items-center gap-2 text-[12px]"
+              style={{ fontFamily: "var(--font-mono)" }}
+            >
+              <span className="block h-[6px] w-[6px] animate-pulse rounded-full bg-accent" />
+              Building week {progress.done} of {progress.total}…
+            </div>
+          ) : null}
+        </div>
+        <div className="flex flex-col items-stretch gap-2">
+          <Button
+            onClick={() => run()}
+            disabled={isRunning || !hasMissing}
+            title={
+              !hasMissing
+                ? "Every completed week already has a snapshot — use Reset & re-backfill to redo from scratch."
+                : undefined
+            }
+          >
+            {isRunning ? "Running…" : "Backfill now"}
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={handleResetAndRebackfill}
+            disabled={isRunning}
+          >
+            Reset &amp; re-backfill
+          </Button>
+        </div>
+      </div>
+    </Card>
   );
 }

--- a/apps/web/src/features/snapshots/index.js
+++ b/apps/web/src/features/snapshots/index.js
@@ -4,6 +4,7 @@ export {
   saveSnapshot,
   applyPulledSnapshot,
   clearSnapshots,
+  clearAutoSnapshots,
 } from "./snapshots-store";
 export { SnapshotsPage } from "./snapshots-page";
 export { useAutoSnapshot } from "./use-auto-snapshot";

--- a/apps/web/src/features/snapshots/snapshots-store.js
+++ b/apps/web/src/features/snapshots/snapshots-store.js
@@ -167,4 +167,24 @@ export function clearSnapshots() {
   writeAll([]);
 }
 
+/**
+ * Remove only AUTO-captured snapshots, preserving any MANUAL ones the
+ * user wrote by hand. Used by the Settings "Reset auto & re-backfill"
+ * flow when a previous backfill ran against broken data sources (e.g.
+ * pre-hotfix when the events feed was empty because GitHub username
+ * wasn't populated in localStorage) and the user wants to re-synthesise
+ * from scratch.
+ *
+ * Server side: stale auto rows on the server for weeks the next
+ * backfill DOES cover will be replaced by saveSnapshot's mirror. Weeks
+ * outside the next backfill's range stay stale on the server — that's
+ * acceptable because the supported path is "reset, then run backfill",
+ * not "reset as a standalone op".
+ */
+export function clearAutoSnapshots() {
+  const all = readSnapshots();
+  const next = all.filter((s) => s.capturedBy !== "auto");
+  writeAll(next);
+}
+
 export const SNAPSHOTS_CHANGE_EVENT = CHANGE_EVENT;


### PR DESCRIPTION
## Summary
Two follow-ups to the content-encoding hotfix (#45) that unblock the events-driven dashboard tiles and let users re-do a botched backfill from Settings.

### 1) Self-heal `github.username` in localStorage
The GitHub OAuth callback populates the local `username` field by calling `proxyFetch("github","user")` after the token save. Pre-#45 that call **failed silently** due to the gzip-header bug — the callback's `try/catch` swallows profile failures so OAuth still completes with just the token. Users connected pre-fix end up with a working token but **no `username` in localStorage**.

`githubApi.myEventsSince` reads `username` from localStorage and threw when missing, so every events-driven tile (Activity / Signal / Heatmap / Reviews / SinceLastVisit) silently rendered empty. SWR's `shouldRetryOnError: false` meant the error stuck for the whole session.

Now `myEventsSince` awaits `resolveGithubUsername()` which:
- Returns the stored value if present (hot path, no extra round-trip)
- Else calls `/user`, persists `{username, displayName, avatarUrl}` via `saveConnection` (so it mirrors to the server-side row too), returns the login
- Memoises the in-flight promise at module scope so parallel tiles share a single `/user` fetch instead of dog-piling the proxy

### 2) Settings-side backfill controls
The existing `<BackfillBanner />` only surfaces when `missingWeeks > 0`. If a previous backfill ran against broken data sources (e.g. the events feed was empty pre-fix), it produced **all-zero auto snapshots** — the banner then self-hides because "every week has a row", and there was no way to redo from the UI.

Adds two controls to **Settings → Snapshots → Cycle history**:
- **Backfill now** — same as the banner; idempotent, disabled at 0 missing weeks
- **Reset & re-backfill** — clears AUTO snapshots (preserving MANUAL ones, which the user wrote by hand) then runs synthesis from scratch. Confirms via `window.confirm`. The follow-up `run()` re-enumerates from a freshly-cleared store so every completed week re-enters the work queue.

New `clearAutoSnapshots()` in `snapshots-store` wipes only `capturedBy === "auto"` rows locally. Server-side stale auto rows are overwritten as the next backfill saves each week via the existing `saveSnapshot` mirror — no new endpoint needed.

## Files
- `apps/web/src/features/integrations/api-clients/github.js`
- `apps/web/src/features/snapshots/snapshots-store.js`
- `apps/web/src/features/snapshots/index.js`
- `apps/web/src/features/settings/tabs/snapshots-prefs-tab.jsx`

## Test plan
- [ ] Hard refresh the dashboard; Activity tile + Signal card populate from real events (self-heal fires once silently)
- [ ] Verify only one `GET /api/v1/integrations/proxy/github/user` call fires per session in the network tab (memoisation working)
- [ ] Open Settings → Snapshots; the new "Cycle history" section renders with the two buttons
- [ ] Click **Reset & re-backfill** with all-zero auto snapshots in the store; confirm prompt appears
- [ ] After accepting, see progress indicator and toast; rows in `/snapshots` page repopulate with real merged/reviews/turnaround/linkage/rounds for the last ~90 days
- [ ] Weeks older than ~90 days remain `partial: true` with `gaps: ["events"]` — heatmap/reviews show as 0, flagged as unavailable rather than zero-effort (existing behaviour, documented in `use-backfill.js`)
- [ ] Any pre-existing MANUAL snapshot is **preserved** by Reset & re-backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)