### PR TITLE
perf(analyst): close the click→first-block latency gap

### DIFF
--- a/apps/api/src/modules/ai/classify-controller.ts
+++ b/apps/api/src/modules/ai/classify-controller.ts
@@ -135,6 +135,22 @@ export async function classifyGoalsHandler(
     }
   };
 
+  // Flush a START envelope BEFORE opening the classifier so the client
+  // sees stream bytes within a few ms of connecting, instead of waiting
+  // out the upstream model's cold-start (~500-1500ms on free-tier
+  // providers like Mistral). The classifier emits its own START shortly
+  // after, but the client's fold logic is idempotent on START (refreshes
+  // totalGoals + startedAt with the same values), so the double-emit is
+  // safe. Pairs with the client's optimistic-skeleton seed in
+  // apps/web/src/features/analyst/use-classify-goals.js — together they
+  // close the "click → first visible block" gap to under a frame.
+  writeEvent(
+    AnalysisEvents.start({
+      totalGoals: goals.length,
+      startedAt: Date.now(),
+    }),
+  );
+
   try {
     for await (const event of classifier.classify(goals, {
       signal: abortController.signal,

--- a/apps/web/src/features/analyst/use-classify-goals.js
+++ b/apps/web/src/features/analyst/use-classify-goals.js
@@ -213,7 +213,31 @@ export function useClassifyGoals() {
         setPhase(PHASES.ERROR);
         return;
       }
-      setEvents([]);
+      // Optimistic skeleton: seed `events` with a synthetic START + one
+      // GOAL_STARTED per goal BEFORE the network call goes out. The
+      // analysis-stream renderer keys goal blocks on goalId, so when
+      // the real GOAL_STARTED events arrive from the server they merge
+      // into the same blocks (with identical title / parentL1 values,
+      // no visual jump). Without this seed, the overlay would sit on
+      // the "Warming up the analyst" empty placeholder for the entire
+      // upstream-model cold-start window (~500–1500ms on free-tier
+      // providers). With it, the user sees N "reading…" cards within
+      // the same tick — feels instant even when the model is slow.
+      const optimisticEvents = [
+        {
+          type: ANALYSIS.START,
+          payload: { totalGoals: list.length, startedAt: Date.now() },
+        },
+        ...list.map((g) => ({
+          type: ANALYSIS.GOAL_STARTED,
+          payload: {
+            goalId: g.id,
+            title: g.title,
+            parentL1: g.parentL1Title,
+          },
+        })),
+      ];
+      setEvents(optimisticEvents);
       setError(null);
       setPhase(PHASES.RUNNING);
       const ctrl = new AbortController();


### PR DESCRIPTION
## Summary

When you click **Analyse my goals**, the overlay opens but then sits on the *"Warming up the analyst"* empty placeholder until the upstream model returns its first chunk (~500–1500ms on free-tier Mistral/GLM). Connection is fine; the model just hasn't coughed up bytes yet.

Two tiny changes that together bring the perceived gap from *half-a-second-plus* to under a frame:

### 1. Client — optimistic skeleton seed

Before posting to `/api/v1/ai/classify-goals`, seed `events` with a synthetic `START` + one `GOAL_STARTED` per goal in the list. The analysis-stream renderer keys per-goal blocks on `goalId`, so when the real `GOAL_STARTED` events arrive from the server they merge into the same blocks (identical title / parentL1 values, no visual jump). User sees N "reading…" cards within the same tick.

### 2. Server — flush START before opening the classifier

`classifyGoalsHandler` now writes the `START` envelope right after `flushHeaders()` and **before** iterating the classifier. The classifier still emits its own `START`, but the client's fold logic is idempotent on `START` (just refreshes `totalGoals` + `startedAt`), so the double-emit is harmless.

The two changes are independent — either alone helps — but together they cover both the *"I clicked but nothing's happening"* case AND the *"the connection succeeded but I'm waiting on the model"* case.

**No model/provider changes, no new event types, no behavioural change once the real stream starts emitting.** Purely perceived-latency UX work.

## Test plan

- [x] `next build --experimental-build-mode=compile` passes (apps/web)
- [x] `tsc --noEmit` passes (apps/api)
- [ ] Click "Analyse my goals" — see N skeleton "reading…" cards instantly, then watch them tick through "reasoning" → "classified"
- [ ] Mid-run abort still works (`abort()` tears down skeletons + real blocks together)
- [ ] Error path: if `/classify-goals` 4xx/5xx, phase transitions to ERROR and skeletons remain visible with the error chip
- [ ] Re-running analysis on the same goals doesn't duplicate cards (synthetic + real events merge by goalId)

🤖 Generated with [Claude Code](https://claude.com/claude-code)