### PR TITLE
hotfix(web): bucket events by local-time date, not UTC

### DIFF
--- a/apps/web/src/components/ui/contribution-heatmap.jsx
+++ b/apps/web/src/components/ui/contribution-heatmap.jsx
@@ -39,15 +39,23 @@ export function ContributionHeatmap({
   cellGap = 3,
   className = "",
 }) {
-  // Build "yyyy-mm-dd" → count map. Slice on the ISO string keeps us in
-  // the user's local-equivalent UTC day; good enough for daily buckets.
+  // Build "yyyy-mm-dd" → count map keyed in the user's LOCAL time.
+  //
+  // We can't use `ts.slice(0, 10)` here: that's the UTC date. The grid
+  // cells below are generated from `isoDay(day)` where `day` is a Date
+  // with local components, so a UTC-keyed lookup will miss any event
+  // that sits in a different calendar day across the local-vs-UTC
+  // offset (e.g. an event at 23:30Z on May 10 belongs in the May 11
+  // cell for a Cairo user, but `slice(0,10)` returns "2026-05-10").
   const byDay = useMemo(() => {
     const map = new Map();
     for (const e of events || []) {
-      const ts = e?.created_at || "";
-      if (typeof ts !== "string" || ts.length < 10) continue;
-      const day = ts.slice(0, 10);
-      map.set(day, (map.get(day) || 0) + 1);
+      const ts = e?.created_at;
+      if (!ts) continue;
+      const d = new Date(ts);
+      if (Number.isNaN(d.getTime())) continue;
+      const key = isoDay(d);
+      map.set(key, (map.get(key) || 0) + 1);
     }
     return map;
   }, [events]);

--- a/apps/web/src/features/dashboard/tiles/heatmap-tile.jsx
+++ b/apps/web/src/features/dashboard/tiles/heatmap-tile.jsx
@@ -53,13 +53,21 @@ export function HeatmapTile() {
 /**
  * Peak events on any single day in the window. Used in the tile label
  * so the user has a sense of scale without needing to read every cell.
+ *
+ * Uses LOCAL-time date keys (not `created_at.slice(0,10)`, which is UTC)
+ * so the count matches the user's notion of "a day" — and matches the
+ * line-chart Activity tile, which buckets in local time too. With a UTC
+ * key, events from the early-morning UTC hours straddle the wrong
+ * calendar day for any user east of UTC and the peak undercounts.
  */
 function computePeak(events) {
   const byDay = new Map();
   for (const e of events) {
-    const day = (e?.created_at || "").slice(0, 10);
-    if (!day) continue;
-    byDay.set(day, (byDay.get(day) || 0) + 1);
+    if (!e?.created_at) continue;
+    const d = new Date(e.created_at);
+    if (Number.isNaN(d.getTime())) continue;
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    byDay.set(key, (byDay.get(key) || 0) + 1);
   }
   let max = 0;
   for (const v of byDay.values()) if (v > max) max = v;

--- a/apps/web/src/features/integrations/metrics/activity.js
+++ b/apps/web/src/features/integrations/metrics/activity.js
@@ -1,7 +1,36 @@
 import { DAY_MS } from "@/lib/date";
 
 /**
- * Bucketize raw GitLab events into one count per day, oldest → newest.
+ * YYYY-MM-DD in **local** time.
+ *
+ * Why this exists: the obvious shortcut `date.toISOString().slice(0, 10)`
+ * formats in UTC, not the user's local zone. Mixing that with bucket
+ * boundaries anchored at local midnight (via `setHours(0, 0, 0, 0)`)
+ * produces a one-day mismatch for every user east of UTC.
+ *
+ * Concretely (Cairo, UTC+2):
+ *   - local midnight today = 2026-05-11 00:00 local = 2026-05-10 22:00Z
+ *   - `today.toISOString().slice(0,10)` = "2026-05-10"  ← yesterday UTC!
+ *   - an event at 17:37Z today has slice = "2026-05-11"
+ *   - the buckets {…, "2026-05-09", "2026-05-10"} never contain
+ *     "2026-05-11", so today's events fall outside every bucket
+ *     and `totalEvents` returns 0
+ *
+ * Using local-time components from `getFullYear/getMonth/getDate` for
+ * BOTH the bucket key AND the event-lookup key keeps everything in the
+ * same reference frame.
+ */
+function localDateKey(input) {
+  const d = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(d.getTime())) return "";
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Bucketize raw events into one count per local-time day, oldest → newest.
  */
 export function dailyActivity(events = [], days = 14) {
   const today = new Date();
@@ -10,15 +39,16 @@ export function dailyActivity(events = [], days = 14) {
   for (let i = days - 1; i >= 0; i--) {
     const d = new Date(today.getTime() - i * DAY_MS);
     buckets.push({
-      date: d.toISOString().slice(0, 10),
+      date: localDateKey(d),
       label: d.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
       n: 0,
     });
   }
   const byDate = Object.fromEntries(buckets.map((b) => [b.date, b]));
   for (const ev of events) {
-    const d = (ev.created_at || "").slice(0, 10);
-    if (byDate[d]) byDate[d].n += 1;
+    if (!ev?.created_at) continue;
+    const key = localDateKey(ev.created_at);
+    if (byDate[key]) byDate[key].n += 1;
   }
   return buckets;
 }


### PR DESCRIPTION
## Summary
The Activity tile and Signal-14D hero card were rendering "0 events / —" for Cairo (UTC+2) users despite the GitHub events feed returning 100 events for today. The Reviews tile (same data source) correctly showed 67 reviews because it filters by ms timestamps via `splitByRange`.

Root cause: `dailyActivity()` built bucket date keys via `today.toISOString().slice(0,10)` *after* anchoring `today` at local midnight via `setHours(0,0,0,0)`. For any user east of UTC, `today.toISOString()` then formats yesterday's UTC date. Events keyed by `created_at.slice(0,10)` (UTC) never match the newest bucket, so the whole chart goes empty for today.

Confirmed on the wire:

```
$ curl /api/v1/integrations/proxy/github/users/nova-sudo/events/public?per_page=100
count: 100
newest: 2026-05-11T17:37:27Z
oldest: 2026-05-11T13:26:50Z
events per day: { "2026-05-11": 100 }
```

vs. dashboard's newest bucket key for the same user: `"2026-05-10"`.

## Fix
Three call sites now key by **local** time on both sides — the bucket keys and the event lookups use Date components (`getFullYear`/`getMonth`/`getDate`) instead of UTC ISO slicing:

- `apps/web/src/features/integrations/metrics/activity.js` — new `localDateKey()` helper, both bucket and event lookup go through it. Powers the Activity tile and the Signal-14D hero card.
- `apps/web/src/features/dashboard/tiles/heatmap-tile.jsx` — `computePeak()` keyed locally so its "peak N/day" label matches the data.
- `apps/web/src/components/ui/contribution-heatmap.jsx` — the `byDay` lookup map keyed locally so cells near local-midnight events render under the correct day.

## Why it was masked
The heatmap's "100 EVENTS · PEAK 100/DAY" label rendered correctly today because every event happened to be on the same UTC date as the user's local date (afternoon UTC = afternoon Cairo, same calendar day). The latent bug there would have surfaced for events at 22:00Z–02:00Z (late local evening).

## Test plan
- [ ] Hard refresh the dashboard; Activity tile populates with today's 100 events bucketed on the rightmost bar
- [ ] Signal-14D hero card shows a digit, not "—"
- [ ] Heatmap "peak N/day" label still reads 100 (no regression)
- [ ] Manually run in console with a contrived event at `2026-05-11T22:30:00Z` while local time is May 12 — cell renders in the May 12 column (the bug case the latent heatmap fix addresses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)