### PR TITLE
feat(widgets): finish TICKET_CYCLE — real cycle-time + histogram

### DIFF
--- a/apps/web/src/features/goal-widgets/data-sources/source-deps.js
+++ b/apps/web/src/features/goal-widgets/data-sources/source-deps.js
@@ -20,6 +20,9 @@ export {
   mergedWithin,
   mergedTrend,
   turnaroundHistogram,
+  resolvedTicketsInWindow,
+  medianTicketCycleDays,
+  ticketCycleHistogram,
 } from "@/features/integrations";
 
 export { SOURCE_METRICS } from "@/features/goal-specs";

--- a/apps/web/src/features/goal-widgets/data-sources/use-data-source.js
+++ b/apps/web/src/features/goal-widgets/data-sources/use-data-source.js
@@ -30,6 +30,9 @@ import {
   mergedWithin,
   mergedTrend,
   turnaroundHistogram,
+  resolvedTicketsInWindow,
+  medianTicketCycleDays,
+  ticketCycleHistogram,
   SOURCE_METRICS,
 } from "./source-deps";
 
@@ -149,8 +152,21 @@ export function useDataSource(source) {
     // downstream `for ... of` never sees the envelope object (which was
     // causing the "tickets is not iterable" widget crash).
     const tickets = Array.isArray(jira.data?.issues) ? jira.data.issues : [];
+    // Cycle time uses `resolutiondate − created` for tickets RESOLVED
+    // inside the spec window (`sinceIso`). This is the simple MVP cycle
+    // time — a richer "in-progress → done" version would need the Jira
+    // changelog endpoint, which we don't fetch yet.
+    const resolvedInWindow = resolvedTicketsInWindow(tickets, sinceIso);
+    const median = medianTicketCycleDays(resolvedInWindow);
+    const histogram = ticketCycleHistogram(resolvedInWindow);
     return {
-      data: { tickets },
+      data: {
+        median,
+        histogram,
+        resolvedCount: resolvedInWindow.length,
+        totalCount: tickets.length,
+        tickets,
+      },
       isLoading: jira.isLoading,
       error: jira.error,
       windowDays: days,

--- a/apps/web/src/features/goal-widgets/widgets/_register.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/_register.jsx
@@ -55,7 +55,8 @@ registerWidget(SPEC_KINDS.LINKAGE, {
 registerWidget(SPEC_KINDS.TICKET_CYCLE, {
   variant: SPEC_VARIANTS.AUTO,
   Component: TicketCycleWidget,
-  description: "Preview — shows Jira status breakdown; cycle-time coming soon.",
+  description:
+    "Median Jira ticket cycle (created → resolved) with day-bin histogram.",
 });
 registerWidget(SPEC_KINDS.CODE_RUBRIC, {
   variant: SPEC_VARIANTS.AUTO,

--- a/apps/web/src/features/goal-widgets/widgets/ticket-cycle-widget.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/ticket-cycle-widget.jsx
@@ -1,80 +1,161 @@
 "use client";
 
-import { WidgetShell } from "../widget-shell";
+import { fmtDays } from "@/lib/fmt";
+import { WidgetShell, TargetChip } from "../widget-shell";
 import { useDataSource } from "../data-sources/use-data-source";
+import { evalTarget } from "./merged-count-widget";
+import { ComplianceLine } from "../compliance-line";
 
 /**
- * Ticket-cycle-time widget — BARE version.
+ * Ticket-cycle-time widget — Jira-side counterpart to TURNAROUND.
  *
- * A full implementation needs per-ticket Jira changelog reads to compute
- * status-transition durations (To Do → In Progress → Done). The Jira client
- * doesn't expose that yet, so this widget currently surfaces a high-level
- * ticket-status breakdown and a "coming soon" note.
+ * Cycle time here is `resolutiondate − created` (the simple MVP — see
+ * `metrics/ticket-cycle.js` for the why-no-changelog-yet note). Layout
+ * mirrors TurnaroundWidget so the two read as a matched pair when a goal
+ * tree contains both PR-throughput and ticket-throughput sub-goals.
  *
- * Explicit stub (rather than silently skipping the kind) so classifier
- * specs can still point at this widget; users see progress rather than
- * a missing widget error.
+ * Headline: median cycle time in days
+ * Sub:      bin histogram (`<1d`, `1–3d`, `3–7d`, `1–2w`, `2–4w`, `>4w`)
+ * Footer:   ComplianceLine (manual progress overlay)
+ *
+ * Empty / loading / error states piggyback on the same numeric/glyph
+ * pattern the other auto widgets use ("…" / "!"), so the analyst grid
+ * stays visually consistent.
  */
-export function TicketCycleWidget({ spec, goal, variant = "light", className, onRetry }) {
-  const { data, isLoading, error } = useDataSource(spec.source);
-  const tickets = data?.tickets || [];
-  const byStatus = bucketByStatus(tickets);
+export function TicketCycleWidget({
+  spec,
+  goal,
+  variant = "light",
+  className,
+  onRetry,
+}) {
+  const { data, isLoading, error, windowDays } = useDataSource(spec.source);
+  const median = data?.median ?? null;
+  const histogram = data?.histogram || [];
+  const resolvedCount = data?.resolvedCount ?? 0;
+  const target = spec.source?.target;
+  const meets = target && median != null ? evalTarget(median, target) : null;
+  const maxBin = Math.max(...histogram.map((b) => b.n), 1);
 
   return (
     <WidgetShell
       spec={spec}
       variant={variant}
-      label="Ticket cycle · (preview)"
+      label={`Ticket cycle · ${windowDays}d`}
       title={goal?.title || spec.title}
+      rightChip={<TargetChip target={target} unit="d" variant={variant} />}
       onRetry={onRetry}
       className={className}
     >
       <div className="flex h-full flex-col justify-between gap-2">
-        <div
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-            color: variant === "light" ? "rgba(255,255,255,0.72)" : "var(--muted-fg)",
-            lineHeight: 1.5,
-          }}
-        >
-          {error
-            ? "Jira not connected — cycle time unavailable."
-            : isLoading
-              ? "Reading Jira…"
-              : "Cycle time requires per-ticket changelog support (coming soon)."}
-        </div>
-        <div className="flex flex-col gap-1">
-          {Object.entries(byStatus).map(([status, n]) => (
+        <div className="flex items-baseline gap-2">
+          <div
+            className="font-semibold leading-none"
+            style={{
+              fontFamily: "var(--font-display)",
+              fontSize: 48,
+              letterSpacing: "-1.6px",
+            }}
+          >
+            {error ? "!" : isLoading ? "…" : fmtDays(median)}
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              color:
+                variant === "light"
+                  ? "rgba(255,255,255,0.72)"
+                  : "var(--muted-fg)",
+            }}
+          >
+            median
+          </div>
+          {meets != null ? (
             <div
-              key={status}
-              className="flex items-center justify-between"
-              style={{ fontFamily: "var(--font-mono)", fontSize: 10.5 }}
+              className="ml-auto uppercase tracking-[0.5px]"
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                color: meets ? "var(--accent-2)" : "rgba(255,255,255,0.7)",
+              }}
             >
-              <span
-                style={{
-                  color:
-                    variant === "light"
-                      ? "rgba(255,255,255,0.78)"
-                      : "var(--muted-fg)",
-                }}
-              >
-                {status}
-              </span>
-              <span className="font-semibold">{n}</span>
+              {meets ? "on target" : "over target"}
             </div>
-          ))}
+          ) : null}
         </div>
+
+        {/* Histogram — same visual idiom as TURNAROUND, wider day bins. */}
+        <div className="flex items-end gap-[3px]" style={{ height: 42 }}>
+          {histogram.map((b) => {
+            const h = Math.max(2, (b.n / maxBin) * 40);
+            return (
+              <div
+                key={b.label}
+                className="flex flex-1 flex-col items-center gap-1"
+                title={`${b.label}: ${b.n}`}
+              >
+                <div
+                  className="w-full rounded-t-[2px]"
+                  style={{
+                    height: h,
+                    background:
+                      variant === "light"
+                        ? "rgba(255,255,255,0.6)"
+                        : "var(--accent-dim)",
+                  }}
+                />
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 8.5,
+                    color:
+                      variant === "light"
+                        ? "rgba(255,255,255,0.6)"
+                        : "var(--dim-fg)",
+                  }}
+                >
+                  {b.label}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Sample-size hint when low signal so the median isn't taken at
+            face value (a single fast-resolved ticket would otherwise read
+            as "<1d cycle time" with no caveat). */}
+        {!error && !isLoading && resolvedCount > 0 && resolvedCount < 5 ? (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              color:
+                variant === "light"
+                  ? "rgba(255,255,255,0.6)"
+                  : "var(--muted-fg)",
+            }}
+          >
+            low signal · {resolvedCount} resolved in window
+          </div>
+        ) : null}
+        {!error && !isLoading && resolvedCount === 0 ? (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10.5,
+              color:
+                variant === "light"
+                  ? "rgba(255,255,255,0.65)"
+                  : "var(--muted-fg)",
+            }}
+          >
+            no resolved tickets in the last {windowDays} days
+          </div>
+        ) : null}
+
+        <ComplianceLine goalId={goal?.id} variant={variant} />
       </div>
     </WidgetShell>
   );
