### PR TITLE
feat(web): TOTP enrolment gate (forces 2FA before app access)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "lucide-react": "^0.544.0",
     "next": "16.0.7",
     "next-themes": "^0.4.6",
+    "qrcode": "^1.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "recharts": "^2.15.4",

--- a/apps/web/src/app/totp-setup/page.jsx
+++ b/apps/web/src/app/totp-setup/page.jsx
@@ -1,0 +1,40 @@
+/**
+ * /totp-setup — TOTP enrolment gate for users who don't yet have 2FA.
+ *
+ * Mirrors /onboarding's shape: top-level route, AuthGuard wrapper, no
+ * AppShell, no hub theme. Renders outside the app chrome because the
+ * user can't meaningfully reach any hub yet — the AuthGuard traps
+ * them here until they enrol.
+ *
+ * The guard's logic detects pathname === "/totp-setup" and SKIPS the
+ * "redirect to /totp-setup" step that fires elsewhere, avoiding a
+ * redirect loop. Pattern matches /onboarding.
+ *
+ * Why this comes BEFORE /onboarding in the auth chain: establishing
+ * 2FA before collecting PII (department, employee id, hub picks)
+ * means a hijacked password can't read or write that information,
+ * which is the whole point of the second factor.
+ */
+
+import { AuthGuard } from "@/features/auth";
+import { TotpSetupForm } from "@/features/auth";
+
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+  return (
+    <AuthGuard>
+      <main
+        style={{
+          minHeight: "100vh",
+          background: "var(--bg)",
+          color: "var(--fg)",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <TotpSetupForm />
+      </main>
+    </AuthGuard>
+  );
+}

--- a/apps/web/src/features/auth/auth-guard.jsx
+++ b/apps/web/src/features/auth/auth-guard.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * Auth + onboarding gate for protected pages.
+ * Auth + TOTP-enrolment + onboarding gate for protected pages.
  *
  * Behaviour
  *   NEXT_PUBLIC_AUTH_REQUIRED=false (default) → renders children as-is,
@@ -11,16 +11,23 @@
  *   NEXT_PUBLIC_AUTH_REQUIRED=true →
  *     1. while loading initial /me, render a placeholder
  *     2. no session OR partial session (needsTotp) → redirect to /login
- *     3. authenticated but onboarding incomplete → redirect to /onboarding
- *     4. otherwise render children
+ *     3. authenticated but TOTP not enrolled → redirect to /totp-setup
+ *     4. authenticated + TOTP enrolled but onboarding incomplete →
+ *        redirect to /onboarding
+ *     5. otherwise render children
  *
- * The /login page and /onboarding page intentionally do NOT wrap
- * themselves in AuthGuard's full chain to avoid redirect loops:
+ * Order matters: TOTP comes BEFORE onboarding so we establish 2FA
+ * before the user enters profile / PII fields. A hijacked password
+ * shouldn't be able to read or write that information.
+ *
+ * Trap-pages skip their own redirect step to avoid loops:
  *   - /login skips AuthGuard entirely
- *   - /onboarding wraps in AuthGuard but its own `OnboardingPage` is
- *     a no-op for the onboarding-incomplete branch (since we'd be
- *     redirecting to where we already are). We detect "the page is
- *     /onboarding" and skip the onboarding-redirect step.
+ *   - /totp-setup wraps in AuthGuard; the totp-enrol-redirect step
+ *     no-ops when pathname is /totp-setup
+ *   - /onboarding wraps in AuthGuard; the onboarding-redirect step
+ *     no-ops when pathname is /onboarding (but the totp gate still
+ *     fires — a user who's on /onboarding without TOTP enrolled
+ *     gets bounced to /totp-setup, which is correct)
  */
 
 import { useEffect } from "react";
@@ -31,6 +38,7 @@ const AUTH_REQUIRED =
   typeof process !== "undefined" &&
   process.env.NEXT_PUBLIC_AUTH_REQUIRED === "true";
 
+const TOTP_SETUP_PATH = "/totp-setup";
 const ONBOARDING_PATH = "/onboarding";
 
 export function AuthGuard({ children, fallback = null }) {
@@ -41,14 +49,30 @@ export function AuthGuard({ children, fallback = null }) {
   const needsLoginRedirect =
     AUTH_REQUIRED && !loading && (!user || needsTotp);
 
-  // M-OB gate: authenticated but onboarding never completed →
-  // route to /onboarding. Skip when we're ALREADY on /onboarding to
-  // avoid a redirect loop.
+  // 2FA gate: authenticated but the user has no TOTP secret on file →
+  // trap them at /totp-setup. The session is fully verified at the
+  // server level (totpVerified: true was set at login because there
+  // was nothing to verify), but app access still requires enrolment
+  // by policy. Skip when we're ALREADY on /totp-setup to avoid a
+  // redirect loop.
+  const needsTotpSetupRedirect =
+    AUTH_REQUIRED &&
+    !loading &&
+    !!user &&
+    !needsTotp &&
+    !user.totpEnrolled &&
+    pathname !== TOTP_SETUP_PATH;
+
+  // M-OB gate: authenticated, TOTP enrolled, but onboarding never
+  // completed → route to /onboarding. Skip when we're ALREADY on
+  // /onboarding. The TOTP gate above takes precedence so a user
+  // who's not enrolled gets bounced to /totp-setup first.
   const needsOnboardingRedirect =
     AUTH_REQUIRED &&
     !loading &&
     !!user &&
     !needsTotp &&
+    !!user.totpEnrolled &&
     !user.onboardingCompletedAt &&
     pathname !== ONBOARDING_PATH;
 
@@ -62,14 +86,25 @@ export function AuthGuard({ children, fallback = null }) {
       router.replace(target);
       return;
     }
+    if (needsTotpSetupRedirect) {
+      router.replace(TOTP_SETUP_PATH);
+      return;
+    }
     if (needsOnboardingRedirect) {
       router.replace(ONBOARDING_PATH);
     }
-  }, [needsLoginRedirect, needsOnboardingRedirect, pathname, router]);
+  }, [
+    needsLoginRedirect,
+    needsTotpSetupRedirect,
+    needsOnboardingRedirect,
+    pathname,
+    router,
+  ]);
 
   if (!AUTH_REQUIRED) return children;
   if (loading) return fallback ?? <AuthLoading />;
   if (!user || needsTotp) return fallback ?? <AuthLoading />;
