### PR TITLE
feat(qa): configurable Jira project key + Jenkins job name

### DIFF
--- a/apps/web/src/features/hubs/index.js
+++ b/apps/web/src/features/hubs/index.js
@@ -31,6 +31,10 @@ export { useActiveHub, useActiveHubStrict, HubContext } from "./hub-context.js";
 export { useHubLink } from "./use-hub-link.js";
 export { useHubSlotGuard } from "./use-hub-slot-guard.js";
 export { useAllowedProviders } from "./use-allowed-providers.js";
+export {
+  useQaHubConfig,
+  DEFAULT_QA_CONFIG,
+} from "./use-qa-hub-config.js";
 export { resetHubsStore } from "./hubs-store.js";
 export {
   getActivePick,

--- a/apps/web/src/features/hubs/use-qa-hub-config.js
+++ b/apps/web/src/features/hubs/use-qa-hub-config.js
@@ -1,0 +1,105 @@
+"use client";
+
+/**
+ * QA Hub config — per-user (per-browser) settings that govern which
+ * data sources the QA hub's widgets pull from:
+ *
+ *   - jiraProjectKey   which Jira project the defect widgets query
+ *                       (e.g. ESPQA, QA, BUG). Used by DefectsTile,
+ *                       DefectPriorityMixTile, and the JQL the QA
+ *                       linkage widget will mine in PR D.
+ *   - jenkinsJobName   which Jenkins job powers the automation-health
+ *                       tiles (FlakeRateTile, and the default
+ *                       selection for BuildPassRateTile).
+ *
+ * Storage:
+ *   localStorage under `eshub:qa:config:v1`. Matches the v0 storage
+ *   model — everything personal lives in the browser, nothing
+ *   crosses to the API. When we move QA Hub config to backend
+ *   persistence (later in the arc) the public hook surface stays
+ *   the same; only the read/write helpers swap.
+ *
+ * Reactivity:
+ *   Subscribers re-render on
+ *     - other tabs writing the same key (native `storage` event)
+ *     - same-tab calls to setConfig (custom `eshub:qa-config-changed`
+ *       event, dispatched from writeConfig — the native `storage`
+ *       event only fires on OTHER tabs)
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "eshub:qa:config:v1";
+const CHANGE_EVENT = "eshub:qa-config-changed";
+
+export const DEFAULT_QA_CONFIG = Object.freeze({
+  jiraProjectKey: "ESPQA",
+  jenkinsJobName: "qa-sim-target",
+});
+
+/** Read the persisted config, falling back to defaults on any error. */
+function readConfig() {
+  if (typeof window === "undefined") return { ...DEFAULT_QA_CONFIG };
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_QA_CONFIG };
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return { ...DEFAULT_QA_CONFIG };
+    // Spread defaults first so any newly-added field gets its default
+    // value when reading an older shape.
+    return { ...DEFAULT_QA_CONFIG, ...parsed };
+  } catch {
+    return { ...DEFAULT_QA_CONFIG };
+  }
+}
+
+/** Persist the config and notify same-tab + cross-tab subscribers. */
+function writeConfig(next) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
+  } catch {
+    // localStorage throws in private-browsing modes / over-quota.
+    // We swallow because the widgets fall back to defaults
+    // gracefully — no need to break the form's save action.
+  }
+}
+
+/**
+ * React hook. Returns `{ config, setConfig, resetConfig }`.
+ *
+ * `setConfig(patch)` does a shallow merge over the persisted object,
+ * so callers can update a single field without re-stating the others.
+ */
+export function useQaHubConfig() {
+  // Lazy init so we don't read localStorage during render-on-server.
+  const [config, setConfigState] = useState(() => readConfig());
+
+  useEffect(() => {
+    const sync = () => setConfigState(readConfig());
+    window.addEventListener("storage", sync);
+    window.addEventListener(CHANGE_EVENT, sync);
+    // SSR may have hydrated with defaults; re-read once on mount
+    // in case localStorage has a non-default value.
+    sync();
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(CHANGE_EVENT, sync);
+    };
+  }, []);
+
+  const setConfig = useCallback((patch) => {
+    const next = { ...readConfig(), ...patch };
+    writeConfig(next);
+    setConfigState(next);
+  }, []);
+
+  const resetConfig = useCallback(() => {
+    const next = { ...DEFAULT_QA_CONFIG };
+    writeConfig(next);
+    setConfigState(next);
+  }, []);
+
+  return { config, setConfig, resetConfig };
+}

