### PR TITLE
fix(analyst): drop synthetic GOAL_STARTED seed — blocks were freezing on 'reading'

### DIFF
--- a/apps/web/src/features/analyst/use-classify-goals.js
+++ b/apps/web/src/features/analyst/use-classify-goals.js
@@ -213,31 +213,27 @@ export function useClassifyGoals() {
         setPhase(PHASES.ERROR);
         return;
       }
-      // Optimistic skeleton: seed `events` with a synthetic START + one
-      // GOAL_STARTED per goal BEFORE the network call goes out. The
-      // analysis-stream renderer keys goal blocks on goalId, so when
-      // the real GOAL_STARTED events arrive from the server they merge
-      // into the same blocks (with identical title / parentL1 values,
-      // no visual jump). Without this seed, the overlay would sit on
-      // the "Warming up the analyst" empty placeholder for the entire
-      // upstream-model cold-start window (~500–1500ms on free-tier
-      // providers). With it, the user sees N "reading…" cards within
-      // the same tick — feels instant even when the model is slow.
-      const optimisticEvents = [
+      // Optimistic kick-off: seed `events` with a synthetic START
+      // BEFORE the network call goes out. This gives the summary
+      // strip its `totalGoals` / `startedAt` so the user immediately
+      // sees "0 / 12 · analyzing · 0s" instead of empty placeholder.
+      //
+      // We DO NOT also seed synthetic GOAL_STARTED-per-goal events:
+      // the fold replaces a block on every GOAL_STARTED it sees,
+      // which means a synthetic-then-server pair can race the
+      // intervening REASONING/CLASSIFIED events in subtle ways
+      // (observed: blocks freezing on "reading" after the server's
+      // real GOAL_STARTED lands). Letting the server's GOAL_STARTED
+      // be the SOLE source of block creation removes that whole
+      // class of bug. Blocks appear as the server queue picks goals
+      // up (concurrency=3), each transitioning reading → reasoning
+      // → classified in real time.
+      setEvents([
         {
           type: ANALYSIS.START,
           payload: { totalGoals: list.length, startedAt: Date.now() },
         },
-        ...list.map((g) => ({
-          type: ANALYSIS.GOAL_STARTED,
-          payload: {
-            goalId: g.id,
-            title: g.title,
-            parentL1: g.parentL1Title,
-          },
-        })),
-      ];
-      setEvents(optimisticEvents);
+      ]);
       setError(null);
       setPhase(PHASES.RUNNING);
       const ctrl = new AbortController();


### PR DESCRIPTION
## What broke

After PR #65 shipped, classification ran through the server side correctly (verified against the raw NDJSON response — 11 of 12 goals returned `analysis:goal-classified` with valid specs, 1 returned `analysis:goal-failed`). But the UI displayed every block frozen on the `"reading…"` chip indefinitely. Even with a complete `analysis:complete` event in the stream.

## Root cause

PR #65 seeded both:
1. **Synthetic START** — to give the summary strip its `totalGoals` / `startedAt` immediately
2. **Synthetic GOAL_STARTED for every goal** — to render N skeleton cards before the model spoke

The `foldEvents` in `analysis-stream.jsx` handles `GOAL_STARTED` as:

```js
blocks.set(evt.payload.goalId, {
  state: "reading", reasoning: "", spec: null, ...
});
```

i.e. it **replaces** the block on every `GOAL_STARTED` it sees. The intent of PR #65 was for the server's later `GOAL_STARTED` to harmlessly replace the synthetic one, then `REASONING`/`CLASSIFIED` to progress the new block. In practice something in that interleaving leaves blocks frozen on `state: "reading"` even after `GOAL_CLASSIFIED` fires.

The cleanest fix is to remove the source of the contention: let the **server's** `GOAL_STARTED` be the sole source of block creation.

## What changes

- Keep synthetic `START` — still gives the summary strip its initial `totalGoals` / `startedAt`, which is the bigger perceived-latency win
- Drop the synthetic `GOAL_STARTED` seed entirely — blocks now appear as the server queue picks them up (concurrency=3) and progress through reading → reasoning → classified normally

## Trade-off

User briefly sees the empty "Warming up the analyst" placeholder for ~500ms (cold-start) before the first real `GOAL_STARTED` lands. That's worse than the skeleton flash from PR #65, but vastly better than the alternative (frozen blocks that never finish).

A later PR can reintroduce skeletons via a **separate** state slot (not via `events`) so the fold's GOAL_STARTED replay logic never sees synthetic events.

## Test plan

- [x] `next build --experimental-build-mode=compile` passes
- [ ] Manual: Click "Analyse my goals" — summary strip shows "0 / 12 · analyzing · 0s" immediately
- [ ] Manual: After ~500ms, first 3 goal blocks appear in "reading…" state (concurrency=3)
- [ ] Manual: Each block transitions through "classifying…" then to "✓ {widget}" as the model finishes that goal
- [ ] Manual: Final state shows 11 ✓ chips + 1 "failed" chip (for goal `637720000016191544` which fails validation)
- [ ] Manual: Summary strip ends at "11 / 12 · complete · 1 failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)