-}
-
-function bucketByStatus(tickets) {
-  const out = {};
-  for (const t of tickets) {
-    const status = t?.fields?.status?.name || "Unknown";
-    out[status] = (out[status] || 0) + 1;
-  }
-  return out;
 }

--- a/apps/web/src/features/integrations/metrics/index.js
+++ b/apps/web/src/features/integrations/metrics/index.js
@@ -5,6 +5,11 @@ export {
   turnaroundHistogram,
   fmtDurationHours,
 } from "./turnaround";
+export {
+  resolvedTicketsInWindow,
+  medianTicketCycleDays,
+  ticketCycleHistogram,
+} from "./ticket-cycle";
 export { avgReviewerComments } from "./rounds";
 export { linkagePct } from "./linkage";
 export { countMrComments } from "./reviews";

--- a/apps/web/src/features/integrations/metrics/ticket-cycle.js
+++ b/apps/web/src/features/integrations/metrics/ticket-cycle.js
@@ -1,0 +1,77 @@
+/**
+ * Jira ticket cycle-time metrics.
+ *
+ * "Cycle time" here is the simple `resolutiondate - created` duration —
+ * MVP definition that doesn't need per-ticket changelog reads. A truer
+ * "in-progress → done" cycle time requires the Jira `expand=changelog`
+ * payload (status-transition timestamps); when we wire that we'll add a
+ * second pair of helpers here and let widgets opt in via spec.source.
+ *
+ * Pure functions — no React, no SWR. Takes the raw Jira issue array
+ * shape (objects with `fields.created`, `fields.resolutiondate`,
+ * `fields.status.name`).
+ */
+
+import { DAY_MS } from "@/lib/date";
+
+/**
+ * Keep only tickets that have BOTH `fields.created` and a non-null
+ * `fields.resolutiondate`. Optionally filter to tickets resolved on/after
+ * `sinceIso` so the window matches the rest of the AUTO metrics.
+ *
+ * `sinceIso` is the ISO string returned by `isoDaysAgo(days)` (snapped to
+ * UTC midnight). Passing `null` returns every resolved ticket.
+ */
+export function resolvedTicketsInWindow(tickets = [], sinceIso = null) {
+  const sinceMs = sinceIso ? new Date(sinceIso).getTime() : -Infinity;
+  return tickets.filter((t) => {
+    const resolved = t?.fields?.resolutiondate;
+    const created = t?.fields?.created;
+    if (!resolved || !created) return false;
+    return new Date(resolved).getTime() >= sinceMs;
+  });
+}
+
+/** Median cycle time (resolutiondate − created), in days. */
+export function medianTicketCycleDays(tickets = []) {
+  const durations = tickets
+    .filter((t) => t?.fields?.resolutiondate && t?.fields?.created)
+    .map(
+      (t) =>
+        (new Date(t.fields.resolutiondate) - new Date(t.fields.created)) /
+        DAY_MS,
+    )
+    .sort((a, b) => a - b);
+  if (durations.length === 0) return null;
+  const mid = Math.floor(durations.length / 2);
+  return durations.length % 2
+    ? durations[mid]
+    : (durations[mid - 1] + durations[mid]) / 2;
+}
+
+/**
+ * Bucketize cycle time into 6 display bins. Bins are wider than the PR
+ * turnaround histogram because Jira tickets typically live in days/weeks
+ * (a "<2h" bin is wasted real estate for ticket data).
+ */
+const BINS = [
+  { label: "<1d", max: 1 },
+  { label: "1–3d", max: 3 },
+  { label: "3–7d", max: 7 },
+  { label: "1–2w", max: 14 },
+  { label: "2–4w", max: 28 },
+  { label: ">4w", max: Infinity },
+];
+
+export function ticketCycleHistogram(tickets = []) {
+  const bins = BINS.map((b) => ({ ...b, n: 0 }));
+  for (const t of tickets) {
+    const resolved = t?.fields?.resolutiondate;
+    const created = t?.fields?.created;
+    if (!resolved || !created) continue;
+    const days = (new Date(resolved) - new Date(created)) / DAY_MS;
+    const bucket = bins.find((b) => days < b.max);
+    if (bucket) bucket.n += 1;
+  }
+  return bins;
+}


