### PR TITLE
feat: admin invite UI + TOTP reset (M-CAP follow-up)

### DIFF
--- a/apps/api/src/modules/admin/controller.ts
+++ b/apps/api/src/modules/admin/controller.ts
@@ -383,6 +383,110 @@ export async function updateUserHandler(
   }
 }
 
+// ─── POST /api/v1/admin/users/:id/totp/reset ─────────────────────────
+
+/**
+ * Admin-side TOTP reset. Clears the target user's totpSecret and
+ * totpEnrolledAt so they re-enrol on next login (the AuthGuard's
+ * client-side gate traps them at /totp-setup until they re-enrol;
+ * post-#2 the server will also enforce this).
+ *
+ * Use case: a user lost their phone / authenticator app and can no
+ * longer pass the second factor. They contact an admin, who confirms
+ * identity out-of-band (in person, video call, etc.) and runs this
+ * reset. The next login skips the TOTP step (because totpEnrolledAt
+ * is now null) — they go straight into the enrol flow.
+ *
+ * Self-protection: an admin cannot reset their OWN TOTP via this
+ * endpoint. If they need to, they call /auth/totp/disable (which
+ * requires a current code) or have ANOTHER admin do it. This
+ * prevents a hijacked admin session from neutering its own 2FA on
+ * the spot — the attacker would need a second compromised admin.
+ *
+ * No body required. The :id path param identifies the target user.
+ *
+ * Audit: writes `user.totp_reset_by_admin` with before/after = the
+ * old totpEnrolledAt timestamp (null after).
+ */
+export async function resetUserTotpHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const targetId = requireUserId(req);
+
+    if (targetId.equals(session.userId)) {
+      throw new HttpError(
+        400,
+        "self_lockout",
+        "You can't reset your own TOTP via the admin endpoint. Use /auth/totp/disable (requires a current code), or have another admin do it.",
+      );
+    }
+
+    const col = await getUsersCollection();
+    const target = await col.findOne({
+      _id: targetId,
+      orgId: session.orgId,
+    });
+    if (!target) {
+      throw new HttpError(404, "not_found", "User not found in this org.");
+    }
+
+    // If the user has nothing to reset, return 200 anyway — the admin's
+    // intent is "make sure TOTP is off for this user" and that's
+    // already the case. Idempotent.
+    if (target.totpSecret === null && target.totpEnrolledAt === null) {
+      res.json({ user: toPublicUser(target), reset: false });
+      return;
+    }
+
+    const now = new Date();
+    const updated = await col.findOneAndUpdate(
+      { _id: targetId, orgId: session.orgId },
+      {
+        $set: {
+          totpSecret: null,
+          totpEnrolledAt: null,
+          updatedAt: now,
+        },
+      },
+      { returnDocument: "after" },
+    );
+    if (!updated) {
+      throw new HttpError(
+        500,
+        "internal_error",
+        "TOTP reset returned no document.",
+      );
+    }
+
+    await writeAudit({
+      orgId: session.orgId,
+      actorUserId: session.userId,
+      actorRole: session.role,
+      action: "user.totp_reset_by_admin",
+      targetType: "user",
+      targetId: targetId.toHexString(),
+      before: {
+        totpEnrolledAt: target.totpEnrolledAt
+          ? target.totpEnrolledAt.toISOString()
+          : null,
+      },
+      after: { totpEnrolledAt: null },
+      ...networkMeta(req),
+    });
+
+    res.json({ user: toPublicUser(updated), reset: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
 // ─── GET /api/v1/admin/audit ─────────────────────────────────────────
 
 export async function listAuditHandler(

--- a/apps/api/src/modules/admin/routes.ts
+++ b/apps/api/src/modules/admin/routes.ts
@@ -1,10 +1,13 @@
 /**
  * /api/v1/admin/* router.
  *
- *   GET   /users           admin: list every user in the org
- *   PATCH /users/:id       admin: edit roles/status/hubs/displayName
+ *   GET   /users                       admin: list every user in the org
+ *   PATCH /users/:id                   admin: edit roles/status/hubs/displayName
+ *   POST  /users/:id/totp/reset        admin: clear a user's TOTP enrolment
+ *                                       (admin-side recovery for lost
+ *                                       authenticators; not allowed on self)
  *
- *   GET   /audit           admin: filterable audit-log feed
+ *   GET   /audit                       admin: filterable audit-log feed
  *
  * Authorization: every route requires a full session AND the admin
  * role. Same pattern hub-configs follows. Audit-log read intentionally
@@ -20,6 +23,7 @@ import { requireRole } from "../../middleware/require-role.js";
 import {
   listAuditHandler,
   listUsersHandler,
+  resetUserTotpHandler,
   updateUserHandler,
 } from "./controller.js";
 
@@ -36,6 +40,12 @@ adminRouter.patch(
   requireAuth(),
   requireRole("admin"),
   updateUserHandler,
+);
+adminRouter.post(
+  "/users/:id/totp/reset",
+  requireAuth(),
+  requireRole("admin"),
+  resetUserTotpHandler,
 );
 
 adminRouter.get(

--- a/apps/web/src/hubs/admin/admin-users.jsx
+++ b/apps/web/src/hubs/admin/admin-users.jsx
@@ -29,7 +29,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import { apiGet, apiPatch } from "@/lib/api-client";
+import { apiGet, apiPatch, apiPost } from "@/lib/api-client";
 import { useSession } from "@/features/auth";
 import { CAPABILITIES } from "@espace-devhub/shared/capabilities";
 import { HUB_ORDER } from "@espace-devhub/shared/hubs";
@@ -45,10 +45,20 @@ export function AdminUsers() {
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [openUserId, setOpenUserId] = useState(null);
+  const [inviteOpen, setInviteOpen] = useState(false);
 
   const canManage = sessionUser?.capabilities?.includes(
     CAPABILITIES.ADMIN_USERS_MANAGE,
   );
+
+  async function reloadUsers() {
+    const r = await apiGet("/admin/users");
+    if (!r.ok) {
+      toast.error(r.error?.message || "Couldn't load users.");
+      return;
+    }
+    setUsers(r.data?.users ?? []);
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -74,6 +84,11 @@ export function AdminUsers() {
     );
   }
 
+  function handleInviteSuccess() {
+    setInviteOpen(false);
+    void reloadUsers();
+  }
+
   if (!canManage) {
     return (
       <main className="mx-auto max-w-3xl px-10 py-12">
@@ -88,30 +103,46 @@ export function AdminUsers() {
 
   return (
     <main className="relative z-[2] mx-auto max-w-5xl px-10 pb-14 pt-10">
-      <header className="mb-8">
-        <div
-          className="mb-2 uppercase tracking-[0.5px] text-muted-fg"
-          style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
-        >
-          Admin · user management
+      <header className="mb-8 flex items-start justify-between gap-6">
+        <div>
+          <div
+            className="mb-2 uppercase tracking-[0.5px] text-muted-fg"
+            style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+          >
+            Admin · user management
+          </div>
+          <h1
+            className="font-semibold"
+            style={{
+              fontFamily: "var(--font-display)",
+              fontSize: 28,
+              letterSpacing: "-0.5px",
+            }}
+          >
+            Members of your org.
+          </h1>
+          <p className="mt-2 max-w-2xl text-[13.5px] leading-[1.55] text-muted-fg">
+            Click a row to edit roles, status, and hub access. Changes
+            take effect on the user&apos;s next request — they don&apos;t
+            need to log out. Self-edits can&apos;t strip your own admin
+            role or disable your own account.
+          </p>
         </div>
-        <h1
-          className="font-semibold"
-          style={{
-            fontFamily: "var(--font-display)",
-            fontSize: 28,
-            letterSpacing: "-0.5px",
-          }}
+        <button
+          type="button"
+          onClick={() => setInviteOpen(true)}
+          style={primaryButtonStyle}
         >
-          Members of your org.
-        </h1>
-        <p className="mt-2 max-w-2xl text-[13.5px] leading-[1.55] text-muted-fg">
-          Click a row to edit roles, status, and hub access. Changes
-          take effect on the user&apos;s next request — they don&apos;t
-          need to log out. Self-edits can&apos;t strip your own admin
-          role or disable your own account.
-        </p>
+          + Invite user
+        </button>
       </header>
+
+      {inviteOpen ? (
+        <InviteDialog
+          onClose={() => setInviteOpen(false)}
+          onSuccess={handleInviteSuccess}
+        />
+      ) : null}
 
       {loading ? (
         <div
@@ -294,6 +325,33 @@ function UserEditor({ user, isSelf, onUpdate }) {
     toast.success(`Saved ${r.data?.user?.displayName || "user"}.`);
   }
 
+  // Admin-side TOTP reset. Only relevant when the target user has
+  // TOTP enrolled (otherwise the operation is a no-op and the button
+  // is hidden). Forbidden on self — the server rejects too, but we
+  // hide the button to make that clear without round-tripping.
+  async function handleResetTotp() {
+    if (
+      !window.confirm(
+        `Reset TOTP for ${user.displayName}?\n\nTheir authenticator app will stop working. On their next sign-in they'll be walked through enrolment again. Confirm out-of-band (in person, video call) that this is really them.`,
+      )
+    ) {
+      return;
+    }
+    setSaving(true);
+    const r = await apiPost(`/admin/users/${user.id}/totp/reset`, {});
+    setSaving(false);
+    if (!r.ok) {
+      toast.error(r.error?.message || "Couldn't reset TOTP.");
+      return;
+    }
+    onUpdate(r.data?.user);
+    if (r.data?.reset === false) {
+      toast.info(`${user.displayName} already had no TOTP enrolled.`);
+    } else {
+      toast.success(`TOTP reset for ${user.displayName}.`);
+    }
+  }
+
   return (
     <div
       className="border-t px-5 py-5"
@@ -398,29 +456,49 @@ function UserEditor({ user, isSelf, onUpdate }) {
         </Field>
       </div>
 
-      <div className="mt-6 flex items-center justify-between">
+      <div className="mt-6 flex items-center justify-between gap-4">
         <UserMeta user={user} />
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={!dirty || saving}
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-            fontWeight: 700,
-            letterSpacing: "0.5px",
-            textTransform: "uppercase",
-            background: "var(--accent)",
-            color: "var(--accent-on, #fff)",
-            border: 0,
-            borderRadius: "var(--radius-sub, 3px)",
-            padding: "9px 16px",
-            cursor: saving ? "wait" : dirty ? "pointer" : "default",
-            opacity: dirty && !saving ? 1 : 0.5,
-          }}
-        >
-          {saving ? "Saving…" : dirty ? "Save changes" : "No changes"}
-        </button>
+        <div className="flex items-center gap-2">
+          {/* Reset-TOTP — only shown when the user actually has TOTP
+              enrolled (no point offering a no-op) and never on self
+              (server-side guarded too). */}
+          {user.hasTotp && !isSelf ? (
+            <button
+              type="button"
+              onClick={handleResetTotp}
+              disabled={saving}
+              style={{
+                ...dangerButtonStyle,
+                opacity: saving ? 0.55 : 1,
+                cursor: saving ? "wait" : "pointer",
+              }}
+              title="Clears the user's TOTP secret. They'll re-enrol on next sign-in."
+            >
+              Reset TOTP
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!dirty || saving}
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: "0.5px",
+              textTransform: "uppercase",
+              background: "var(--accent)",
+              color: "var(--accent-on, #fff)",
+              border: 0,
+              borderRadius: "var(--radius-sub, 3px)",
+              padding: "9px 16px",
+              cursor: saving ? "wait" : dirty ? "pointer" : "default",
+              opacity: dirty && !saving ? 1 : 0.5,
+            }}
+          >
+            {saving ? "Saving…" : dirty ? "Save changes" : "No changes"}
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -532,6 +610,259 @@ const inputStyle = {
   borderRadius: "var(--radius-sub, 3px)",
   outline: "none",
 };
+
+const primaryButtonStyle = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: "0.5px",
+  textTransform: "uppercase",
+  background: "var(--accent)",
+  color: "var(--accent-on, #fff)",
+  border: 0,
+  borderRadius: "var(--radius-sub, 3px)",
+  padding: "9px 16px",
+  cursor: "pointer",
+};
+
+const ghostButtonStyle = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: "0.5px",
+  textTransform: "uppercase",
+  background: "transparent",
+  color: "var(--fg)",
+  border: "1px solid var(--border-strong)",
+  borderRadius: "var(--radius-sub, 3px)",
+  padding: "9px 16px",
+  cursor: "pointer",
+};
+
+const dangerButtonStyle = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: "0.5px",
+  textTransform: "uppercase",
+  background: "transparent",
+  color: "var(--bad, #b91c1c)",
+  border: "1px solid var(--bad, #b91c1c)",
+  borderRadius: "var(--radius-sub, 3px)",
+  padding: "7px 12px",
+  cursor: "pointer",
+};
+
+/**
+ * Invite-user dialog. Lightweight modal — backdrop blocks pointer
+ * events on the underlying list so an accidental click outside the
+ * dialog is treated as "cancel". Form posts to /api/v1/auth/invite
+ * (the same endpoint admin-invite-from-CLI uses; admin-side UI just
+ * wires a friendlier surface to it).
+ *
+ * Server enforces:
+ *   - email uniqueness within the org (409 user_already_active if
+ *     the address already maps to an active/disabled user; re-invites
+ *     of `invited`-status users are allowed and re-mint the token)
+ *   - admin role on the caller (guarded by the route's requireRole)
+ *
+ * The form mirrors the inviteSchema on the server: email + displayName
+ * required, multi-select roles, defaults to one role checked ("dev")
+ * because every invitee needs at least one role.
+ */
+function InviteDialog({ onClose, onSuccess }) {
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [roles, setRoles] = useState(["dev"]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  function toggleRole(roleId) {
+    setRoles((prev) => {
+      const has = prev.includes(roleId);
+      if (has) {
+        if (prev.length === 1) return prev; // can't drop the last
+        return prev.filter((r) => r !== roleId);
+      }
+      return [...prev, roleId];
+    });
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+    if (!email.trim() || !displayName.trim() || roles.length === 0) {
+      setError("Email, name, and at least one role are required.");
+      return;
+    }
+    setSubmitting(true);
+    // The inviteSchema accepts both legacy `role` + new `roles`. Send
+    // both: server keeps `role` (= roles[0]) in lockstep until the
+    // singular column is removed.
+    const r = await apiPost("/auth/invite", {
+      email: email.trim().toLowerCase(),
+      role: roles[0],
+      roles,
+      displayName: displayName.trim(),
+    });
+    setSubmitting(false);
+    if (!r.ok) {
+      setError(humaniseInviteError(r.error));
+      return;
+    }
+    toast.success(`Invite sent to ${email.trim().toLowerCase()}.`);
+    onSuccess();
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.45)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 50,
+      }}
+      onClick={(e) => {
+        // Click outside the inner card → close. Don't close when the
+        // form itself bubbles a click up to the backdrop.
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-md border bg-card p-6"
+        style={{
+          borderColor: "var(--border-strong)",
+          width: 460,
+          maxWidth: "92vw",
+        }}
+      >
+        <div
+          className="mb-4 uppercase tracking-[0.5px] text-muted-fg"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+        >
+          Invite new user
+        </div>
+        <h2
+          className="mb-4 font-semibold"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: 20,
+            letterSpacing: "-0.4px",
+          }}
+        >
+          They&apos;ll get an email with a one-time setup link.
+        </h2>
+
+        <div className="flex flex-col gap-4">
+          <Field label="Email">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={submitting}
+              autoFocus
+              required
+              placeholder="name@example.com"
+              style={inputStyle}
+            />
+          </Field>
+          <Field label="Display name">
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              disabled={submitting}
+              required
+              placeholder="Full name as they should appear"
+              style={inputStyle}
+            />
+          </Field>
+          <div>
+            <FieldLabel>Roles</FieldLabel>
+            <p
+              className="mt-1 text-muted-fg"
+              style={{ fontSize: 11.5, lineHeight: 1.5 }}
+            >
+              They can hold multiple. Capabilities are the union across
+              roles. Adjust later from the row editor.
+            </p>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {ALL_ROLES.map((r) => {
+                const checked = roles.includes(r);
+                const disabled =
+                  submitting || (roles.length === 1 && checked);
+                return (
+                  <Pill
+                    key={r}
+                    checked={checked}
+                    disabled={disabled}
+                    onClick={() => toggleRole(r)}
+                  >
+                    {r}
+                  </Pill>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {error ? (
+          <div
+            className="mt-4"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11.5,
+              color: "var(--bad)",
+            }}
+          >
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-6 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            style={ghostButtonStyle}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            style={{
+              ...primaryButtonStyle,
+              opacity: submitting ? 0.6 : 1,
+              cursor: submitting ? "wait" : "pointer",
+            }}
+          >
+            {submitting ? "Sending…" : "Send invite"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function humaniseInviteError(err) {
+  if (!err) return "Something went wrong. Try again.";
+  if (err.code === "user_already_active")
+    return "An active or disabled user with that email already exists. Edit them from the list instead.";
+  if (err.code === "validation_error")
+    return err.message || "Check the fields and try again.";
+  if (err.code === "rate_limited")
+    return "Too many invites from this network. Wait a moment and retry.";
+  if (err.code === "network_error")
+    return "Couldn't reach the server. Check your connection and try again.";
+  return err.message || "Something went wrong. Try again.";
+}
 
 function sameArray(a, b) {
   if (!Array.isArray(a) || !Array.isArray(b)) return a === b;


### PR DESCRIPTION
## Summary
Closes the "admin needs to onboard people" loop that was previously bottlenecked on mongosh-style `db.users.insertOne`. Wires the existing `POST /api/v1/auth/invite` endpoint into a real dialog, and adds the TOTP-reset escape hatch admins need when a user loses their phone.

## API — new endpoint
`POST /api/v1/admin/users/:id/totp/reset`
- Clears target user's `totpSecret` + `totpEnrolledAt`. Next login skips the TOTP step; the AuthGuard's client gate traps them at `/totp-setup` until they re-enrol.
- **Idempotent**: target already has both null → 200 + `reset: false`, no audit row.
- **Self-protection**: admin can't reset own TOTP (would let a hijacked session neuter its own 2FA). Self-reset goes through `/auth/totp/disable` (needs current code) or another admin. Mirrors the PATCH endpoint's self-lockout guard.
- Audit row: `user.totp_reset_by_admin` with before/after = old `totpEnrolledAt`.

## Frontend

### Invite dialog
**`+ Invite user`** button on `/admin/users` header → modal with:
- `email` (required)
- `displayName` (required)
- `roles` multi-toggle pills (defaults `["dev"]`, can't drop to empty)

On submit, POSTs to `/auth/invite`. Server handles:
- 409 on existing active/disabled email with that address
- Re-mints token for an existing `invited`-status row (no duplicate user creation)
- Sends the invite email with `/accept-invite?token=…`

Closes the dialog on success + reloads users list so the new invitee appears immediately (status: `invited`).

Errors humanised — `user_already_active` becomes a clear "Edit them from the list instead" instead of the raw API code.

### Reset-TOTP button
On the expanded user editor — danger styling (red border + text). Visible only when **both**:
- `user.hasTotp === true` (no point offering a no-op)
- `!isSelf` (server rejects self-reset; hide locally too)

`window.confirm()` copy explicitly tells admins to verify identity out-of-band before resetting — the whole point of TOTP is that a password compromise alone can't impersonate the user; an admin who rubber-stamps a reset request without confirming identity re-introduces that risk.

## Files
- `apps/api/src/modules/admin/controller.ts` (+`resetUserTotpHandler`)
- `apps/api/src/modules/admin/routes.ts` (mount `POST .../totp/reset`)
- `apps/web/src/hubs/admin/admin-users.jsx` (`InviteDialog` + reset button + handlers)

Verified: `tsc --noEmit` clean (api); `next build --experimental-build-mode=compile` clean (web).

## Deferred
- **Hard-delete user** (`DELETE /admin/users/:id`) — soft-delete via PATCH `status=disabled` already covers the operational need; hard-delete would orphan audit-log refs.
- **Admin-side password reset** — today users use self-serve `/forgot-password`; if that's blocked (wrong email on file) the admin can PATCH the email and the user retries.

## Test plan
- [x] Compile clean (api + web)
- [ ] As admin: click "+ Invite user" → dialog opens; email + name required, roles default `[dev]`
- [ ] Submit with valid fields → toast confirms, dialog closes, new row appears with status `invited`
- [ ] Submit with an email that already exists (active) → inline error: "...already exists. Edit them from the list instead."
- [ ] Submit with an `invited`-status email → re-mints token (verifiable in `auth_tokens` collection), no error
- [ ] Resend an invite by re-running with same email → token rotates
- [ ] Expand any other user row → "Reset TOTP" button visible only when their `hasTotp` chip says enrolled
- [ ] Expand own row → no "Reset TOTP" button (self-guard)
- [ ] Click Reset TOTP on a user → window.confirm fires → on OK, toast confirms → row's metadata flips to "no TOTP"
- [ ] Audit log shows `user.totp_reset_by_admin` entry with before/after diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)