### PR TITLE
fix(analyst): reset mountedRef=true at effect setup (StrictMode safety)

### DIFF
--- a/apps/web/src/features/analyst/use-classify-goals.js
+++ b/apps/web/src/features/analyst/use-classify-goals.js
@@ -180,15 +180,31 @@ export function useClassifyGoals() {
   const abortRef = useRef(null);
   const mountedRef = useRef(true);
 
-  useEffect(
-    () => () => {
-      // eslint-disable-next-line no-console
-      console.warn("[classify] useClassifyGoals UNMOUNT — mountedRef→false, aborting in-flight");
+  // CRITICAL: set mountedRef.current = true at the START of the effect,
+  // not just via useRef(true) at hook init. React 19 StrictMode in dev
+  // runs the cleanup once before the real mount to verify cleanup
+  // correctness. With a cleanup-only effect like this one, the sequence is:
+  //
+  //   1. useRef(true) → mountedRef.current = true
+  //   2. Effect mounts (no setup body, just returns cleanup)
+  //   3. StrictMode invokes cleanup → mountedRef.current = false
+  //   4. Effect re-runs (still no setup body to restore current)
+  //   5. mountedRef.current stays FALSE for the rest of the component's life
+  //
+  // Result: every for-await loop in start() bails out at event #1 because
+  // mountedRef.current reads false. The analyst UI shows
+  // "0/N · analyzing · …s · Warming up" indefinitely while the server
+  // stream completes fully but is ignored client-side.
+  //
+  // Setting current = true at the top of the effect makes step 4 restore
+  // it correctly, and the cleanup at real unmount still flips it to false.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
       if (abortRef.current) abortRef.current.abort();
-    },
-    [],
-  );
+    };
+  }, []);
 
   const reset = useCallback(() => {
     setEvents([]);
@@ -206,22 +222,10 @@ export function useClassifyGoals() {
    */
   const start = useCallback(
     async (subset) => {
-      // TEMP DEBUG: tracking down the "0/N · analyzing · 55s · Warming up"
-      // stall — server stream completes per network tab but client
-      // events array never grows past the synthetic START. Remove these
-      // logs once the rendering bug is diagnosed.
-      // eslint-disable-next-line no-console
-      console.log("[classify] start() invoked. phase:", phase);
-      if (phase === PHASES.RUNNING) {
-        // eslint-disable-next-line no-console
-        console.warn("[classify] start() bailed: phase already RUNNING");
-        return;
-      }
+      if (phase === PHASES.RUNNING) return;
       const list = subset && Array.isArray(subset)
         ? subset
         : flattenGoalsForClassification(goals);
-      // eslint-disable-next-line no-console
-      console.log("[classify] flattened goals:", list.length);
       if (list.length === 0) {
         setError("No goals to classify. Add goals in Settings first.");
         setPhase(PHASES.ERROR);
@@ -278,61 +282,20 @@ export function useClassifyGoals() {
         if (!res.body) {
           throw new Error("Classifier returned an empty stream.");
         }
-        // eslint-disable-next-line no-console
-        console.log("[classify] fetch ok:", res.status, "— opening NDJSON reader");
-        let evtCount = 0;
         for await (const evt of readNdjson(res.body)) {
-          evtCount += 1;
-          // eslint-disable-next-line no-console
-          console.log(
-            `[classify] event #${evtCount}:`,
-            evt.type,
-            evt.payload?.goalId ? `(goal ${evt.payload.goalId.slice(-4)})` : "",
-            "mounted:",
-            mountedRef.current,
-          );
-          if (!mountedRef.current) {
-            // eslint-disable-next-line no-console
-            console.warn("[classify] mountedRef false — breaking loop at event", evtCount);
-            break;
-          }
+          if (!mountedRef.current) break;
           // Persist classified specs immediately so downstream consumers
           // (dashboard section 5, analyst grid) update in real time.
           if (evt.type === ANALYSIS.GOAL_CLASSIFIED && evt.payload?.spec) {
-            try {
-              saveSpec(evt.payload.spec);
-            } catch (saveErr) {
-              // eslint-disable-next-line no-console
-              console.warn("[classify] saveSpec threw:", saveErr);
-            }
+            saveSpec(evt.payload.spec);
           }
-          setEvents((prev) => {
-            const next = [...prev, evt];
-            // Periodically log how many events have actually landed in
-            // React state — this is the smoking-gun check: if this number
-            // stays at 1 while the stream is clearly delivering, the
-            // setEvents path is broken upstream.
-            if (next.length % 50 === 0 || next.length <= 5) {
-              // eslint-disable-next-line no-console
-              console.log("[classify] events in state →", next.length);
-            }
-            return next;
-          });
+          setEvents((prev) => [...prev, evt]);
           if (evt.type === ANALYSIS.COMPLETE) {
             markAnalyzedAt(Date.now());
           }
         }
-        // eslint-disable-next-line no-console
-        console.log(
-          "[classify] for-await EXITED. total events:",
-          evtCount,
-          "mounted:",
-          mountedRef.current,
-        );
         if (mountedRef.current) setPhase(PHASES.COMPLETE);
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error("[classify] caught error:", err?.name, err?.message);
         if (err?.name === "AbortError") {
           if (mountedRef.current) setPhase(PHASES.IDLE);
           return;


### PR DESCRIPTION
## The actual root cause of every analyst stuck-UI symptom

User's debug log (PR #70 instrumentation) gave us the smoking gun:

```
[classify] start() invoked. phase: idle
[classify] flattened goals: 12
[classify] fetch ok: 200 — opening NDJSON reader
[classify] event #1: analysis:start  mounted: false  ← !!!
[classify] mountedRef false — breaking loop at event 1
[classify] for-await EXITED. total events: 1 mounted: false
```

`mountedRef.current` was already `false` when the first server event arrived, even though the component was visibly mounted and the elapsed counter was ticking.

## Why

The cleanup-only `useEffect` pattern interacts badly with React 19 StrictMode dev double-invoke:

```js
const mountedRef = useRef(true);

useEffect(
  () => () => {                          // ← no setup body
    mountedRef.current = false;
    if (abortRef.current) abortRef.current.abort();
  },
  [],
);
```

1. `useRef(true)` → `mountedRef.current = true`
2. Effect mounts (no setup, just returns cleanup)
3. StrictMode invokes cleanup → `mountedRef.current = false`
4. Effect re-runs (still no setup body to restore it)
5. `mountedRef.current` stays `false` for the rest of the component's life

Every `for await` iteration in `start()` checks `mountedRef.current`, finds `false`, and breaks at event #1. The server streams 250+ events successfully; the network tab shows a clean 200; but React state never receives them. UI shows `0/N · analyzing · …s · Warming up` forever.

This explains everything we saw across PRs #65, #66, #68, #69 — none of those fixes were wrong per se, but they couldn't make the UI update because `mountedRef.current === false` killed every for-await before it could call `setEvents`.

## The fix

Explicitly reset `mountedRef.current = true` at the start of the effect setup:

```js
useEffect(() => {
  mountedRef.current = true;       // ← restore on every (re-)mount
  return () => {
    mountedRef.current = false;
    if (abortRef.current) abortRef.current.abort();
  };
}, []);
```

Now the StrictMode sequence:
1. Setup: `mountedRef.current = true`
2. Cleanup: `mountedRef.current = false`
3. Setup again: `mountedRef.current = true` ✅
4. Real unmount cleanup at end of component life: `mountedRef.current = false`

## Plus

Removed the PR #70 debug `console.log` calls — they served their purpose.

## Test plan

- [x] `next build --experimental-build-mode=compile` passes
- [ ] Hard-refresh browser
- [ ] Open dev tools console (no `[classify]` noise this time)
- [ ] Click "Analyse my goals"
- [ ] Summary strip ticks: `0 / 12 · analyzing · 0s` → `0 / 12 · 1s` → ...
- [ ] Goal cards appear in `reading…` within ~1s
- [ ] Cards progress through `classifying…` → `✓ {WIDGET}` / `failed` in real time
- [ ] Final state: `10 / 12 · complete · 2 failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)