### PR TITLE
fix(api): revert server-side START flush — stalls classifier stream

### DIFF
--- a/apps/api/src/modules/ai/classify-controller.ts
+++ b/apps/api/src/modules/ai/classify-controller.ts
@@ -135,22 +135,16 @@ export async function classifyGoalsHandler(
     }
   };
 
-  // Flush a START envelope BEFORE opening the classifier so the client
-  // sees stream bytes within a few ms of connecting, instead of waiting
-  // out the upstream model's cold-start (~500-1500ms on free-tier
-  // providers like Mistral). The classifier emits its own START shortly
-  // after, but the client's fold logic is idempotent on START (refreshes
-  // totalGoals + startedAt with the same values), so the double-emit is
-  // safe. Pairs with the client's optimistic-skeleton seed in
-  // apps/web/src/features/analyst/use-classify-goals.js — together they
-  // close the "click → first visible block" gap to under a frame.
-  writeEvent(
-    AnalysisEvents.start({
-      totalGoals: goals.length,
-      startedAt: Date.now(),
-    }),
-  );
-
+  // NOTE on perceived latency: the client (see use-classify-goals.js)
+  // seeds its `events` state with a synthetic START on click, which
+  // immediately shows "0 / N · analyzing · 0s" in the summary strip.
+  // We deliberately do NOT emit a duplicate START from the server here
+  // — an earlier attempt did, and it appeared to interact badly with
+  // the per-goal streaming loop (the response would deliver the START
+  // chunk and then stall before yielding the classifier's own events).
+  // The classifier emits its own START as the first event from
+  // `classify()`, which is sufficient and arrives before any goal-
+  // specific events.
   try {
     for await (const event of classifier.classify(goals, {
       signal: abortController.signal,


### PR DESCRIPTION
## What broke

PR #65 added a `writeEvent(AnalysisEvents.start(...))` call in `classifyGoalsHandler` *before* opening the classifier's `for await` loop, to give the client immediate stream bytes. After that change, the stream **stalls after delivering the START chunk** — none of the classifier's per-goal events reach the client. The analyst summary strip freezes at "0 / N · analyzing · 3s" forever.

The user confirmed the bug reproduces across both **Mistral** and **GLM** providers via the analyst's provider toggle, so it's not a provider-specific rate-limit or cold-start — it's something about how the manual `res.write` before the generator loop interferes with the per-goal streaming machinery.

## What changes

- Remove the manual `writeEvent(AnalysisEvents.start(...))` before the for-await loop in `classify-controller.ts`
- Add a comment explaining why we don't add it back
- The classifier itself emits a START as the first event from its `classify()` generator, which is enough

## What stays

- **Client-side synthetic START** (PR #66 / `use-classify-goals.js`) still seeds the summary strip on click — so the user still sees "0 / N · analyzing · 0s" immediately without waiting for any network bytes
- All the per-goal block rendering stays the same

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Click "Analyse my goals" — summary strip shows "0 / N · analyzing · 0s" immediately
- [ ] First 3 goal cards appear within a second or two
- [ ] Cards tick through `reading → reasoning → ✓ classified` (or `failed`) as the model finishes each
- [ ] Final state: `10 / 12 · complete · 2 failed` (the two server-side validation failures from earlier are a separate, unrelated prompt-quality bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)