### PR TITLE
fix(admin): source hub-config integration toggles from shared registry

### DIFF
--- a/apps/web/src/hubs/admin/admin-hub-config.jsx
+++ b/apps/web/src/hubs/admin/admin-hub-config.jsx
@@ -26,8 +26,14 @@ import { toast } from "sonner";
 import { apiDelete, apiGet, apiPut } from "@/lib/api-client";
 import { useSession } from "@/features/auth";
 import { CAPABILITIES } from "@espace-devhub/shared/capabilities";
+import { ALL_PROVIDERS } from "@espace-devhub/shared/hubs";
 
-const ALL_INTEGRATIONS = ["github", "gitlab", "jira"];
+// Source the integration list from the shared registry so adding
+// a new provider (e.g. PR A's `jenkins`, the imminent `zephyr`,
+// future zoho/etc.) automatically appears as a togglable pill in
+// the admin hub-config UI. Hardcoding here was the bug that hid
+// jenkins from QA hub config after PR A merged.
+const ALL_INTEGRATIONS = [...ALL_PROVIDERS];
 
 export function AdminHubConfig() {
   const { user } = useSession();


### PR DESCRIPTION
## Summary
The admin \`/admin/hub-config\` UI hardcoded the togglable integration pills as \`["github", "gitlab", "jira"]\`. Adding a new provider to the shared registry (e.g. PR #59's \`jenkins\`, the upcoming \`zephyr\`) had no effect on the admin UI — the new provider never appeared as a toggle, even though the rest of the app saw it.

## Symptom
After PR #59 merged: on any org with an existing hub-config override for the QA hub, the override pinned \`allowedIntegrations: [github, gitlab, jira]\` and the admin UI offered no way to add \`jenkins\` because that pill didn't render. Net effect: jenkins stayed filtered out of \`/hubs/me\` until the override row was deleted directly from Mongo.

## Fix
Import \`ALL_PROVIDERS\` from \`@espace-devhub/shared/hubs\` and spread it into the local \`ALL_INTEGRATIONS\` array. Same call sites, no behaviour change other than the list growing automatically as we add providers.

## Test plan
- [x] \`next build --experimental-build-mode=compile\` clean
- [ ] As admin, visit /admin/hub-config → expand the QA hub row → all four pills (gitlab, github, jira, jenkins) appear; non-allowed ones styled muted
- [ ] Toggle jenkins on for the QA hub → /hubs/me response includes jenkins for that org
- [ ] No regression on dev hub config (still shows the same providers as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)