### PR TITLE
feat(web): admin Users + Audit pages (M-CAP PR 4 — UI half)

### DIFF
--- a/apps/web/src/hubs/admin/admin-audit.jsx
+++ b/apps/web/src/hubs/admin/admin-audit.jsx
@@ -1,0 +1,488 @@
+"use client";
+
+/**
+ * Admin Hub — audit log viewer. UI on top of:
+ *   GET /api/v1/admin/audit?action=&actorUserId=&targetType=&since=&until=&limit=
+ *
+ * Mirrors the users-page chrome (same header, same row pattern). The
+ * audit log is read-only by contract (lib/audit.ts has no
+ * update/delete), so this view is list + filter + expand-for-diff.
+ *
+ * Filtering
+ * ─────────
+ * Three filters surfaced in the toolbar — the API supports more but
+ * action, actor, and targetType are the ones an admin actually reaches
+ * for. The other filters (targetId, since, until) are useful in
+ * scripts but cluttered the UI; we can promote them later if needed.
+ *
+ *   action       free-text exact match. Hint: dot-namespaced verb
+ *                like "user.update" or "hub_config.upsert".
+ *   actor        dropdown of org users (one prefetch on mount). Sends
+ *                the user's hex ObjectId.
+ *   targetType   free-text exact match. Common values: user, hub,
+ *                integration, snapshot.
+ *
+ * Pagination
+ * ─────────
+ * Keyset on `ts desc, _id desc`. Server returns `hasMore` + a
+ * convenience `nextUntil` we feed straight back as `?until=…`. No
+ * count(); the only way to know "how many total" is to scroll the
+ * stream. That's fine for an audit log — it's append-only and the
+ * UI cares about recency.
+ *
+ * Diff expand
+ * ─────────
+ * Audit entries carry `before` / `after` blobs scoped to just the
+ * changed fields (per the admin controller's diff trimming). We
+ * render them as side-by-side pretty-printed JSON. For entries
+ * without a diff (read-only actions like `auth.login`), the expand
+ * panel just shows the actor + IP/UA metadata.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { apiGet } from "@/lib/api-client";
+
+const PAGE_SIZE = 50;
+
+export function AdminAudit() {
+  const [entries, setEntries] = useState([]);
+  const [users, setUsers] = useState([]); // for actor-filter dropdown
+  const [hasMore, setHasMore] = useState(false);
+  const [nextUntil, setNextUntil] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [filters, setFilters] = useState({
+    action: "",
+    actorUserId: "",
+    targetType: "",
+  });
+  const [openEntryId, setOpenEntryId] = useState(null);
+
+  // Build a query string from a filter snapshot + an optional `until`
+  // for pagination. Empty strings drop out — Zod's optional on the
+  // server only accepts present-with-value.
+  function buildQuery(f, until) {
+    const params = new URLSearchParams();
+    params.set("limit", String(PAGE_SIZE));
+    if (f.action.trim()) params.set("action", f.action.trim());
+    if (f.actorUserId) params.set("actorUserId", f.actorUserId);
+    if (f.targetType.trim()) params.set("targetType", f.targetType.trim());
+    if (until) params.set("until", until);
+    return params.toString();
+  }
+
+  // Initial load + reload whenever filters change.
+  // Users dropdown only fetches once.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const r = await apiGet("/admin/users");
+      if (cancelled) return;
+      if (r.ok) {
+        setUsers(r.data?.users ?? []);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setOpenEntryId(null);
+    (async () => {
+      const r = await apiGet(`/admin/audit?${buildQuery(filters, null)}`);
+      if (cancelled) return;
+      if (!r.ok) {
+        toast.error(r.error?.message || "Couldn't load audit log.");
+        setLoading(false);
+        return;
+      }
+      setEntries(r.data?.entries ?? []);
+      setHasMore(!!r.data?.hasMore);
+      setNextUntil(r.data?.nextUntil ?? null);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [filters]);
+
+  async function loadMore() {
+    if (!nextUntil || loadingMore) return;
+    setLoadingMore(true);
+    const r = await apiGet(`/admin/audit?${buildQuery(filters, nextUntil)}`);
+    setLoadingMore(false);
+    if (!r.ok) {
+      toast.error(r.error?.message || "Couldn't load more entries.");
+      return;
+    }
+    setEntries((prev) => [...prev, ...(r.data?.entries ?? [])]);
+    setHasMore(!!r.data?.hasMore);
+    setNextUntil(r.data?.nextUntil ?? null);
+  }
+
+  const usersById = useMemo(() => {
+    const map = new Map();
+    for (const u of users) map.set(u.id, u);
+    return map;
+  }, [users]);
+
+  return (
+    <main className="relative z-[2] mx-auto max-w-5xl px-10 pb-14 pt-10">
+      <header className="mb-8">
+        <div
+          className="mb-2 uppercase tracking-[0.5px] text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+        >
+          Admin · audit log
+        </div>
+        <h1
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: 28,
+            letterSpacing: "-0.5px",
+          }}
+        >
+          Privileged-action history.
+        </h1>
+        <p className="mt-2 max-w-2xl text-[13.5px] leading-[1.55] text-muted-fg">
+          Append-only record of every audited action — invites, role
+          changes, hub overrides, password resets, integration
+          connect/disconnect, snapshot mutations. Newest first. Filters
+          apply server-side; pagination is keyset on the entry
+          timestamp.
+        </p>
+      </header>
+
+      <FilterBar filters={filters} setFilters={setFilters} users={users} />
+
+      {loading ? (
+        <div
+          className="mt-6 text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+        >
+          Loading…
+        </div>
+      ) : entries.length === 0 ? (
+        <div
+          className="mt-6 text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+        >
+          No audit entries match these filters.
+        </div>
+      ) : (
+        <div className="mt-5 flex flex-col gap-1.5">
+          {entries.map((e) => (
+            <EntryRow
+              key={e.id}
+              entry={e}
+              expanded={openEntryId === e.id}
+              onExpand={() =>
+                setOpenEntryId(openEntryId === e.id ? null : e.id)
+              }
+              actorDisplay={
+                e.actorUserId
+                  ? usersById.get(e.actorUserId)?.displayName ?? e.actorUserId
+                  : "system"
+              }
+            />
+          ))}
+          {hasMore ? (
+            <div className="mt-4 flex justify-center">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={loadingMore}
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 11,
+                  fontWeight: 700,
+                  letterSpacing: "0.5px",
+                  textTransform: "uppercase",
+                  background: "transparent",
+                  color: "var(--accent)",
+                  border: "1px solid var(--accent)",
+                  borderRadius: "var(--radius-sub, 3px)",
+                  padding: "8px 16px",
+                  cursor: loadingMore ? "wait" : "pointer",
+                }}
+              >
+                {loadingMore ? "Loading…" : "Load older entries"}
+              </button>
+            </div>
+          ) : (
+            <div
+              className="mt-3 text-center text-muted-fg"
+              style={{ fontFamily: "var(--font-mono)", fontSize: 10.5 }}
+            >
+              End of audit log.
+            </div>
+          )}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function FilterBar({ filters, setFilters, users }) {
+  return (
+    <div
+      className="flex flex-wrap items-end gap-3 rounded-md border bg-card p-4"
+      style={{ borderColor: "var(--border-strong)" }}
+    >
+      <div className="flex flex-col gap-1.5">
+        <FilterLabel>Action</FilterLabel>
+        <input
+          type="text"
+          placeholder="e.g. user.update"
+          value={filters.action}
+          onChange={(e) =>
+            setFilters((p) => ({ ...p, action: e.target.value }))
+          }
+          style={{ ...inputStyle, width: 200 }}
+        />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <FilterLabel>Actor</FilterLabel>
+        <select
+          value={filters.actorUserId}
+          onChange={(e) =>
+            setFilters((p) => ({ ...p, actorUserId: e.target.value }))
+          }
+          style={{ ...inputStyle, minWidth: 200 }}
+        >
+          <option value="">(any user)</option>
+          {users.map((u) => (
+            <option key={u.id} value={u.id}>
+              {u.displayName} — {u.email}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <FilterLabel>Target type</FilterLabel>
+        <input
+          type="text"
+          placeholder="e.g. user / hub / integration"
+          value={filters.targetType}
+          onChange={(e) =>
+            setFilters((p) => ({ ...p, targetType: e.target.value }))
+          }
+          style={{ ...inputStyle, width: 200 }}
+        />
+      </div>
+      {(filters.action || filters.actorUserId || filters.targetType) ? (
+        <button
+          type="button"
+          onClick={() =>
+            setFilters({ action: "", actorUserId: "", targetType: "" })
+          }
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10.5,
+            color: "var(--muted-fg)",
+            background: "transparent",
+            border: "1px solid var(--border-strong)",
+            borderRadius: "var(--radius-sub, 3px)",
+            padding: "8px 12px",
+            cursor: "pointer",
+          }}
+        >
+          Clear filters
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function EntryRow({ entry, expanded, onExpand, actorDisplay }) {
+  const hasDiff = entry.before !== undefined || entry.after !== undefined;
+  return (
+    <div
+      className="rounded-sm border bg-card"
+      style={{ borderColor: "var(--border)" }}
+    >
+      <button
+        type="button"
+        onClick={onExpand}
+        className="flex w-full items-center gap-4 px-4 py-2.5 text-left transition-colors hover:bg-accent-dim/10"
+      >
+        <span
+          className="text-muted-fg"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10.5,
+            minWidth: 130,
+            letterSpacing: "0.2px",
+          }}
+        >
+          {formatTs(entry.ts)}
+        </span>
+        <span
+          className="text-accent"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 12,
+            fontWeight: 600,
+            minWidth: 180,
+          }}
+        >
+          {entry.action}
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11.5,
+            flex: 1,
+          }}
+        >
+          {actorDisplay}
+        </span>
+        {entry.targetType ? (
+          <span
+            className="text-muted-fg"
+            style={{ fontFamily: "var(--font-mono)", fontSize: 10.5 }}
+          >
+            {entry.targetType}
+            {entry.targetId ? `/${truncMiddle(entry.targetId, 14)}` : ""}
+          </span>
+        ) : null}
+        <span
+          className="text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+        >
+          {expanded ? "▾" : "▸"}
+        </span>
+      </button>
+
+      {expanded ? (
+        <div
+          className="border-t px-4 py-4"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <div className="grid grid-cols-2 gap-4">
+            <Meta label="Actor user id" value={entry.actorUserId} />
+            <Meta label="Actor role" value={entry.actorRole} />
+            <Meta label="Target type" value={entry.targetType} />
+            <Meta label="Target id" value={entry.targetId} />
+            <Meta label="IP" value={entry.ip} />
+            <Meta label="User agent" value={entry.ua} truncate />
+          </div>
+          {hasDiff ? (
+            <div className="mt-4 grid grid-cols-2 gap-4">
+              <DiffPanel label="before" data={entry.before} />
+              <DiffPanel label="after" data={entry.after} />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function DiffPanel({ label, data }) {
+  const empty = data === null || data === undefined;
+  return (
+    <div>
+      <div
+        className="mb-1 uppercase tracking-[0.4px] text-muted-fg"
+        style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}
+      >
+        {label}
+      </div>
+      <pre
+        className="overflow-auto rounded-sm border p-2"
+        style={{
+          borderColor: "var(--border)",
+          background: "var(--card-alt, var(--card))",
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          lineHeight: 1.45,
+          maxHeight: 240,
+          margin: 0,
+        }}
+      >
+        {empty ? "—" : safeStringify(data)}
+      </pre>
+    </div>
+  );
+}
+
+function Meta({ label, value, truncate }) {
+  return (
+    <div>
+      <div
+        className="uppercase tracking-[0.4px] text-muted-fg"
+        style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11.5,
+          marginTop: 2,
+          wordBreak: truncate ? "break-all" : "normal",
+        }}
+      >
+        {value || <span className="text-dim-fg">—</span>}
+      </div>
+    </div>
+  );
+}
+
+function FilterLabel({ children }) {
+  return (
+    <span
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 10,
+        letterSpacing: "0.5px",
+        color: "var(--muted-fg)",
+        textTransform: "uppercase",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+const inputStyle = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  padding: "8px 10px",
+  background: "var(--card)",
+  border: "1px solid var(--border-strong)",
+  borderRadius: "var(--radius-sub, 3px)",
+  outline: "none",
+};
+
+function formatTs(iso) {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function truncMiddle(s, max) {
+  if (typeof s !== "string" || s.length <= max) return s;
+  const half = Math.floor((max - 1) / 2);
+  return `${s.slice(0, half)}…${s.slice(-half)}`;
+}
+
+function safeStringify(v) {
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}

--- a/apps/web/src/hubs/admin/admin-dashboard.jsx
+++ b/apps/web/src/hubs/admin/admin-dashboard.jsx
@@ -136,14 +136,12 @@ export function AdminDashboard() {
         <NavCard
           href={link("/users")}
           title="User management"
-          body="Manage roles + hub access per user. Full UI lands in a follow-up — the API endpoints are in flight."
-          comingSoon
+          body="Manage roles + status + hub access per user. Self-edits can't strip your own admin role or disable your own account."
         />
         <NavCard
           href={link("/audit")}
           title="Audit log"
-          body="Privileged-action history — invites, role changes, hub overrides, password resets. Viewer lands in a follow-up."
-          comingSoon
+          body="Privileged-action history — invites, role changes, hub overrides, password resets, integration connect/disconnect. Filterable + paginated."
         />
       </div>
     </main>

--- a/apps/web/src/hubs/admin/admin-users.jsx
+++ b/apps/web/src/hubs/admin/admin-users.jsx
@@ -1,0 +1,554 @@
+"use client";
+
+/**
+ * Admin Hub — user management. UI on top of:
+ *   GET   /api/v1/admin/users         list every member of the org
+ *   PATCH /api/v1/admin/users/:id     edit roles/status/hubs/displayName
+ *
+ * Renders one expandable row per user (mirroring admin-hub-config's
+ * shape — same "click row → inline editor" pattern so admins navigate
+ * both surfaces with the same muscle memory).
+ *
+ * The row shows the at-a-glance fields the table needs (email,
+ * roles, status, primary hub, last-login). Expanding reveals an
+ * inline editor that PATCHes on save; the API is single-endpoint
+ * (no per-field PATCH calls) so the editor batches every change
+ * into one round-trip.
+ *
+ * Optimistic UI:
+ *   - Save fires → button shows "Saving…"
+ *   - Server returns the canonical row → we replace the local copy
+ *   - Failure toasts + leaves the row's local edit state intact so
+ *     the admin can adjust + retry without re-typing
+ *
+ * Self-protection: an admin editing their OWN row sees the
+ * `admin` checkbox + `status=disabled` option disabled with a hint,
+ * mirroring the server-side self-lockout guard. Surfacing the rule
+ * locally avoids the round-trip-just-to-be-told-no UX.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { apiGet, apiPatch } from "@/lib/api-client";
+import { useSession } from "@/features/auth";
+import { CAPABILITIES } from "@espace-devhub/shared/capabilities";
+import { HUB_ORDER } from "@espace-devhub/shared/hubs";
+
+// Pulled from db/types.ts ALL_USER_ROLES. Hard-coded here rather than
+// imported because the shared package doesn't re-export them yet and
+// the list is small + stable.
+const ALL_ROLES = ["admin", "dev", "qa", "manager", "hr", "po", "member"];
+const ALL_STATUSES = ["invited", "active", "disabled"];
+
+export function AdminUsers() {
+  const { user: sessionUser } = useSession();
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [openUserId, setOpenUserId] = useState(null);
+
+  const canManage = sessionUser?.capabilities?.includes(
+    CAPABILITIES.ADMIN_USERS_MANAGE,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const r = await apiGet("/admin/users");
+      if (cancelled) return;
+      if (!r.ok) {
+        toast.error(r.error?.message || "Couldn't load users.");
+        setLoading(false);
+        return;
+      }
+      setUsers(r.data?.users ?? []);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function applyUpdate(updatedUser) {
+    setUsers((prev) =>
+      prev.map((u) => (u.id === updatedUser.id ? updatedUser : u)),
+    );
+  }
+
+  if (!canManage) {
+    return (
+      <main className="mx-auto max-w-3xl px-10 py-12">
+        <h1 className="mb-3 text-[24px] font-semibold">Not authorised.</h1>
+        <p className="text-[13px] text-muted-fg">
+          This view requires the {CAPABILITIES.ADMIN_USERS_MANAGE} capability.
+          Ask your org admin to extend your roles.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="relative z-[2] mx-auto max-w-5xl px-10 pb-14 pt-10">
+      <header className="mb-8">
+        <div
+          className="mb-2 uppercase tracking-[0.5px] text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+        >
+          Admin · user management
+        </div>
+        <h1
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: 28,
+            letterSpacing: "-0.5px",
+          }}
+        >
+          Members of your org.
+        </h1>
+        <p className="mt-2 max-w-2xl text-[13.5px] leading-[1.55] text-muted-fg">
+          Click a row to edit roles, status, and hub access. Changes
+          take effect on the user&apos;s next request — they don&apos;t
+          need to log out. Self-edits can&apos;t strip your own admin
+          role or disable your own account.
+        </p>
+      </header>
+
+      {loading ? (
+        <div
+          className="text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+        >
+          Loading…
+        </div>
+      ) : users.length === 0 ? (
+        <div
+          className="text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+        >
+          No users found for this org.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {users.map((u) => (
+            <UserRow
+              key={u.id}
+              user={u}
+              isSelf={sessionUser?.id === u.id}
+              expanded={openUserId === u.id}
+              onExpand={() =>
+                setOpenUserId(openUserId === u.id ? null : u.id)
+              }
+              onUpdate={applyUpdate}
+            />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function UserRow({ user, isSelf, expanded, onExpand, onUpdate }) {
+  return (
+    <div
+      className="rounded-md border bg-card"
+      style={{ borderColor: "var(--border-strong)" }}
+    >
+      <button
+        type="button"
+        onClick={onExpand}
+        className="flex w-full items-center justify-between gap-4 px-5 py-3 text-left transition-colors hover:bg-accent-dim/20"
+      >
+        <div className="flex flex-1 items-baseline gap-3">
+          <span
+            className="text-[14px] font-semibold"
+            style={{ letterSpacing: "-0.2px" }}
+          >
+            {user.displayName}
+          </span>
+          <span
+            className="text-muted-fg"
+            style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+          >
+            {user.email}
+          </span>
+          {isSelf ? (
+            <span
+              className="rounded-full border border-accent px-2 py-0.5 text-accent"
+              style={{ fontFamily: "var(--font-mono)", fontSize: 9 }}
+            >
+              YOU
+            </span>
+          ) : null}
+        </div>
+        <StatusPill status={user.status} />
+        <span
+          className="text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 10.5 }}
+        >
+          {user.roles.join(" · ")}
+        </span>
+        <span
+          className="ml-3 text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+        >
+          {expanded ? "▾" : "▸"}
+        </span>
+      </button>
+
+      {expanded ? (
+        <UserEditor user={user} isSelf={isSelf} onUpdate={onUpdate} />
+      ) : null}
+    </div>
+  );
+}
+
+function UserEditor({ user, isSelf, onUpdate }) {
+  // Local edit state — initialised from the canonical user. Saves
+  // produce a NEW canonical object via the PATCH response, at which
+  // point we lift it up via onUpdate(); the editor stays mounted so
+  // the admin can keep editing without re-expanding.
+  const [displayName, setDisplayName] = useState(user.displayName);
+  const [roles, setRoles] = useState(user.roles);
+  const [status, setStatus] = useState(user.status);
+  const [allowedHubs, setAllowedHubs] = useState(
+    user.allowedHubs.length > 0 ? user.allowedHubs : [],
+  );
+  const [primaryHub, setPrimaryHub] = useState(user.primaryHub);
+  const [saving, setSaving] = useState(false);
+
+  // Re-init when the canonical user updates (after a successful save
+  // OR when a sibling row's save triggers an unrelated re-render).
+  useEffect(() => {
+    setDisplayName(user.displayName);
+    setRoles(user.roles);
+    setStatus(user.status);
+    setAllowedHubs(user.allowedHubs);
+    setPrimaryHub(user.primaryHub);
+  }, [user]);
+
+  const dirty = useMemo(() => {
+    if (displayName !== user.displayName) return true;
+    if (!sameArray(roles, user.roles)) return true;
+    if (status !== user.status) return true;
+    if (!sameArray(allowedHubs, user.allowedHubs)) return true;
+    if (primaryHub !== user.primaryHub) return true;
+    return false;
+  }, [
+    displayName,
+    roles,
+    status,
+    allowedHubs,
+    primaryHub,
+    user.displayName,
+    user.roles,
+    user.status,
+    user.allowedHubs,
+    user.primaryHub,
+  ]);
+
+  function toggleRole(roleId) {
+    setRoles((prev) => {
+      const has = prev.includes(roleId);
+      if (has) {
+        // Disallow removing the last role (UI guard; server also
+        // rejects empty roles).
+        if (prev.length === 1) return prev;
+        return prev.filter((r) => r !== roleId);
+      }
+      return [...prev, roleId];
+    });
+  }
+
+  function toggleHub(hubId) {
+    setAllowedHubs((prev) => {
+      const has = prev.includes(hubId);
+      const next = has ? prev.filter((h) => h !== hubId) : [...prev, hubId];
+      // Keep primaryHub valid — if we just removed the current
+      // primary, drop it to null so the admin notices + re-picks.
+      if (!next.includes(primaryHub ?? "")) {
+        setPrimaryHub(next[0] ?? null);
+      }
+      return next;
+    });
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    // Build a minimal patch — only fields that actually changed.
+    // Server is a no-op on empty patches, but trimming here keeps
+    // the audit log cleaner and is friendlier to debug.
+    const patch = {};
+    if (displayName !== user.displayName) patch.displayName = displayName;
+    if (!sameArray(roles, user.roles)) patch.roles = roles;
+    if (status !== user.status) patch.status = status;
+    if (!sameArray(allowedHubs, user.allowedHubs)) patch.allowedHubs = allowedHubs;
+    if (primaryHub !== user.primaryHub) patch.primaryHub = primaryHub;
+
+    const r = await apiPatch(`/admin/users/${user.id}`, patch);
+    setSaving(false);
+    if (!r.ok) {
+      toast.error(r.error?.message || "Couldn't save user.");
+      return;
+    }
+    onUpdate(r.data?.user);
+    toast.success(`Saved ${r.data?.user?.displayName || "user"}.`);
+  }
+
+  return (
+    <div
+      className="border-t px-5 py-5"
+      style={{ borderColor: "var(--border)" }}
+    >
+      <div className="grid grid-cols-2 gap-5">
+        <Field label="Display name">
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            disabled={saving}
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Status">
+          <select
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+            disabled={saving}
+            style={inputStyle}
+          >
+            {ALL_STATUSES.map((s) => (
+              <option key={s} value={s} disabled={isSelf && s === "disabled"}>
+                {s}
+                {isSelf && s === "disabled" ? " (can't disable yourself)" : ""}
+              </option>
+            ))}
+          </select>
+        </Field>
+      </div>
+
+      <div className="mt-5">
+        <FieldLabel>Roles</FieldLabel>
+        <p
+          className="mt-1 text-muted-fg"
+          style={{ fontSize: 11.5, lineHeight: 1.5 }}
+        >
+          A user can hold multiple roles. Their effective capabilities
+          are the union across all of them. {isSelf ? "You can't remove your own admin role." : null}
+        </p>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {ALL_ROLES.map((r) => {
+            const checked = roles.includes(r);
+            const disabled =
+              saving ||
+              (isSelf && r === "admin" && checked) || // self can't drop admin
+              (roles.length === 1 && checked); // can't drop the last
+            return (
+              <Pill
+                key={r}
+                checked={checked}
+                disabled={disabled}
+                onClick={() => toggleRole(r)}
+              >
+                {r}
+              </Pill>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-5 grid grid-cols-2 gap-5">
+        <div>
+          <FieldLabel>Allowed hubs</FieldLabel>
+          <p
+            className="mt-1 text-muted-fg"
+            style={{ fontSize: 11.5, lineHeight: 1.5 }}
+          >
+            Hubs this user can switch into. Hub access is also gated
+            by capabilities — granting an unsupported hub here just
+            hides it server-side at /hubs/me time.
+          </p>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {HUB_ORDER.map((h) => (
+              <Pill
+                key={h}
+                checked={allowedHubs.includes(h)}
+                disabled={saving}
+                onClick={() => toggleHub(h)}
+              >
+                {h}
+              </Pill>
+            ))}
+          </div>
+        </div>
+
+        <Field label="Primary hub">
+          <select
+            value={primaryHub ?? ""}
+            onChange={(e) => setPrimaryHub(e.target.value || null)}
+            disabled={saving}
+            style={inputStyle}
+          >
+            <option value="">(not set)</option>
+            {allowedHubs.map((h) => (
+              <option key={h} value={h}>
+                {h}
+              </option>
+            ))}
+          </select>
+        </Field>
+      </div>
+
+      <div className="mt-6 flex items-center justify-between">
+        <UserMeta user={user} />
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!dirty || saving}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: "0.5px",
+            textTransform: "uppercase",
+            background: "var(--accent)",
+            color: "var(--accent-on, #fff)",
+            border: 0,
+            borderRadius: "var(--radius-sub, 3px)",
+            padding: "9px 16px",
+            cursor: saving ? "wait" : dirty ? "pointer" : "default",
+            opacity: dirty && !saving ? 1 : 0.5,
+          }}
+        >
+          {saving ? "Saving…" : dirty ? "Save changes" : "No changes"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function UserMeta({ user }) {
+  const items = [
+    user.lastLoginAt
+      ? `last login ${formatDate(user.lastLoginAt)}`
+      : "never signed in",
+    user.hasTotp ? "TOTP enrolled" : "no TOTP",
+    user.hasPassword ? "password set" : "no password",
+    user.onboardingCompletedAt ? "onboarded" : "onboarding pending",
+  ];
+  return (
+    <div
+      className="text-muted-fg"
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 10.5,
+        letterSpacing: "0.2px",
+      }}
+    >
+      {items.join(" · ")}
+    </div>
+  );
+}
+
+function Field({ label, children }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <FieldLabel>{label}</FieldLabel>
+      {children}
+    </label>
+  );
+}
+
+function FieldLabel({ children }) {
+  return (
+    <span
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 10,
+        letterSpacing: "0.5px",
+        color: "var(--muted-fg)",
+        textTransform: "uppercase",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Pill({ checked, disabled, onClick, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        fontWeight: 600,
+        letterSpacing: "0.3px",
+        padding: "4px 10px",
+        borderRadius: "var(--radius-sub, 3px)",
+        cursor: disabled ? "not-allowed" : "pointer",
+        background: checked ? "var(--accent)" : "transparent",
+        color: checked ? "var(--accent-on, #fff)" : "var(--muted-fg)",
+        border: checked ? "1px solid var(--accent)" : "1px solid var(--border-strong)",
+        opacity: disabled ? 0.55 : 1,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function StatusPill({ status }) {
+  const color =
+    status === "active"
+      ? "var(--good, #16a34a)"
+      : status === "invited"
+        ? "var(--accent)"
+        : "var(--bad, #b91c1c)";
+  return (
+    <span
+      className="rounded-full px-2 py-0.5"
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 9.5,
+        letterSpacing: "0.4px",
+        textTransform: "uppercase",
+        color,
+        border: `1px solid ${color}`,
+      }}
+    >
+      {status}
+    </span>
+  );
+}
+
+const inputStyle = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 12.5,
+  padding: "8px 12px",
+  background: "var(--card)",
+  border: "1px solid var(--border-strong)",
+  borderRadius: "var(--radius-sub, 3px)",
+  outline: "none",
+};
+
+function sameArray(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return a === b;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function formatDate(iso) {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/apps/web/src/hubs/admin/index.js
+++ b/apps/web/src/hubs/admin/index.js
@@ -5,4 +5,6 @@
 
 export { AdminDashboard } from "./admin-dashboard.jsx";
 export { AdminHubConfig } from "./admin-hub-config.jsx";
+export { AdminUsers } from "./admin-users.jsx";
+export { AdminAudit } from "./admin-audit.jsx";
 export { AdminPlaceholder } from "./admin-placeholder.jsx";

--- a/apps/web/src/hubs/dashboard-registry.jsx
+++ b/apps/web/src/hubs/dashboard-registry.jsx
@@ -20,9 +20,10 @@
 import { DashboardPage } from "@/features/dashboard";
 import { QaPlaceholder } from "@/hubs/qa";
 import {
+  AdminAudit,
   AdminDashboard,
   AdminHubConfig,
-  AdminPlaceholder,
+  AdminUsers,
 } from "@/hubs/admin";
 
 /**
@@ -64,8 +65,8 @@ export function getDashboardComponent(hubId) {
  */
 const ADMIN_SLOT_COMPONENTS = {
   "hub-config": AdminHubConfig,
-  users: () => <AdminPlaceholder slot="users" />,
-  audit: () => <AdminPlaceholder slot="audit" />,
+  users: AdminUsers,
+  audit: AdminAudit,
 };
 
 export function getAdminSlotComponent(slot) {


### PR DESCRIPTION
## Summary
Pairs with the admin API (#53). Replaces the two `comingSoon` placeholders on `/admin` with real UIs and drops the "soon" badge off the dashboard nav cards. Closes the M-CAP arc.

## `/[hub]/users` — AdminUsers
Click-to-expand row pattern, mirroring `admin-hub-config` so admins navigate both surfaces with the same muscle memory.

**Row glance**: displayName · email · status pill · roles list.

**Expanded editor**:
- `displayName` (text)
- `status` (select; `disabled` greyed out when editing self)
- `roles` (multi-toggle pills; `admin` locked when editing self if currently held; last-remaining role locked to prevent empty)
- `allowedHubs` (multi-toggle pills from shared `HUB_ORDER`); removing the current primary hub drops it to the first remaining hub
- `primaryHub` (select scoped to allowedHubs)
- Footer meta: lastLoginAt · TOTP enrolled? · password set? · onboarding complete? — read-only

Save batches every dirty field into one `PATCH /admin/users/:id`. UI re-initialises from the canonical response so a "save → keep editing" loop is intuitive. Server-side self-lockout guards are surfaced locally (disabled pills + select options) so the admin doesn't get a round-trip-just-to-be-told-no.

## `/[hub]/audit` — AdminAudit
**Filter bar**: action (free-text exact), actor (dropdown of org users fetched once via `/admin/users`), targetType (free-text). Changes re-fetch the page from the top. "Clear filters" resets all three.

**Row glance**: `ts` (Mon DD HH:MM) · `action` · actor displayName · target.

**Expanded panel**: actorUserId / actorRole / targetType / targetId / ip / ua side-by-side, then `before` / `after` JSON diffs when present.

**Pagination**: keyset on the server's `nextUntil` value. "Load older entries" button appends to the visible list — newest stays at top.

## Dashboard
`comingSoon` flag removed from the Users + Audit nav cards. Copy updated to reflect actual shipped behaviour.

`AdminPlaceholder` no longer wired into `ADMIN_SLOT_COMPONENTS` but the file stays in the tree for future scaffolds. Removed from the dashboard-registry import list to avoid a dead reference.

## Files
- `apps/web/src/hubs/admin/admin-users.jsx` (new)
- `apps/web/src/hubs/admin/admin-audit.jsx` (new)
- `apps/web/src/hubs/admin/admin-dashboard.jsx` (drop `comingSoon`)
- `apps/web/src/hubs/admin/index.js` (export both new)
- `apps/web/src/hubs/dashboard-registry.jsx` (swap slots in)

Verified: `next build --experimental-build-mode=compile` clean.

## Test plan
- [x] Compile clean
- [ ] As admin → `/admin` shows nav cards without "soon" badges
- [ ] `/admin/users` lists every org member; rows show roles + status correctly
- [ ] Expanding own row: `admin` role pill locked (can't drop); `disabled` status disabled in the select
- [ ] Expanding another user: pills + select work; "Save changes" disabled until something differs
- [ ] Save flow: roles + hubs + status edits land in PATCH; toast confirms; row re-renders with new pills
- [ ] Empty patch attempt → button stays disabled; no PATCH fires
- [ ] `/admin/audit` shows newest entries first; expanded entry shows actor metadata + before/after JSON
- [ ] Filter by action (e.g. `user.update`) → list filters server-side
- [ ] Filter by actor (dropdown) → list narrows to that user's actions
- [ ] "Load older entries" appends a page; "End of audit log" appears when exhausted
- [ ] As non-admin (dev/qa): both routes blocked by `useHubSlotGuard` (existing behaviour, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)