### PR TITLE
fix(web): cache useSession server snapshot + fix inert empty-string warning

### DIFF
--- a/apps/web/src/components/shell/app-shell.jsx
+++ b/apps/web/src/components/shell/app-shell.jsx
@@ -67,7 +67,11 @@ function AppShellInner({ children, hideFooter }) {
       <div
         className="relative z-[2]"
         aria-hidden={open ? "true" : undefined}
-        inert={open ? "" : undefined}
+        // React 19 treats an empty string for boolean attrs as `false`
+        // and warns. Pass real boolean `true` when we want the shell
+        // inert (analyst overlay open), and `undefined` to omit the
+        // attribute entirely otherwise.
+        inert={open || undefined}
         style={{
           transform: open ? "translateX(-100%)" : "translateX(0)",
           transition: "transform 320ms cubic-bezier(0.22, 0.61, 0.36, 1)",

--- a/apps/web/src/features/auth/use-session.js
+++ b/apps/web/src/features/auth/use-session.js
@@ -8,10 +8,24 @@ import {
   subscribeSession,
 } from "./session-store.js";
 
+// React's useSyncExternalStore compares snapshot return values by
+// reference (Object.is). If getServerSnapshot allocates a new object on
+// every call, React thinks the store changed every render and warns
+// "The result of getServerSnapshot should be cached to avoid an
+// infinite loop." Freezing the snapshot once at module scope and
+// returning the same reference each call silences that and lets the
+// SSR/hydration phase settle deterministically.
+const SERVER_SNAPSHOT = Object.freeze({
+  user: null,
+  loading: true,
+  needsTotp: false,
+  error: null,
+});
+
 function serverSnapshot() {
   // SSR returns the "loading" state — the client will hydrate after
   // the first /me round-trip.
-  return { user: null, loading: true, needsTotp: false, error: null };
+  return SERVER_SNAPSHOT;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two React 19 / Next 16 console warnings cleaned up. Neither was breaking the analyst's "stuck on reading" bug directly, but the session one has the smell of subtle re-render trouble downstream so it's worth clearing.

### 1. `useSession`'s `serverSnapshot`

Was allocating a fresh `{user:null, loading:true, …}` object literal on every call. React's `useSyncExternalStore` compares snapshot return values by reference (`Object.is`); each render saw a new ref and warned:

> The result of getServerSnapshot should be cached to avoid an infinite loop

Fix: hoist the snapshot to a module-level frozen constant and return the same reference every time. SSR/hydration now settles deterministically.

### 2. `AppShellInner` `inert={open ? "" : undefined}`

React 19 treats an empty string for a boolean attribute as `false` and warns:

> Received an empty string for a boolean attribute `inert`. This will treat the attribute as if it were false.

Fix: `inert={open || undefined}` — passes real `true` when the analyst overlay is open, omits the attribute entirely when closed.

## Test plan

- [x] `next build --experimental-build-mode=compile` passes
- [ ] Hard-refresh the browser — both warnings gone from the console
- [ ] Open analyst overlay — shell underneath becomes inert (clicks blocked through to dashboard)
- [ ] Close analyst — shell interactive again

🤖 Generated with [Claude Code](https://claude.com/claude-code)