### PR TITLE
feat(web): synthesise activity events from author:@me PR history

### DIFF
--- a/apps/web/src/features/integrations/api-clients/github.js
+++ b/apps/web/src/features/integrations/api-clients/github.js
@@ -148,6 +148,37 @@ export const githubApi = {
   },
 
   /**
+   * Every PR the current user authored since isoDate, regardless of state
+   * (open, closed-unmerged, merged) and including drafts. Used to
+   * synthesise "PR opened" / "PR merged" event-shaped records that
+   * supplement the events feed for older periods — the user-events
+   * endpoint hard-caps at 300 events / 90 days and gets fully consumed
+   * by recent heavy days, so April/March activity drops off entirely.
+   * The search-issues endpoint, by contrast, has no such cap.
+   *
+   * Unlike `myPrsSince` which runs two queries (is:open / is:merged) to
+   * dodge GitHub's flaky draft flag, this method takes the union with a
+   * single query because activity-feed callers want EVERY PR — drafts
+   * included, since a draft still represents real work that day. Closed-
+   * unmerged PRs are also useful: they show "tried something, abandoned"
+   * markers on the heatmap.
+   *
+   * Single-page (per_page=100, no pagination) — sufficient for the YTD
+   * cadence of all current users. If anyone exceeds 100 PRs/year we'll
+   * paginate; the search-issues endpoint supports it without the 422 cap
+   * that bites the events feed.
+   */
+  myAuthoredPrsSince: async (isoDate) => {
+    const day = (isoDate || "").slice(0, 10);
+    const q = `is:pr author:@me created:>=${day}`;
+    const res = await proxyFetch(
+      "github",
+      `search/issues?q=${encodeURIComponent(q)}&per_page=100`,
+    );
+    return Array.isArray(res?.items) ? res.items : [];
+  },
+
+  /**
    * PRs authored by the user since isoDate, INCLUDING both open and merged
    * (but NOT drafts). Used by the CODE_RUBRIC widget to collect the full
    * "year-to-date" set for grading.

--- a/apps/web/src/features/integrations/hooks/index.js
+++ b/apps/web/src/features/integrations/hooks/index.js
@@ -15,6 +15,7 @@ export {
 } from "./use-github-pulls";
 export { useGithubMergedSince } from "./use-github-merged";
 export { useGithubEventsSince } from "./use-github-events";
+export { useGithubPrEventsSince } from "./use-github-pr-events";
 export {
   useCombinedMergedSince,
   useCombinedEventsSince,

--- a/apps/web/src/features/integrations/hooks/use-combined.js
+++ b/apps/web/src/features/integrations/hooks/use-combined.js
@@ -5,6 +5,7 @@ import { useGitlabMergedSince } from "./use-gitlab-merged";
 import { useGitlabEventsSince } from "./use-gitlab-events";
 import { useGithubMergedSince } from "./use-github-merged";
 import { useGithubEventsSince } from "./use-github-events";
+import { useGithubPrEventsSince } from "./use-github-pr-events";
 import {
   buildDemoEvents,
   buildDemoPrs,
@@ -58,6 +59,12 @@ export function useCombinedEventsSince(since) {
   const demo = useDemoMode();
   const gl = useGitlabEventsSince(since);
   const gh = useGithubEventsSince(since);
+  // GitHub's /users/:u/events/public hard-caps at 300 events / 90 days
+  // and gets fully consumed by recent heavy days. To recover older
+  // months we synthesise "opened" / "merged" event-shaped records from
+  // the user's PR list (search-issues, no cap). See
+  // `use-github-pr-events.js` for the contract + dedup discussion.
+  const ghPr = useGithubPrEventsSince(since);
   const demoEvents = useMemo(() => (demo ? buildDemoEvents() : null), [demo]);
 
   if (demo) {
@@ -65,16 +72,22 @@ export function useCombinedEventsSince(since) {
       data: demoEvents,
       isLoading: false,
       error: null,
-      sources: { gitlab: gl, github: gh, demo: true },
+      sources: { gitlab: gl, github: gh, githubPrSynth: ghPr, demo: true },
     };
   }
 
   const data =
-    gl.data || gh.data ? [...(gl.data || []), ...(gh.data || [])] : undefined;
+    gl.data || gh.data || ghPr.data
+      ? [
+          ...(gl.data || []),
+          ...(gh.data || []),
+          ...(ghPr.data || []),
+        ]
+      : undefined;
   return {
     data,
-    isLoading: gl.isLoading || gh.isLoading,
-    error: gl.error || gh.error || null,
-    sources: { gitlab: gl, github: gh },
+    isLoading: gl.isLoading || gh.isLoading || ghPr.isLoading,
+    error: gl.error || gh.error || ghPr.error || null,
+    sources: { gitlab: gl, github: gh, githubPrSynth: ghPr },
   };
 }

--- a/apps/web/src/features/integrations/hooks/use-github-pr-events.js
+++ b/apps/web/src/features/integrations/hooks/use-github-pr-events.js
@@ -1,0 +1,108 @@
+"use client";
+
+import { githubApi } from "../api-clients";
+import { useIntegrations } from "../use-integrations";
+import { useSwrIf } from "./use-swr-if";
+import { isoDaysAgo } from "@/lib/date";
+
+/**
+ * Synthesise event-shaped records from the user's PR list.
+ *
+ * Why this hook exists: `useGithubEventsSince` reads from `/users/:u/
+ * events/public`, which GitHub caps at 300 events / ~90 days. For users
+ * with heavy daily activity the cap is consumed by recent days, and
+ * older months disappear from the events feed entirely (verified on
+ * the wire: 299 events all from today for the test account).
+ *
+ * The search-issues endpoint has no such cap. For each PR the user
+ * authored we know:
+ *   - created_at  → "PR opened" event
+ *   - merged_at   → "PR merged" event (if merged)
+ *
+ * Both get normalised to the same shape every metric / tile already
+ * consumes:
+ *   {
+ *     created_at:   ISO,
+ *     action_name:  "opened" | "merged",
+ *     target_type:  "MergeRequest",
+ *     target_title: PR title,
+ *     repo_name:    "owner/repo",
+ *     source:       "github-pr-synth",
+ *   }
+ *
+ * What this CAN'T recover: comment timestamps. The search-issues
+ * response only carries a comment COUNT — not the individual
+ * timestamps. So Reviews-given for older periods stays limited to
+ * whatever lives in the user-events window.
+ *
+ * Overlap with the real events feed (today's PRs appear in both):
+ * intentionally NOT deduped here. The action_name strings differ
+ * ("opened" / "merged" here vs. "pushed to" from `normalizeGithubEvents`),
+ * so review-comment-targeting metrics (`groupReviewTargets` in the
+ * Reviews tile) ignore these synthetic records. Daily-activity tiles
+ * will slightly overcount today by the day's PR open/merge count, but
+ * that's a small fraction of the events stream — far smaller than the
+ * "Apr-Mar shows zero" regression we're fixing.
+ */
+export function useGithubPrEventsSince(since) {
+  const { isConnected } = useIntegrations();
+  const iso =
+    since instanceof Date
+      ? since.toISOString()
+      : typeof since === "number"
+        ? isoDaysAgo(since)
+        : since;
+  const swr = useSwrIf(
+    isConnected("github"),
+    `github:pr-events:${iso}`,
+    () => githubApi.myAuthoredPrsSince(iso),
+  );
+  const synthesised = swr.data ? synthesisePrEvents(swr.data) : swr.data;
+  // Apply the same client-side cutoff as the real events hook, in
+  // case GitHub returned a PR whose created_at predates the caller's
+  // window (search-issues filters by `created:>=DAY` which is
+  // day-granular, so a PR created earlier in the boundary day could
+  // slip through).
+  const cutoff = typeof iso === "string" ? new Date(iso).getTime() : null;
+  const data =
+    synthesised && cutoff
+      ? synthesised.filter(
+          (e) => new Date(e.created_at).getTime() >= cutoff,
+        )
+      : synthesised;
+  return { ...swr, data };
+}
+
+function synthesisePrEvents(prs) {
+  if (!Array.isArray(prs)) return [];
+  const out = [];
+  for (const it of prs) {
+    const repoName =
+      typeof it.repository_url === "string"
+        ? it.repository_url.split("/").slice(-2).join("/")
+        : null;
+    const title = it.title || `#${it.number}`;
+    if (it.created_at) {
+      out.push({
+        created_at: it.created_at,
+        action_name: "opened",
+        target_type: "MergeRequest",
+        target_title: title,
+        repo_name: repoName,
+        source: "github-pr-synth",
+      });
+    }
+    const mergedAt = it.pull_request?.merged_at;
+    if (mergedAt) {
+      out.push({
+        created_at: mergedAt,
+        action_name: "merged",
+        target_type: "MergeRequest",
+        target_title: title,
+        repo_name: repoName,
+        source: "github-pr-synth",
+      });
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
Recovers Jan–Apr coverage for the events-driven dashboard tiles (Activity / Signal-14D / Heatmap / Reviews-given / Backfill) when GitHub's `/users/:u/events/public` has rolled past older months because of recent heavy activity.

## Why
GitHub's user-events endpoint hard-caps at 300 events / ~90 days. For heavy-activity days the entire 300-event window gets consumed by today, and older months silently vanish from the events feed — confirmed on the wire:

```
$ for p in 1 2 3 4; do curl .../events/public?per_page=100&page=$p; done
page 1 (100): all 2026-05-11
page 2 ( 99): all 2026-05-11
page 3 (100): all 2026-05-11
page 4: HTTP 422 "pagination is limited for this resource"
```

PR-derived tiles (Merged / Turnaround / Linkage / Rounds) already use `/search/issues`, which has no such cap, so they correctly showed YTD numbers. This PR extends the events stream with PR-derived synthetic records so the activity tiles match.

## What changed
**`githubApi.myAuthoredPrsSince(iso)`** — single search-issues call: `is:pr author:@me created:>=DAY`. Returns the raw items.

**`useGithubPrEventsSince(since)`** — new hook. For each PR emits two event-shaped records:
- `{ action_name: "opened",  target_type: "MergeRequest", created_at: pr.created_at, ... }`
- `{ action_name: "merged",  target_type: "MergeRequest", created_at: pr.pull_request.merged_at, ... }` (if merged)

Source tag: `"github-pr-synth"`.

**`useCombinedEventsSince`** — now flattens `gl.data + gh.data + ghPr.data` into the events array. All existing metrics consume the same normalised shape, so nothing downstream changes.

## Verified on the wire
Test account, `is:pr author:@me created:>=2026-01-01`:

```
54 PRs YTD → 96 synthetic events
events per local month: { '2026-05': 59, '2026-04': 30, '2026-03': 7 }
```

After this PR, those April / March bars / heatmap cells finally appear instead of reading 0.

## Tradeoffs (called out)
- **Today is slightly overcounted**: today's PR open/merge actions appear in BOTH streams (real `PullRequestEvent` + synthetic). The `action_name` strings differ (`"pushed to"` from `normalizeGithubEvents` vs. `"opened"/"merged"` here), so review-targeting metrics (`groupReviewTargets`) are unaffected — they ignore both names. Pure-count tiles (Activity line chart, heatmap intensity) gain a small bump on today only.
- **Comment timestamps NOT recovered**: search-issues only carries a comment COUNT, not per-comment timestamps. Reviews-given for older months remains limited to whatever the user-events window contains. Full fix would require a per-PR `/issues/:n/comments` fetch (300+ calls/year for a busy user) — out of scope.

## Files
- `apps/web/src/features/integrations/api-clients/github.js`
- `apps/web/src/features/integrations/hooks/use-github-pr-events.js` (new)
- `apps/web/src/features/integrations/hooks/use-combined.js`
- `apps/web/src/features/integrations/hooks/index.js`

## Test plan
- [ ] Hard refresh dashboard with preset = **YTD** or **Year**
- [ ] Activity line chart shows non-zero bars across Jan/Feb/Mar/Apr (PR open/merge spikes)
- [ ] Heatmap year view has shaded cells in March and April, not just May
- [ ] Network tab: one extra fetch — `GET /api/v1/integrations/proxy/github/search/issues?q=is%3Apr%20author%3A%40me%20created%3A%3E%3D...`
- [ ] No double-counting of today's reviews-given (action_name filter excludes synthetic)
- [ ] Backfill (Settings → Snapshots → Reset & re-backfill) now produces non-zero `merged` and a count > 0 for April/March weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)