--- a/apps/web/src/features/settings/settings-page.jsx
+++ b/apps/web/src/features/settings/settings-page.jsx
@@ -1,29 +1,54 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button, PageHeader } from "@/components/ui";
-import { useHubLink } from "@/features/hubs";
+import { useActiveHub, useHubLink } from "@/features/hubs";
 import { cn } from "@/lib/cn";
 import {
   AccountTab,
   DangerTab,
   IntegrationsTab,
   OnboardingTab,
+  QaConfigTab,
   SnapshotsPrefsTab,
 } from "./tabs";
 
-const TABS = [
+// `hubFilter` makes a tab hub-scoped — only shown when the active
+// hub's id matches. Tabs without `hubFilter` show for every hub.
+// This is how per-hub configuration (e.g. QA's project keys, future
+// Manager Hub roster picks) lives inside the shared SettingsPage
+// without sprouting per-hub conditional branches inside each tab.
+const ALL_TABS = [
   { id: "onboarding", label: "Onboarding", Component: OnboardingTab },
   { id: "integrations", label: "Integrations", Component: IntegrationsTab },
+  {
+    id: "qa-config",
+    label: "QA Hub config",
+    Component: QaConfigTab,
+    hubFilter: "qa",
+  },
   { id: "account", label: "Account", Component: AccountTab },
   { id: "snapshots", label: "Snapshots & privacy", Component: SnapshotsPrefsTab },
   { id: "danger", label: "Danger zone", Component: DangerTab },
 ];
 
 export function SettingsPage() {
+  const activeHub = useActiveHub();
+  const tabs = useMemo(
+    () =>
+      ALL_TABS.filter(
+        (t) => !t.hubFilter || (activeHub && t.hubFilter === activeHub.id),
+      ),
+    [activeHub],
+  );
+
   const [tab, setTab] = useState("onboarding");
-  const ActivePanel = TABS.find((t) => t.id === tab).Component;
+  // If the user lands on /qa/settings, then switches hub, the QA tab
+  // disappears — fall back to the first visible tab so we never try
+  // to render an undefined component.
+  const activeTab = tabs.find((t) => t.id === tab) ?? tabs[0];
+  const ActivePanel = activeTab.Component;
   const link = useHubLink();
 
   return (
@@ -42,8 +67,8 @@ export function SettingsPage() {
 
       <div className="grid grid-cols-[220px_minmax(0,1fr)] items-start gap-8">
         <nav className="sticky top-20 flex flex-col gap-0.5">
-          {TABS.map(({ id, label }) => {
-            const active = tab === id;
+          {tabs.map(({ id, label }) => {
+            const active = activeTab.id === id;
             return (
               <button
                 key={id}

--- a/apps/web/src/features/settings/tabs/index.js
+++ b/apps/web/src/features/settings/tabs/index.js
@@ -1,5 +1,6 @@
 export { OnboardingTab } from "./onboarding-tab";
 export { IntegrationsTab } from "./integrations-tab";
+export { QaConfigTab } from "./qa-config-tab";
 export { AccountTab } from "./account-tab";
 export { SnapshotsPrefsTab } from "./snapshots-prefs-tab";
 export { DangerTab } from "./danger-tab";

--- a/apps/web/src/features/settings/tabs/qa-config-tab.jsx
+++ b/apps/web/src/features/settings/tabs/qa-config-tab.jsx
@@ -1,0 +1,184 @@
+"use client";
+
+/**
+ * QA Hub config tab — exposed in /qa/settings only (the parent
+ * SettingsPage filters it out for other hubs). Lets the user pick:
+ *
+ *   - Jira project key   (which project the defect widgets query)
+ *   - Jenkins job name   (which job FlakeRateTile reads, and the
+ *                         default for BuildPassRateTile)
+ *
+ * Persistence + reactivity is delegated to useQaHubConfig. This tab
+ * just owns the form draft and the dirty/save mechanics.
+ *
+ * Why a per-hub config tab vs. baking it into IntegrationsTab:
+ *
+ *   IntegrationsTab is shared across all hubs and scoped to
+ *   provider-level concerns (which OAuth tokens you've connected).
+ *   QA Hub config is hub-shaped — Dev Hub doesn't need a Jira
+ *   project key because its widgets are user-scoped. Keeping the
+ *   two separate means we can add more per-hub tabs later (e.g. a
+ *   Manager Hub tab with team-roster picks) without IntegrationsTab
+ *   sprouting hub-conditional sections.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Button,
+  Card,
+  Field,
+  Input,
+  MonoLabel,
+  Section,
+} from "@/components/ui";
+import { DEFAULT_QA_CONFIG, useQaHubConfig } from "@/features/hubs";
+
+export function QaConfigTab() {
+  const { config, setConfig, resetConfig } = useQaHubConfig();
+  const [draft, setDraft] = useState(config);
+
+  // If the underlying config changes externally (other tab, or our
+  // own resetConfig call) re-seed the draft so the form doesn't show
+  // stale typed values. We only re-seed when the *external* config
+  // actually changed (vs. just our own save echoing back), tracked
+  // via lastSeenRef.
+  const lastSeenRef = useRef(config);
+  useEffect(() => {
+    if (
+      config.jiraProjectKey !== lastSeenRef.current.jiraProjectKey ||
+      config.jenkinsJobName !== lastSeenRef.current.jenkinsJobName
+    ) {
+      setDraft(config);
+      lastSeenRef.current = config;
+    }
+  }, [config]);
+
+  const dirty =
+    draft.jiraProjectKey !== config.jiraProjectKey ||
+    draft.jenkinsJobName !== config.jenkinsJobName;
+
+  const save = () => {
+    // Normalize on save (not on every keystroke — would jump the
+    // cursor): trim + uppercase the project key, trim the job name.
+    const trimmed = {
+      jiraProjectKey: (draft.jiraProjectKey || "").trim().toUpperCase(),
+      jenkinsJobName: (draft.jenkinsJobName || "").trim(),
+    };
+    if (!trimmed.jiraProjectKey || !trimmed.jenkinsJobName) return;
+    setConfig(trimmed);
+    setDraft(trimmed);
+  };
+
+  const handleReset = () => {
+    if (
+      window.confirm(
+        `Reset QA Hub config to defaults?\n\n` +
+          `Jira project key → ${DEFAULT_QA_CONFIG.jiraProjectKey}\n` +
+          `Jenkins job name → ${DEFAULT_QA_CONFIG.jenkinsJobName}`,
+      )
+    ) {
+      resetConfig();
+      setDraft({ ...DEFAULT_QA_CONFIG });
+    }
+  };
+
+  return (
+    <>
+      <Section num="01 /" title="Data sources">
+        <Card className="p-6">
+          <p className="mb-5 text-[13px] leading-[1.55] text-muted-fg">
+            Which Jira project the defect widgets query, and which Jenkins job
+            powers the automation-health tiles. Changes apply immediately on
+            save — refresh the dashboard tab to see them.
+          </p>
+          <div className="grid grid-cols-2 gap-5">
+            <Field
+              label="Jira project key"
+              hint="Project that owns your team's bug tickets. Uppercase by convention (e.g. ESPQA, QA)."
+            >
+              <Input
+                value={draft.jiraProjectKey}
+                onChange={(e) =>
+                  setDraft((d) => ({ ...d, jiraProjectKey: e.target.value }))
+                }
+                placeholder={DEFAULT_QA_CONFIG.jiraProjectKey}
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  letterSpacing: "0.4px",
+                }}
+              />
+            </Field>
+            <Field
+              label="Jenkins job name"
+              hint="Job that runs your regression suite. FlakeRateTile reads it directly; BuildPassRateTile uses it as the default selection."
+            >
+              <Input
+                value={draft.jenkinsJobName}
+                onChange={(e) =>
+                  setDraft((d) => ({ ...d, jenkinsJobName: e.target.value }))
+                }
+                placeholder={DEFAULT_QA_CONFIG.jenkinsJobName}
+                style={{ fontFamily: "var(--font-mono)" }}
+              />
+            </Field>
+          </div>
+          <div className="mt-5 flex items-center gap-3">
+            <Button onClick={save} disabled={!dirty}>
+              Save
+            </Button>
+            <Button variant="ghost" onClick={handleReset}>
+              Reset to defaults
+            </Button>
+            {!dirty && draft !== config ? null : null}
+          </div>
+        </Card>
+      </Section>
+
+      <Section num="02 /" title="Jira project requirements">
+        <Card className="p-6">
+          <MonoLabel>For the defect widgets to show data</MonoLabel>
+          <ul className="mt-3 grid gap-3 text-[12.5px] leading-[1.55] text-muted-fg">
+            <li>
+              <span className="text-fg">·</span> The widgets query{" "}
+              <code style={codeStyle}>
+                project = {(draft.jiraProjectKey || "?").toUpperCase()} AND
+                issuetype = Bug
+              </code>{" "}
+              — your project needs a <strong className="text-fg">Bug</strong>{" "}
+              issuetype enabled. Many Jira Work Management projects ship with
+              Task + Epic only; add Bug under{" "}
+              <strong className="text-fg">
+                Project settings → Issue types
+              </strong>
+              .
+            </li>
+            <li>
+              <span className="text-fg">·</span> Priority breakdown needs the{" "}
+              <strong className="text-fg">Priority</strong> field on the Bug
+              create screen. If priority chips all read{" "}
+              <em className="text-fg">Unset</em>, enable it under{" "}
+              <strong className="text-fg">
+                Project settings → Issue layout
+              </strong>
+              .
+            </li>
+            <li>
+              <span className="text-fg">·</span> Config lives in your browser
+              under <code style={codeStyle}>eshub:qa:config:v1</code> — clearing
+              site data resets to defaults.
+            </li>
+          </ul>
+        </Card>
+      </Section>
+    </>
+  );
+}
+
+const codeStyle = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  background: "var(--accent-dim)",
+  color: "var(--accent)",
+  padding: "1px 5px",
+  borderRadius: 3,
+};

--- a/apps/web/src/hubs/qa/build-pass-rate-tile.jsx
+++ b/apps/web/src/hubs/qa/build-pass-rate-tile.jsx
@@ -25,7 +25,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { BentoTile, MonoLabel } from "@/components/ui";
-import { useHubLink } from "@/features/hubs";
+import { useHubLink, useQaHubConfig } from "@/features/hubs";
 import { useIntegrations } from "@/features/integrations";
 import {
   useJenkinsJobs,
@@ -104,15 +104,28 @@ function NotConnectedBody() {
 
 function ConnectedBody() {
   const { jobs, isLoading: jobsLoading, error: jobsError } = useJenkinsJobs();
+  const { config } = useQaHubConfig();
   const [selectedJob, setSelectedJob] = useState(null);
 
-  // Default to the first buildable job once the list resolves.
+  // Default selection priority:
+  //   1) the job the user picked in QA Hub config (jenkinsJobName)
+  //   2) the first buildable job
+  //   3) the first job in the list
+  // The user can still pick a different job via the dropdown — this
+  // is just the initial selection. Re-runs when the config job name
+  // changes so a fresh save in another tab seeds the right default.
   useEffect(() => {
-    if (!selectedJob && jobs.length > 0) {
-      const firstBuildable = jobs.find((j) => j.buildable) ?? jobs[0];
-      setSelectedJob(firstBuildable.name);
+    if (selectedJob || jobs.length === 0) return;
+    const preferred = config.jenkinsJobName
+      ? jobs.find((j) => j.name === config.jenkinsJobName)
+      : null;
+    if (preferred) {
+      setSelectedJob(preferred.name);
+      return;
     }
-  }, [jobs, selectedJob]);
+    const firstBuildable = jobs.find((j) => j.buildable) ?? jobs[0];
+    setSelectedJob(firstBuildable.name);
+  }, [jobs, selectedJob, config.jenkinsJobName]);
 
   if (jobsError) {
     return (

--- a/apps/web/src/hubs/qa/defect-priority-mix-tile.jsx
+++ b/apps/web/src/hubs/qa/defect-priority-mix-tile.jsx
@@ -18,11 +18,10 @@
 import { useMemo } from "react";
 import Link from "next/link";
 import { BentoTile } from "@/components/ui";
-import { useHubLink } from "@/features/hubs";
+import { useHubLink, useQaHubConfig } from "@/features/hubs";
 import { useIntegrations } from "@/features/integrations";
 import { useJiraDefectsForProject } from "@/features/integrations/hooks";
 
-const PROJECT_KEY = "ESPQA";
 const WINDOW_DAYS = 14;
 
 // Stable display order + per-priority colour. Colours track the
@@ -39,7 +38,9 @@ const PRIORITY_ORDER = [
 
 export function DefectPriorityMixTile() {
   const { isConnected } = useIntegrations();
+  const { config } = useQaHubConfig();
   const connected = isConnected("jira");
+  const projectKey = config.jiraProjectKey;
 
   return (
     <BentoTile
@@ -48,7 +49,7 @@ export function DefectPriorityMixTile() {
       label="Defect priority mix"
       right={connected ? <span style={meta}>last 14d</span> : null}
     >
-      {connected ? <Body /> : <NotConnectedBody />}
+      {connected ? <Body projectKey={projectKey} /> : <NotConnectedBody />}
     </BentoTile>
   );
 }
@@ -71,9 +72,9 @@ function NotConnectedBody() {
   );
 }
 
-function Body() {
+function Body({ projectKey }) {
   const { data, isLoading, error } = useJiraDefectsForProject(
-    PROJECT_KEY,
+    projectKey,
     WINDOW_DAYS,
   );
   const buckets = useMemo(() => bucketByPriority(data?.issues ?? []), [data]);

--- a/apps/web/src/hubs/qa/defects-tile.jsx
+++ b/apps/web/src/hubs/qa/defects-tile.jsx
@@ -13,45 +13,39 @@
  *   target that's fragile.
  *
  *   A 14-day rolling window approximates a typical sprint length on
- *   most teams and works regardless of sprint state. PR C will add
- *   a "Sprint cadence" setting so this can switch to true sprint
+ *   most teams and works regardless of sprint state. A "Sprint
+ *   cadence" setting (PR D / PR E) can switch this to true sprint
  *   bounds when configured.
  *
- * Project key is hard-coded to ESPQA — same caveat as the
- * BuildPassRate's job name. PR C makes it a per-org setting.
- *
- * The headline is just a count. The companion DefectPriorityMixTile
- * (next file) breaks the same data down by priority. Sharing one
- * Jira query between the two tiles means we only make one network
- * call per dashboard load (SWR dedupes on the cache key).
+ * Project key comes from useQaHubConfig (QA Hub → Settings → QA Hub
+ * config). Defaults to ESPQA; users with a different Jira project
+ * change it once and both this tile and DefectPriorityMixTile pick
+ * it up (they share the same SWR cache key, so the two tiles still
+ * cost one Jira call together).
  */
 
 import Link from "next/link";
 import { BentoTile } from "@/components/ui";
-import { useHubLink } from "@/features/hubs";
+import { useHubLink, useQaHubConfig } from "@/features/hubs";
 import { useIntegrations } from "@/features/integrations";
 import { useJiraDefectsForProject } from "@/features/integrations/hooks";
 
-// Hard-coded for now; PR C surfaces this in QA Hub config.
-const PROJECT_KEY = "ESPQA";
 const WINDOW_DAYS = 14;
 
 export function DefectsTile() {
   const { isConnected } = useIntegrations();
+  const { config } = useQaHubConfig();
   const connected = isConnected("jira");
+  const projectKey = config.jiraProjectKey;
 
   return (
     <BentoTile
       col="span 4"
       row="span 2"
       label="Defects · last 14d"
-      right={
-        connected ? (
-          <span style={meta}>{PROJECT_KEY}</span>
-        ) : null
-      }
+      right={connected ? <span style={meta}>{projectKey}</span> : null}
     >
-      {connected ? <Body /> : <NotConnectedBody />}
+      {connected ? <Body projectKey={projectKey} /> : <NotConnectedBody />}
     </BentoTile>
   );
 }
@@ -73,9 +67,9 @@ function NotConnectedBody() {
   );
 }
 
-function Body() {
+function Body({ projectKey }) {
   const { data, isLoading, error } = useJiraDefectsForProject(
-    PROJECT_KEY,
+    projectKey,
     WINDOW_DAYS,
   );
   const issues = Array.isArray(data?.issues) ? data.issues : [];
@@ -90,7 +84,7 @@ function Body() {
         head="!"
         sub={
           isProjectMissing
-            ? `Couldn't find project ${PROJECT_KEY} in your Jira. Create it or adjust the QA Hub config.`
+            ? `Couldn't find project ${projectKey} in your Jira. Create it, or change the project key in QA Hub config.`
             : `Couldn't load defects: ${error.code ?? error.status ?? "error"}`
         }
       />

--- a/apps/web/src/hubs/qa/flake-rate-tile.jsx
+++ b/apps/web/src/hubs/qa/flake-rate-tile.jsx
@@ -43,20 +43,22 @@
 import { useMemo } from "react";
 import Link from "next/link";
 import { BentoTile } from "@/components/ui";
-import { useHubLink } from "@/features/hubs";
+import { useHubLink, useQaHubConfig } from "@/features/hubs";
 import { useIntegrations } from "@/features/integrations";
 import { useJenkinsBuildsForJob } from "@/features/integrations/hooks";
 
-// Same job name the BuildPassRateTile uses by default. Both tiles
-// will eventually accept a selector when we ship the "configure
-// which job per widget" UI in PR D.
-const JOB_NAME = "qa-sim-target";
+// Job name comes from useQaHubConfig (QA Hub → Settings → QA Hub
+// config). Defaults to "qa-sim-target" — the synthetic CI target we
+// ship for the demo flow. BuildPassRateTile prefers the same value
+// when auto-selecting a job.
 const WINDOW_DAYS = 30;
 const LOW_SIGNAL_THRESHOLD = 5;
 
 export function FlakeRateTile() {
   const { isConnected } = useIntegrations();
+  const { config } = useQaHubConfig();
   const connected = isConnected("jenkins");
+  const jobName = config.jenkinsJobName;
 
   return (
     <BentoTile
@@ -65,7 +67,7 @@ export function FlakeRateTile() {
       label="Flake rate · last 30d"
       right={connected ? <span style={meta}>UNSTABLE / completed</span> : null}
     >
-      {connected ? <Body /> : <NotConnectedBody />}
+      {connected ? <Body jobName={jobName} /> : <NotConnectedBody />}
     </BentoTile>
   );
 }
@@ -88,8 +90,8 @@ function NotConnectedBody() {
   );
 }
 
-function Body() {
-  const { builds, isLoading, error } = useJenkinsBuildsForJob(JOB_NAME);
+function Body({ jobName }) {
+  const { builds, isLoading, error } = useJenkinsBuildsForJob(jobName);
   const stats = useMemo(() => compute(builds, WINDOW_DAYS), [builds]);
 
   if (error) {
@@ -116,7 +118,7 @@ function Body() {
       <div>
         <div style={{ ...meta, marginBottom: 6 }}>SUITE</div>
         <div style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
-          {JOB_NAME}
+          {jobName}
         </div>
         {stats.completed < LOW_SIGNAL_THRESHOLD ? (
           <div className="mt-2" style={lowSignal}>


### PR DESCRIPTION
## Summary

Retires the hard-coded `ESPQA` + `qa-sim-target` constants in the QA Hub tiles. Users can now set both values once under **QA Hub → Settings → QA Hub config**, and all four QA tiles pick them up.

### New surface

- **`useQaHubConfig()`** hook in `features/hubs`. Backs the config to `localStorage` under `eshub:qa:config:v1`, fan-outs same-tab via a custom event so multiple consumers stay in sync. Defaults to `ESPQA` + `qa-sim-target` so existing setups keep working with no intervention.
- **`QaConfigTab`** in `features/settings/tabs/qa-config-tab.jsx`. Two fields (project key, job name), Save + Reset, plus a *"Jira project requirements"* panel that calls out the two common reasons defect widgets read empty (missing Bug issuetype, Priority field off the create screen) with the exact Jira Settings paths to fix each.

### Wiring

- `SettingsPage` filters tabs by an optional `hubFilter` — the QA-config tab only shows on `/qa/settings`. Same mechanism will carry future per-hub config (Manager Hub roster picks, etc.) without sprouting per-hub conditionals inside each tab.
- `DefectsTile` + `DefectPriorityMixTile` read `projectKey` from the hook. They still share the same SWR cache key, so the two tiles continue to cost one Jira call together.
- `FlakeRateTile` reads `jobName` from the hook.
- `BuildPassRateTile` prefers the configured Jenkins job when auto-selecting; falls back to first-buildable if the configured job isn't in the user's Jenkins. The dropdown still lets the user pick anything.

### Heads-up: Jira Bug issuetype

The QA Hub's defect widgets query `issuetype = Bug`. If your Jira project doesn't have a Bug issuetype (common on **Jira Work Management** — those ship with Task + Epic only), the widgets read 0 even after pointing them at the right project key. Add Bug under **Jira → Project settings → Issue types → Add issue type**. The QaConfigTab spells this out in the *"Jira project requirements"* panel.

## Test plan

- [x] `next build --experimental-build-mode=compile` passes
- [ ] Manual: open `/qa/settings` → "QA Hub config" tab visible
- [ ] Manual: open `/dev/settings` → "QA Hub config" tab NOT visible
- [ ] Manual: change project key to `ESD`, save, refresh dashboard → DefectsTile right-label updates to `ESD`
- [ ] Manual: open two tabs to `/qa/settings`, change in one → other tab re-seeds form values
- [ ] Manual: Reset to defaults restores `ESPQA` / `qa-sim-target`
- [ ] Manual: BuildPassRateTile auto-selects the configured job when present, falls back when not
- [ ] Manual: clear localStorage → all tiles read defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)