### PR TITLE
fix(api): disable Nagle + prime stream so classifier events flush in real time

### DIFF
--- a/apps/api/src/modules/ai/classify-controller.ts
+++ b/apps/api/src/modules/ai/classify-controller.ts
@@ -96,6 +96,15 @@ export async function classifyGoalsHandler(
   res.setHeader("X-Accel-Buffering", "no");
   // Flush headers immediately so the client opens the stream.
   res.flushHeaders?.();
+  // Disable Nagle's algorithm on the underlying TCP socket so each
+  // res.write() flushes immediately instead of being batched into a
+  // larger packet (default 200ms). Without this, on loopback dev the
+  // classifier can yield 4+ events in the first 10ms but the kernel
+  // batches them and the client sees nothing until the 3rd or 4th
+  // write fills the Nagle window — which manifests as the analyst's
+  // summary strip freezing at "0/N · analyzing · 3s" while the
+  // classifier silently progresses.
+  res.socket?.setNoDelay(true);
 
   const abortController = new AbortController();
   const goals: GoalForClassification[] = parsed.goals.map((g) => ({
@@ -135,16 +144,25 @@ export async function classifyGoalsHandler(
     }
   };
 
-  // NOTE on perceived latency: the client (see use-classify-goals.js)
-  // seeds its `events` state with a synthetic START on click, which
-  // immediately shows "0 / N · analyzing · 0s" in the summary strip.
-  // We deliberately do NOT emit a duplicate START from the server here
-  // — an earlier attempt did, and it appeared to interact badly with
-  // the per-goal streaming loop (the response would deliver the START
-  // chunk and then stall before yielding the classifier's own events).
-  // The classifier emits its own START as the first event from
-  // `classify()`, which is sufficient and arrives before any goal-
-  // specific events.
+  // Force-flush a priming byte before opening the classifier. The
+  // first res.write() on a Node HTTP response is what actually wakes
+  // up the chunked-transfer-encoding pipeline + the client's
+  // response.body reader on fetch. Without this, the classifier's own
+  // START event (the next write that happens) appears to sit in a
+  // socket buffer alongside the first goal-started events; combined
+  // with Nagle (now disabled above) and TCP coalescing on loopback,
+  // the client sees nothing until much later. Writing this START
+  // explicitly here both primes the pipeline AND gives the client a
+  // duplicate of its own synthetic START — the client's fold logic
+  // is idempotent on START so the double-emit is harmless (it just
+  // refreshes totalGoals and startedAt with the same values).
+  writeEvent(
+    AnalysisEvents.start({
+      totalGoals: goals.length,
+      startedAt: Date.now(),
+    }),
+  );
+
   try {
     for await (const event of classifier.classify(goals, {
       signal: abortController.signal,


### PR DESCRIPTION
## Root cause of "0/N · analyzing · 3s frozen"

The classifier yields ~4 events in its first ~10ms:
- `analysis:start` (sync at line 389 of `mistral-classifier.ts`)
- Three `analysis:goal-started` (sync yields at line 216 of `classifyOneGoal`, before any awaited fetch)

All 4 `res.write()` calls happen in quick succession. But Node's HTTP response writes through a TCP socket with **Nagle's algorithm enabled by default**, which batches small writes (waits up to 200ms for an ACK on the previous packet before sending the next one). On loopback dev, the kernel coalesces them; the client's `response.body.getReader()` doesn't see anything until either:
- The Nagle window times out (~200ms+)
- A large chunk fills the buffer
- The response ends

So the client's `for await (const evt of readNdjson(res.body))` sits idle even though the server has clearly emitted ≥4 events. The analyst summary strip renders exactly once when something finally arrives, then freezes because no further `setEvents` calls happen.

## What changes

1. **`res.socket?.setNoDelay(true)`** right after `flushHeaders()` — disables Nagle on this specific connection. Each `res.write()` now flushes immediately.

2. **Priming `writeEvent(AnalysisEvents.start(...))`** before opening the classifier loop. The first `res.write()` is what fully primes Node's chunked-transfer-encoding pipeline + the client's fetch reader. Writing START explicitly here also gives the client a duplicate START — the fold logic is idempotent on START (refreshes `totalGoals` + `startedAt` with the same values), so the dup is harmless.

I previously thought (2) alone was the bug and reverted it. Wrong. The real bug was Nagle; removing (2) made the stall worse because there was no priming byte at all.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Restart `apps/api` dev server to pick up the change
- [ ] Click "Analyse my goals"
- [ ] Summary strip immediately reads `0 / 12 · analyzing · 0s`
- [ ] Within ~1 second: 3 goal cards appear in `reading…`
- [ ] Cards tick through `reasoning` → `classified` / `failed` as the model finishes each
- [ ] Counter `elapsedSec` updates every second instead of freezing
- [ ] Final state: `10 / 12 · complete · 2 failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)