### PR DESCRIPTION
## Phase 2 of the AI + widget focus arc

`TICKET_CYCLE` was the only widget still registered as a stub:

> "Preview — shows Jira status breakdown; cycle-time coming soon."

Goals classified as `TICKET_CYCLE` (e.g. "Reduce ticket cycle time", "Close tickets faster") got a meaningless tile with raw status counts and no headline metric. Phase 2 finishes it.

## What ships

- **`metrics/ticket-cycle.js`** (new) — three pure helpers
  - `resolvedTicketsInWindow(tickets, sinceIso)` — filter to resolved-in-window
  - `medianTicketCycleDays(tickets)` — median of `resolutiondate − created`
  - `ticketCycleHistogram(tickets)` — day-grained bins: `<1d`, `1–3d`, `3–7d`, `1–2w`, `2–4w`, `>4w`

- **`use-data-source.js` TICKET_CYCLE_TIME branch** now filters by `sinceIso` (window) and returns `{ median, histogram, resolvedCount, totalCount, tickets }`.

- **Widget rewritten** to mirror `TurnaroundWidget`'s layout — same idiom so PR-throughput + ticket-throughput tiles read as a matched pair on dashboards:
  - **Headline:** median in days
  - **Right chip:** target with on/over-target badge
  - **Histogram:** 6 day bins
  - **Footer:** `ComplianceLine`
  - **Empty states:**
    - `low signal · N resolved in window` when fewer than 5 tickets resolved
    - `no resolved tickets in the last Nd` when zero

- **Registry description** updated — drops the "coming soon" hedge.

## What's still deferred

True "in-progress → done" cycle time (status-transition-based) needs the Jira `expand=changelog` payload, which the Jira client doesn't fetch yet. The MVP `resolutiondate − created` is what most teams call "cycle time" in casual conversation anyway. When we wire changelog, a second pair of helpers (`inProgressCycleDays`, `inProgressHistogram`) goes into the same file and we can let widgets opt in.

## Test plan

- [x] `next build --experimental-build-mode=compile` passes
- [ ] Click "Analyse my goals" → a goal classified as `TICKET_CYCLE` (e.g. "Reduce ticket cycle time") renders the new median + histogram instead of the status breakdown
- [ ] With no resolved tickets in the window, widget shows "no resolved tickets in the last Nd"
- [ ] With 1–4 resolved tickets, widget shows the median PLUS the "low signal" caveat
- [ ] Target chip + on/over-target badge render when `spec.source.target` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)