### PR TITLE
feat(web): password-reset pages (forgot-password + reset redemption)

### DIFF
--- a/apps/web/src/app/forgot-password/page.jsx
+++ b/apps/web/src/app/forgot-password/page.jsx
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * /forgot-password — entry point for the password-reset flow.
+ *
+ * Sibling of /login and /accept-invite. No AppShell, no hub theme,
+ * no AuthGuard — the entire purpose is to be reachable WITHOUT a
+ * session. Wrapping it in AuthGuard would bounce a locked-out user
+ * back to /login, defeating the point.
+ *
+ * The form does its own POST + success-state handling; this page is
+ * just the surrounding chrome.
+ */
+
+import { PasswordResetRequestForm } from "@/features/auth";
+
+export const dynamic = "force-dynamic";
+
+export default function ForgotPasswordPage() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "var(--bg)",
+        color: "var(--fg)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <PasswordResetRequestForm />
+    </main>
+  );
+}

--- a/apps/web/src/app/password-reset/page.jsx
+++ b/apps/web/src/app/password-reset/page.jsx
@@ -1,0 +1,39 @@
+"use client";
+
+/**
+ * /password-reset?token=… — landing page for the reset email link.
+ *
+ * Mirror of /accept-invite's structure (top-level route, no AppShell,
+ * no AuthGuard wrap — the user redeeming a reset link is by
+ * definition signed out). The form reads the token from the query
+ * string, captures the new password, and on success redirects to
+ * /login where the user can sign in fresh.
+ *
+ * Suspense boundary because useSearchParams() forces a client-side
+ * render bailout — Next.js refuses to silently prerender that, so
+ * without the boundary `next build` errors on this route. Same
+ * pattern as /accept-invite and /login.
+ */
+
+import { Suspense } from "react";
+import { PasswordResetForm } from "@/features/auth";
+
+export const dynamic = "force-dynamic";
+
+export default function PasswordResetPage() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "var(--bg)",
+        color: "var(--fg)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Suspense fallback={null}>
+        <PasswordResetForm />
+      </Suspense>
+    </main>
+  );
+}

--- a/apps/web/src/features/auth/index.js
+++ b/apps/web/src/features/auth/index.js
@@ -1,13 +1,15 @@
 /**
  * Barrel for the auth feature. Public API:
  *
- *   useSession()         — reactive session state + login/logout/refresh
- *   <SessionProvider>    — mount once at the root layout
- *   <LoginForm>          — used by /login page (and reusable elsewhere)
- *   <AcceptInviteForm>   — used by /accept-invite page
- *   <AuthGuard>          — wraps protected page contents
- *   <UserChip>           — header chip showing the session user + logout
- *   <RequireCapability>  — gate child elements on a capability check
+ *   useSession()                 — reactive session state + login/logout/refresh
+ *   <SessionProvider>            — mount once at the root layout
+ *   <LoginForm>                  — used by /login page (and reusable elsewhere)
+ *   <AcceptInviteForm>           — used by /accept-invite page
+ *   <PasswordResetRequestForm>   — used by /forgot-password page
+ *   <PasswordResetForm>          — used by /password-reset?token=… page
+ *   <AuthGuard>                  — wraps protected page contents
+ *   <UserChip>                   — header chip showing the session user + logout
+ *   <RequireCapability>          — gate child elements on a capability check
  *   hasCapability/hasAllCapabilities — non-React reader helpers
  */
 
@@ -15,6 +17,8 @@ export { useSession } from "./use-session.js";
 export { SessionProvider } from "./session-provider.jsx";
 export { LoginForm } from "./login-form.jsx";
 export { AcceptInviteForm } from "./accept-invite-form.jsx";
