### PR TITLE
hotfix(web): drop premature short-circuit in events pagination

### DIFF
--- a/apps/web/src/features/integrations/api-clients/github.js
+++ b/apps/web/src/features/integrations/api-clients/github.js
@@ -131,9 +131,17 @@ export const githubApi = {
       }
       if (!Array.isArray(batch) || batch.length === 0) break;
       all.push(...batch);
-      // Page wasn't filled → we already have every event GitHub will
-      // return; further requests just yield empty arrays.
-      if (batch.length < PER_PAGE) break;
+      // NOTE: we do NOT short-circuit on `batch.length < PER_PAGE`.
+      // GitHub's `/users/:u/events/public` regularly returns 99
+      // (or fewer) events on a page that still has a `Link:
+      // rel="next"` — events from private repos that have since
+      // been flipped public, or vice-versa, leave gaps that the
+      // count doesn't reveal. The authoritative end-of-stream
+      // signal is the 422 caught above OR an empty array. The
+      // older heuristic dropped page 3 entirely on busy accounts
+      // (verified on the wire: page 2 = 99, but page 3 had a
+      // full 100 events of older data).
+      //
       // Oldest event on this page is already past the caller's window
       // → no need to walk further into history.
       if (cutoffMs > 0) {


### PR DESCRIPTION
## Summary
With synthetic PR events merged (#50), the YTD heatmap label should read ~406 events with peak ~359/day. Instead the dashboard read **305 events with peak 258** — exactly one page missing — and the May 11 cell rendered in `palette[1]` (lightest) instead of `palette[4]` (darkest) because the maxDay threshold scale collapsed.

## Root cause
The pagination loop in #49 short-circuited on `batch.length < PER_PAGE`, assuming a sub-100 page meant the end of the stream. **GitHub's `/users/:u/events/public` regularly returns 99 events on a page that still has a populated `Link: rel="next"`** — private/deleted events leave gaps that the result count doesn't reveal.

Confirmed on the wire:

```
page 1: 100 events
page 2:  99 events      ← old heuristic stopped here
page 3: 100 events of older data (silently dropped)
page 4: HTTP 422 (real end-of-stream)
```

## Fix
Remove the `batch.length < PER_PAGE` check. The loop now relies only on the authoritative stop signals:
- 422 catch (cap exhausted)
- empty-array break (no more results)
- oldest-event-before-cutoff (caller's window covered)
- `MAX_PAGES = 3` (GitHub's documented hard cap)

The "page wasn't filled" heuristic was a false optimisation that introduced a real correctness gap.

## Test plan
- [ ] Hard refresh dashboard with preset = **YTD** or **Year**
- [ ] Heatmap label increases from "305 events / peak 258/day" → "~406 / ~359"
- [ ] May 11 cell renders dark (palette[4] indigo) — same intensity as the Week preset's Mon cell
- [ ] Network tab: 3 sequential `?page=1/2/3` requests when a tile mounts (only stops early if cutoff is hit or 422)
- [ ] Light-day user (page 1 returns 0 or hits cutoff early): pagination still short-circuits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)