+  if (needsTotpSetupRedirect) return fallback ?? <AuthLoading />;
   if (needsOnboardingRedirect) return fallback ?? <AuthLoading />;
   return children;
 }

--- a/apps/web/src/features/auth/index.js
+++ b/apps/web/src/features/auth/index.js
@@ -7,6 +7,7 @@
  *   <AcceptInviteForm>           — used by /accept-invite page
  *   <PasswordResetRequestForm>   — used by /forgot-password page
  *   <PasswordResetForm>          — used by /password-reset?token=… page
+ *   <TotpSetupForm>              — used by /totp-setup page
  *   <AuthGuard>                  — wraps protected page contents
  *   <UserChip>                   — header chip showing the session user + logout
  *   <RequireCapability>          — gate child elements on a capability check
@@ -19,6 +20,7 @@ export { LoginForm } from "./login-form.jsx";
 export { AcceptInviteForm } from "./accept-invite-form.jsx";
 export { PasswordResetRequestForm } from "./password-reset-request-form.jsx";
 export { PasswordResetForm } from "./password-reset-form.jsx";
+export { TotpSetupForm } from "./totp-setup-form.jsx";
 export { AuthGuard } from "./auth-guard.jsx";
 export { UserChip } from "./user-chip.jsx";
 export {

--- a/apps/web/src/features/auth/totp-setup-form.jsx
+++ b/apps/web/src/features/auth/totp-setup-form.jsx
@@ -1,0 +1,385 @@
+"use client";
+
+/**
+ * TOTP enrolment form. Mounted at /totp-setup.
+ *
+ * Two-step ceremony:
+ *   1. On mount, POST /api/v1/auth/totp/enrol — server generates a
+ *      fresh base32 secret, encrypts + persists it as PENDING
+ *      (totpSecret set, totpEnrolledAt still null), and returns
+ *      { secret, otpauthUrl }.
+ *   2. The user scans the QR into their authenticator OR manually
+ *      types the secret. They submit the 6-digit code their app
+ *      generates. We POST /api/v1/auth/totp/verify-enrolment.
+ *      Server confirms the code matches and sets totpEnrolledAt.
+ *
+ * Why enrolment happens after the first login + before onboarding:
+ * a fresh user lands here with `totpVerified: true` (the session was
+ * minted that way because they had no TOTP at login), but the
+ * AuthGuard refuses to let them past until totpEnrolled flips true.
+ * Doing this BEFORE the onboarding profile fields means we
+ * establish 2FA before they hand over any PII.
+ *
+ * QR rendering uses the `qrcode` npm package client-side. The
+ * provisioning URL contains the user's email + the raw secret —
+ * it MUST NOT be sent to a third-party QR API (e.g. Google Charts).
+ * Local-only rendering keeps the secret inside the browser.
+ *
+ * Errors surfaced from the API:
+ *   totp_already_enrolled   → "TOTP is already set up — refresh."
+ *   invalid_state           → "Enrolment expired — restart."
+ *   invalid_totp_code       → "Code did not match. Try the next one."
+ *   network_error           → generic retry copy
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import QRCode from "qrcode";
+import { apiPost } from "@/lib/api-client";
+import { useSession } from "./use-session.js";
+
+const PHASE_LOADING = "loading";
+const PHASE_SHOW_SECRET = "show_secret";
+const PHASE_VERIFY = "verify";
+const PHASE_DONE = "done";
+
+export function TotpSetupForm() {
+  const { refresh } = useSession();
+  const [phase, setPhase] = useState(PHASE_LOADING);
+  const [secret, setSecret] = useState("");
+  const [otpauthUrl, setOtpauthUrl] = useState("");
+  const [qrDataUrl, setQrDataUrl] = useState("");
+  const [code, setCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const startedRef = useRef(false);
+
+  // Kick off enrolment once on mount. Strict-mode would double-fire
+  // useEffect in dev — `startedRef` makes the second call a no-op so
+  // we don't generate two pending secrets on the server (the second
+  // /enrol call would overwrite the first, which is harmless but
+  // confuses the audit log).
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    (async () => {
+      const r = await apiPost("/auth/totp/enrol", {});
+      if (!r.ok) {
+        setError(humanise(r.error));
+        setPhase(PHASE_VERIFY); // give the user a path forward via the input
+        return;
+      }
+      setSecret(r.data?.secret ?? "");
+      setOtpauthUrl(r.data?.otpauthUrl ?? "");
+      setPhase(PHASE_SHOW_SECRET);
+    })();
+  }, []);
+
+  // Render the QR client-side from the otpauth URL. The URL contains
+  // the user's email + raw secret — sending it to a third-party QR
+  // service would leak the secret, so the encoding happens in the
+  // browser only.
+  useEffect(() => {
+    if (!otpauthUrl) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const dataUrl = await QRCode.toDataURL(otpauthUrl, {
+          errorCorrectionLevel: "M",
+          margin: 1,
+          width: 220,
+          color: { dark: "#0b0b0c", light: "#ffffff" },
+        });
+        if (!cancelled) setQrDataUrl(dataUrl);
+      } catch {
+        // QR rendering failure is non-fatal — the secret + URL fall back
+        // panels still let the user finish enrolment via manual entry.
+        if (!cancelled) setQrDataUrl("");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [otpauthUrl]);
+
+  async function handleVerify(e) {
+    e.preventDefault();
+    setError(null);
+    if (code.length !== 6) {
+      setError("Enter the 6-digit code from your authenticator app.");
+      return;
+    }
+    setSubmitting(true);
+    const r = await apiPost("/auth/totp/verify-enrolment", { code });
+    setSubmitting(false);
+    if (!r.ok) {
+      setError(humanise(r.error));
+      setCode("");
+      return;
+    }
+    // Refresh the session so user.totpEnrolled flips to true →
+    // AuthGuard's next render lets the user proceed.
+    await refresh();
+    setPhase(PHASE_DONE);
+    toast.success("Two-factor enabled.");
+  }
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col gap-6 py-12">
+      <Header phase={phase} />
+
+      {phase === PHASE_LOADING ? (
+        <LoadingPanel />
+      ) : phase === PHASE_DONE ? (
+        <DonePanel />
+      ) : (
+        <>
+          {phase === PHASE_SHOW_SECRET ? (
+            <SecretPanel qrDataUrl={qrDataUrl} secret={secret} />
+          ) : null}
+
+          <form
+            onSubmit={handleVerify}
+            className="flex flex-col gap-3"
+          >
+            <CodeInput
+              value={code}
+              onChange={setCode}
+              disabled={submitting}
+            />
+
+            {error ? (
+              <div
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 11.5,
+                  color: "var(--bad)",
+                }}
+              >
+                {error}
+              </div>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={code.length !== 6 || submitting}
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 11,
+                fontWeight: 700,
+                letterSpacing: "0.5px",
+                textTransform: "uppercase",
+                background: "var(--accent)",
+                color: "var(--accent-on, #fff)",
+                border: 0,
+                borderRadius: "var(--radius-sub, 3px)",
+                padding: "12px 16px",
+                cursor: submitting ? "wait" : "pointer",
+                opacity: code.length === 6 && !submitting ? 1 : 0.6,
+              }}
+            >
+              {submitting ? "Verifying…" : "Verify & enable"}
+            </button>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Header({ phase }) {
+  const title =
+    phase === PHASE_DONE ? "Two-factor enabled." : "Set up two-factor.";
+  const subtitle =
+    phase === PHASE_DONE
+      ? "Your account now requires a 6-digit code at sign-in."
+      : "Required before you can use the app. Scan the QR with an authenticator app (1Password, Authy, Google Authenticator, etc.), then enter the 6-digit code it generates.";
+
+  return (
+    <div>
+      <h1
+        className="font-semibold"
+        style={{
+          fontFamily: "var(--font-display, var(--font-inter-tight))",
+          fontSize: 28,
+          letterSpacing: "-0.8px",
+        }}
+      >
+        {title}
+      </h1>
+      <p
+        className="mt-1 text-muted-fg"
+        style={{ fontSize: 13.5, lineHeight: 1.5 }}
+      >
+        {subtitle}
+      </p>
+    </div>
+  );
+}
+
+function LoadingPanel() {
+  return (
+    <div
+      className="text-muted-fg"
+      style={{ fontFamily: "var(--font-mono)", fontSize: 11.5 }}
+    >
+      Generating your secret…
+    </div>
+  );
+}
+
+function SecretPanel({ qrDataUrl, secret }) {
+  const formatted = useMemo(() => formatSecret(secret), [secret]);
+
+  return (
+    <div
+      className="flex flex-col items-center gap-4 rounded-md border bg-card p-5"
+      style={{ borderColor: "var(--border-strong)" }}
+    >
+      {qrDataUrl ? (
+        <img
+          src={qrDataUrl}
+          alt="TOTP QR code"
+          width={220}
+          height={220}
+          style={{
+            display: "block",
+            background: "#fff",
+            borderRadius: 4,
+          }}
+        />
+      ) : (
+        <div
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            color: "var(--muted-fg)",
+          }}
+        >
+          QR rendering failed — use manual entry below.
+        </div>
+      )}
+
+      <div className="w-full">
+        <div
+          className="mb-1 uppercase tracking-[0.4px] text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}
+        >
+          Manual entry secret
+        </div>
+        <code
+          className="block break-all rounded-sm border bg-card-alt px-3 py-2 text-fg"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 13,
+            letterSpacing: "0.6px",
+            borderColor: "var(--border)",
+          }}
+        >
+          {formatted}
+        </code>
+        <div
+          className="mt-1 text-muted-fg"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            letterSpacing: "0.3px",
+          }}
+        >
+          Algorithm: SHA-1 · 6 digits · 30-second period
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CodeInput({ value, onChange, disabled }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          letterSpacing: "0.5px",
+          color: "var(--muted-fg)",
+          textTransform: "uppercase",
+        }}
+      >
+        Code from your authenticator
+      </span>
+      <input
+        type="text"
+        inputMode="numeric"
+        autoComplete="one-time-code"
+        pattern="\d{6}"
+        maxLength={6}
+        value={value}
+        onChange={(e) => onChange(e.target.value.replace(/\D/g, ""))}
+        disabled={disabled}
+        autoFocus
+        required
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 18,
+          letterSpacing: "8px",
+          padding: "10px 14px",
+          textAlign: "center",
+          background: "var(--card)",
+          border: "1px solid var(--border-strong)",
+          borderRadius: "var(--radius-sub, 3px)",
+          outline: "none",
+        }}
+      />
+    </label>
+  );
+}
+
+function DonePanel() {
+  // The AuthGuard re-renders after the refresh() call, which routes
+  // the user onward (to /onboarding if their profile is incomplete,
+  // else to /). This panel is only briefly visible. We don't push
+  // router.replace() here because the guard's effect handles it —
+  // doing both would race.
+  return (
+    <div
+      className="rounded-md border bg-card p-4"
+      style={{ borderColor: "var(--border-strong)" }}
+    >
+      <p
+        className="text-fg"
+        style={{ fontSize: 13.5, lineHeight: 1.55 }}
+      >
+        Routing you to the next step…
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Pretty-print the base32 secret in groups of four for manual entry.
+ * Authenticator apps don't care about spacing — they strip whitespace —
+ * but humans typing a 32-char string benefit from chunking.
+ */
+function formatSecret(s) {
+  if (!s) return "";
+  return s.replace(/(.{4})/g, "$1 ").trim();
+}
+
+function humanise(err) {
+  if (!err) return "Something went wrong. Try again.";
+  if (err.code === "totp_already_enrolled")
+    return "Two-factor is already set up. Refresh the page to continue.";
+  if (err.code === "invalid_state")
+    return "Enrolment session expired. Refresh the page to restart.";
+  if (err.code === "invalid_totp_code")
+    return "Code did not match. Try the next one your app generates.";
+  if (err.code === "totp_secret_corrupted")
+    return "Stored secret couldn't be read. Refresh the page to start over.";
+  if (err.code === "rate_limited")
+    return "Too many attempts. Wait a moment and try again.";
+  if (err.code === "validation_error")
+    return err.message || "Code must be 6 digits.";
+  if (err.code === "network_error")
+    return "Couldn't reach the server. Check your connection and retry.";
+  return err.message || "Something went wrong. Try again.";
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "lucide-react": "^0.544.0",
         "next": "16.0.7",
         "next-themes": "^0.4.6",
+        "qrcode": "^1.5.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "recharts": "^2.15.4",
@@ -4432,6 +4433,15 @@
       "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
       "license": "MIT"
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001792",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
@@ -4911,6 +4921,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -4971,6 +4990,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
     "node_modules/dom-helpers": {
@@ -7457,6 +7482,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/postal-mime": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
@@ -7586,6 +7620,89 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -7882,6 +7999,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/resend": {
       "version": "6.12.3",
       "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
@@ -8073,6 +8196,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -8949,6 +9078,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/wmf": {
       "version": "1.0.2",


### PR DESCRIPTION
## Summary
Closes the security debt where users could reach every protected route without ever enrolling TOTP.

### The hole
Pre-fix flow:
1. Fresh user logs in with email + password
2. Server mints session with `totpVerified: true` (no TOTP to verify)
3. `requireAuth({requireTotp:true})` middleware passes
4. User has full access despite never proving 2FA

The middleware is correct — `totpVerified` is "this session passed the 2FA step it needed to" — but un-enrolled users had no 2FA step to pass, so the check became a no-op. Adding a separate "is the user even enrolled?" gate closes the hole.

## Approach
Mirrors the existing onboarding gate (M-OB) pattern at the AuthGuard layer.

```
AuthGuard order:
  1. unauthenticated / partial session    → /login
  2. authed AND !user.totpEnrolled        → /totp-setup    ← NEW
  3. authed AND totpEnrolled AND
     !user.onboardingCompletedAt          → /onboarding
  4. else render children
```

**TOTP comes BEFORE onboarding** by policy: a hijacked password shouldn't be able to read or write the onboarding PII (department, employee id, hub picks). Establish 2FA first.

## `/totp-setup` page
Top-level route, sibling of `/onboarding`. Wraps in AuthGuard. The guard's totp-redirect step no-ops when pathname is `/totp-setup` (same loop-prevention pattern as `/onboarding`).

**Three-phase ceremony**:
1. **loading**: on mount, `POST /api/v1/auth/totp/enrol` → server generates a fresh base32 secret, encrypts it, persists as PENDING (`totpSecret` set, `totpEnrolledAt` still null), returns `{ secret, otpauthUrl }`.
2. **show_secret**: render QR client-side from the otpauth URL (via `qrcode` package, 220×220, errorCorrection=M) PLUS the base32 secret in 4-char-grouped mono font for manual entry. The provisioning URL contains the user's email + raw secret — it MUST stay in-browser; sending it to a third-party QR API would leak the secret. Local rendering keeps it inside the browser.
3. **verify**: 6-digit numeric input → `POST /totp/verify-enrolment` → server validates against the pending secret, sets `totpEnrolledAt`. Frontend calls `refresh()` so `user.totpEnrolled` flips true → AuthGuard's next render routes the user onward.

Strict-mode `useEffect` double-fires the initial `/enrol` call in dev; a `startedRef` makes the second call a no-op so we don't generate two pending secrets in the audit log.

## Dependency
Adds **`qrcode`** (~30KB, pure JS, no native bindings) to the web workspace. Standard canonical library for the encoding. No third-party rendering API used.

## What this does NOT do (deferred)
- **Backup codes** — single-use recovery codes for the lost-phone case. UI + endpoint land separately.
- **Server-side enforcement at the API layer.** Today this is a CLIENT gate (matches existing M-OB pattern). A determined attacker calling the API directly could still hit protected routes. Closing that requires a new `requireTotpEnrolled` flag on the session document; tracked for a follow-up because it touches every auth call site.
- **TOTP-reset path** for users who lose their authenticator. Today the only escape would be admin reset, which doesn't yet exist (#53 stopped short of `POST /admin/users/:id/totp/reset`).

## Files
- `apps/web/src/features/auth/totp-setup-form.jsx` (new)
- `apps/web/src/app/totp-setup/page.jsx` (new)
- `apps/web/src/features/auth/auth-guard.jsx` (add TOTP step + reorder comment)
- `apps/web/src/features/auth/index.js` (export form)
- `apps/web/package.json` + `package-lock.json` (qrcode dep)

Verified: `next build --experimental-build-mode=compile` clean. `/totp-setup` route appears in the manifest.

## Test plan
- [x] Compile clean; `/totp-setup` in route manifest
- [ ] Fresh user logs in (no TOTP) → bounced to `/totp-setup`
- [ ] QR renders within ~1s; secret shown in chunked mono font
- [ ] Scan QR with 1Password / Authy / Google Authenticator → 6-digit code appears in the app
- [ ] Enter wrong code → "Code did not match" inline; input clears
- [ ] Enter correct code → success toast → routed to `/onboarding` (if profile incomplete) or `/` (if complete)
- [ ] Future logins: TOTP step appears (`needsTotp: true`)
- [ ] Bypass attempt: typing `/` or `/admin` in the URL while un-enrolled → bounced back to `/totp-setup`
- [ ] `/login` itself unaffected — un-enrolled users still reach it
- [ ] `next build` (turbopack full build, not just compile) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)