+export { PasswordResetRequestForm } from "./password-reset-request-form.jsx";
+export { PasswordResetForm } from "./password-reset-form.jsx";
 export { AuthGuard } from "./auth-guard.jsx";
 export { UserChip } from "./user-chip.jsx";
 export {

--- a/apps/web/src/features/auth/login-form.jsx
+++ b/apps/web/src/features/auth/login-form.jsx
@@ -19,6 +19,7 @@
  */
 
 import { useState } from "react";
+import Link from "next/link";
 import { useSession } from "./use-session.js";
 
 export function LoginForm({ onSuccess }) {
@@ -245,6 +246,28 @@ export function LoginForm({ onSuccess }) {
           >
             {submitting ? "Signing in…" : "Continue"}
           </button>
+
+          {/* Forgot-password link — only on the password step, not the
+              TOTP step (a user on step 2 already authenticated and is
+              just stuck on the 6-digit code; the right recovery there
+              is backup codes, not password reset). */}
+          <div
+            className="mt-1"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              color: "var(--muted-fg)",
+              textAlign: "center",
+            }}
+          >
+            <Link
+              href="/forgot-password"
+              className="text-accent hover:underline"
+              style={{ fontWeight: 600 }}
+            >
+              Forgot password?
+            </Link>
+          </div>
         </form>
       )}
     </div>

--- a/apps/web/src/features/auth/password-reset-form.jsx
+++ b/apps/web/src/features/auth/password-reset-form.jsx
@@ -1,0 +1,307 @@
+"use client";
+
+/**
+ * Password-reset *redemption* form. Mounted at /password-reset?token=…
+ *
+ * Reads the single-use token from the URL, captures a new password +
+ * confirmation, POSTs to /api/v1/auth/password/reset. The server:
+ *   1. Redeems the token (one-shot — same token can't be reused).
+ *   2. argon2id-hashes the new password.
+ *   3. Force-logs out every existing session for this user (so a
+ *      compromised session can't ride the change).
+ *   4. Deletes any other pending reset/invite tokens for this user.
+ *
+ * Notably: the server does NOT mint a new session on reset. The
+ * legitimate user lands at /login after the success state, types
+ * their new password, and gets routed into the app normally — same
+ * flow they'd hit if they'd remembered the old password.
+ *
+ * Mirrors the AcceptInviteForm shape (password + confirm, MIN_LENGTH
+ * guard, humanised errors) so users who hit either flow see a
+ * consistent surface.
+ *
+ * Errors surfaced from the API:
+ *   invalid_token   → "Reset link is invalid or expired."
+ *   validation_*    → field-level message
+ *   rate_limited    → "Too many attempts on this network…"
+ *   network_error   → generic "couldn't reach the server"
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { apiPost } from "@/lib/api-client";
+
+const MIN_PASSWORD_LENGTH = 12;
+
+export function PasswordResetForm() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const token = params.get("token") || "";
+
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState(null);
+
+  if (!token) {
+    return (
+      <ErrorPanel
+        title="Missing reset token."
+        body="Your reset link is incomplete. Open it again from the email you received, or request a new link."
+      />
+    );
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(
+        `Password needs at least ${MIN_PASSWORD_LENGTH} characters. Pick something long.`,
+      );
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords don't match.");
+      return;
+    }
+
+    setSubmitting(true);
+    const r = await apiPost("/auth/password/reset", { token, password });
+    setSubmitting(false);
+    if (!r.ok) {
+      setError(humanise(r.error));
+      return;
+    }
+    setDone(true);
+    // Give the user a beat to read the success copy, then redirect
+    // to /login. They'll sign in with the password they just set.
+    setTimeout(() => router.replace("/login"), 1800);
+  }
+
+  if (done) {
+    return <SuccessPanel />;
+  }
+
+  return (
+    <div className="mx-auto flex max-w-sm flex-col gap-5 py-12">
+      <div>
+        <h1
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display, var(--font-inter-tight))",
+            fontSize: 28,
+            letterSpacing: "-0.8px",
+          }}
+        >
+          Set a new password
+        </h1>
+        <p
+          className="mt-1 text-muted-fg"
+          style={{ fontSize: 13.5, lineHeight: 1.5 }}
+        >
+          Pick something long. You&apos;ll be signed in fresh after
+          you set it.
+        </p>
+      </div>
+
+      <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
+        <PasswordField
+          label="New password"
+          value={password}
+          onChange={setPassword}
+          autoFocus
+          autoComplete="new-password"
+          disabled={submitting}
+        />
+        <PasswordField
+          label="Confirm new password"
+          value={confirm}
+          onChange={setConfirm}
+          autoComplete="new-password"
+          disabled={submitting}
+        />
+        <p
+          className="text-muted-fg"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10.5,
+            letterSpacing: "0.3px",
+          }}
+        >
+          {MIN_PASSWORD_LENGTH}+ characters · stored as an argon2id hash
+        </p>
+
+        {error ? (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11.5,
+              color: "var(--bad)",
+            }}
+          >
+            {error}
+          </div>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={!password || !confirm || submitting}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: "0.5px",
+            textTransform: "uppercase",
+            background: "var(--accent)",
+            color: "var(--accent-on, #fff)",
+            border: 0,
+            borderRadius: "var(--radius-sub, 3px)",
+            padding: "12px 16px",
+            cursor: submitting ? "wait" : "pointer",
+            opacity: password && confirm && !submitting ? 1 : 0.6,
+          }}
+        >
+          {submitting ? "Updating…" : "Set new password"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+function PasswordField({
+  label,
+  value,
+  onChange,
+  autoFocus,
+  autoComplete,
+  disabled,
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          letterSpacing: "0.5px",
+          color: "var(--muted-fg)",
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </span>
+      <input
+        type="password"
+        autoComplete={autoComplete}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        required
+        autoFocus={autoFocus}
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 13,
+          padding: "10px 14px",
+          background: "var(--card)",
+          border: "1px solid var(--border-strong)",
+          borderRadius: "var(--radius-sub, 3px)",
+          outline: "none",
+        }}
+      />
+    </label>
+  );
+}
+
+function SuccessPanel() {
+  return (
+    <div className="mx-auto flex max-w-sm flex-col gap-4 py-12">
+      <h1
+        className="font-semibold"
+        style={{
+          fontFamily: "var(--font-display, var(--font-inter-tight))",
+          fontSize: 26,
+          letterSpacing: "-0.7px",
+        }}
+      >
+        Password updated.
+      </h1>
+      <p
+        className="text-muted-fg"
+        style={{ fontSize: 13.5, lineHeight: 1.55 }}
+      >
+        Redirecting you to sign-in. Use your new password to continue.
+      </p>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          color: "var(--muted-fg)",
+        }}
+      >
+        Not redirected?{" "}
+        <Link
+          href="/login"
+          className="text-accent hover:underline"
+          style={{ fontWeight: 600 }}
+        >
+          Go to sign-in
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function ErrorPanel({ title, body }) {
+  return (
+    <div className="mx-auto flex max-w-sm flex-col gap-3 py-12">
+      <h1
+        className="font-semibold"
+        style={{
+          fontFamily: "var(--font-display, var(--font-inter-tight))",
+          fontSize: 24,
+          letterSpacing: "-0.6px",
+        }}
+      >
+        {title}
+      </h1>
+      <p
+        className="text-muted-fg"
+        style={{ fontSize: 13.5, lineHeight: 1.5 }}
+      >
+        {body}
+      </p>
+      <div
+        className="mt-1"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          color: "var(--muted-fg)",
+        }}
+      >
+        <Link
+          href="/forgot-password"
+          className="text-accent hover:underline"
+          style={{ fontWeight: 600 }}
+        >
+          Request a new link
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function humanise(err) {
+  if (!err) return "Something went wrong. Try again.";
+  if (err.code === "invalid_token")
+    return "Reset link is invalid or expired. Request a fresh one.";
+  if (err.code === "rate_limited")
+    return "Too many attempts on this network. Wait a few minutes and try again.";
+  if (err.code === "validation_error")
+    return err.message || "Check the fields and try again.";
+  if (err.code === "network_error")
+    return "Couldn't reach the server. Check your connection and try again.";
+  return err.message || "Something went wrong. Try again.";
+}

--- a/apps/web/src/features/auth/password-reset-request-form.jsx
+++ b/apps/web/src/features/auth/password-reset-request-form.jsx
@@ -1,0 +1,215 @@
+"use client";
+
+/**
+ * Password-reset *request* form. Mounted at /forgot-password.
+ *
+ * Takes an email, POSTs to /api/v1/auth/password/reset-request, which:
+ *   - always returns { ok: true } (tells an attacker nothing about
+ *     which emails are registered — enumeration defense)
+ *   - if the address resolves to an active, password-set user, mints
+ *     a single-use reset token + emails the link
+ *
+ * Because the server intentionally hides "no such user" from the
+ * caller, this form's success state is identical for valid and
+ * invalid inputs: "if an account exists, an email is on its way."
+ * Anything more specific would leak account existence.
+ *
+ * Rate-limited server-side at the per-IP layer
+ * (`passwordResetRequestLimiter`); the form additionally disables the
+ * submit button while in flight to prevent accidental double-fires.
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+import { apiPost } from "@/lib/api-client";
+
+export function PasswordResetRequestForm() {
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    const r = await apiPost("/auth/password/reset-request", { email });
+    setSubmitting(false);
+    if (!r.ok) {
+      // Reset-request is enumeration-safe on the happy path — the
+      // only errors that reach the client are rate-limit / validation
+      // / network. Surface them; don't swallow.
+      setError(humanise(r.error));
+      return;
+    }
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <SuccessPanel email={email} />
+    );
+  }
+
+  return (
+    <div className="mx-auto flex max-w-sm flex-col gap-5 py-12">
+      <div>
+        <h1
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display, var(--font-inter-tight))",
+            fontSize: 28,
+            letterSpacing: "-0.8px",
+          }}
+        >
+          Reset your password
+        </h1>
+        <p
+          className="mt-1 text-muted-fg"
+          style={{ fontSize: 13.5, lineHeight: 1.5 }}
+        >
+          Enter the email tied to your account. If we recognise it,
+          you&apos;ll get a link to set a new password.
+        </p>
+      </div>
+
+      <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
+        <label className="flex flex-col gap-1.5">
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              letterSpacing: "0.5px",
+              color: "var(--muted-fg)",
+              textTransform: "uppercase",
+            }}
+          >
+            Email
+          </span>
+          <input
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={submitting}
+            autoFocus
+            required
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 13,
+              padding: "10px 14px",
+              background: "var(--card)",
+              border: "1px solid var(--border-strong)",
+              borderRadius: "var(--radius-sub, 3px)",
+              outline: "none",
+            }}
+          />
+        </label>
+
+        {error ? (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11.5,
+              color: "var(--bad)",
+            }}
+          >
+            {error}
+          </div>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={!email || submitting}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: "0.5px",
+            textTransform: "uppercase",
+            background: "var(--accent)",
+            color: "var(--accent-on, #fff)",
+            border: 0,
+            borderRadius: "var(--radius-sub, 3px)",
+            padding: "12px 16px",
+            cursor: submitting ? "wait" : "pointer",
+            opacity: email && !submitting ? 1 : 0.6,
+          }}
+        >
+          {submitting ? "Sending…" : "Send reset link"}
+        </button>
+      </form>
+
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          color: "var(--muted-fg)",
+        }}
+      >
+        Remembered it?{" "}
+        <Link
+          href="/login"
+          className="text-accent hover:underline"
+          style={{ fontWeight: 600 }}
+        >
+          Back to sign-in
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function SuccessPanel({ email }) {
+  return (
+    <div className="mx-auto flex max-w-sm flex-col gap-4 py-12">
+      <h1
+        className="font-semibold"
+        style={{
+          fontFamily: "var(--font-display, var(--font-inter-tight))",
+          fontSize: 26,
+          letterSpacing: "-0.7px",
+        }}
+      >
+        Check your inbox.
+      </h1>
+      <p
+        className="text-muted-fg"
+        style={{ fontSize: 13.5, lineHeight: 1.55 }}
+      >
+        If <span style={{ color: "var(--fg)" }}>{email}</span> is
+        registered, we&apos;ve sent you a reset link. Open the link
+        from the same browser you signed in with. The link expires
+        soon — request a fresh one if it&apos;s already gone stale.
+      </p>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          color: "var(--muted-fg)",
+        }}
+      >
+        Didn&apos;t get it? Double-check the address, then{" "}
+        <Link
+          href="/login"
+          className="text-accent hover:underline"
+          style={{ fontWeight: 600 }}
+        >
+          back to sign-in
+        </Link>{" "}
+        and try again.
+      </div>
+    </div>
+  );
+}
+
+function humanise(err) {
+  if (!err) return "Something went wrong. Try again.";
+  if (err.code === "rate_limited")
+    return "Too many requests from this network. Wait a few minutes and try again.";
+  if (err.code === "validation_error")
+    return err.message || "That doesn't look like a valid email.";
+  if (err.code === "network_error")
+    return "Couldn't reach the server. Check your connection and try again.";
+  return err.message || "Something went wrong. Try again.";
+}


### PR DESCRIPTION
## Summary
Closes a real broken-link bug: the password-reset email already points to `${appOrigin}/password-reset?token=…` (see `auth/controller.ts:327`) but no page existed at that route — a user clicking the link landed on Next.js's default 404. The matching API endpoints have been live for a while:

```
POST /api/v1/auth/password/reset-request   { email }
POST /api/v1/auth/password/reset           { token, password }
```

…with rate limits, audit-log writes, session destruction on success, and enumeration-safe responses on the request side. This PR is just the UI.

## New surfaces

### `/forgot-password`
`PasswordResetRequestForm` — email input → POST `reset-request` → enumeration-safe success panel ("if it's registered, an email is on its way"). Mirrors `AcceptInviteForm`'s chrome so the auth flow feels consistent.

### `/password-reset?token=…`
`PasswordResetForm` — token from URL + new password + confirm → POST `reset` → success panel + `setTimeout(replace("/login"), 1800)`. Server destroys every existing session for the user on success AND does NOT mint a new one, so `/login` is the correct landing. Mirrors `AcceptInviteForm`'s `MIN_PASSWORD_LENGTH = 12` guard and confirm-mismatch handling.

### Entry point
The login form's password step now carries a **"Forgot password?"** link below the Continue button. Deliberately **not** shown on the TOTP step — by step 2 the user has already authenticated, so the right recovery there is backup codes, not a password reset.

## Both pages
- Top-level routes (siblings of `/login` and `/accept-invite`); no AppShell, no hub theme, no `AuthGuard` wrap. AuthGuard would bounce a locked-out user to `/login`, which would defeat the entire point of the recovery flow.
- Suspense boundary on `/password-reset` (`useSearchParams` forces a client-side render bailout — same precedent as `/accept-invite`).

## Errors humanised

| Code | Surfaced |
|---|---|
| `invalid_token` | "Reset link is invalid or expired. Request a fresh one." |
| `rate_limited` | "Too many attempts on this network. Wait a few minutes…" |
| `validation_*` | field-level message |
| `network_error` | generic retry copy |

## Files
- `apps/web/src/app/forgot-password/page.jsx` (new)
- `apps/web/src/app/password-reset/page.jsx` (new)
- `apps/web/src/features/auth/password-reset-request-form.jsx` (new)
- `apps/web/src/features/auth/password-reset-form.jsx` (new)
- `apps/web/src/features/auth/login-form.jsx` (add Forgot link)
- `apps/web/src/features/auth/index.js` (export both forms)

## Test plan
- [x] `next build --experimental-build-mode=compile` clean; both routes appear in manifest
- [ ] Click "Forgot password?" on `/login` → land on `/forgot-password`
- [ ] Enter known email → success panel renders, audit log shows `user.password_reset_requested`, email arrives
- [ ] Enter unknown email → identical success panel (enumeration-safe)
- [ ] Click email link → `/password-reset?token=…` renders with form
- [ ] Submit < 12-char password → inline validation error, no API call
- [ ] Submit mismatched confirm → inline validation error
- [ ] Submit valid pair → success panel → auto-redirect to `/login` after ~1.8s
- [ ] Try reusing the now-redeemed token (resubmit before redirect) → "invalid_token" error
- [ ] Sign in with new password → routes into app normally
- [ ] Existing sessions on other devices forced out (verify via cookie-jar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)