### PR TITLE
feat(ai): switch classifier to JSON Schema response_format

### DIFF
--- a/apps/api/src/modules/ai/classifier/mistral-classifier.ts
+++ b/apps/api/src/modules/ai/classifier/mistral-classifier.ts
@@ -25,6 +25,7 @@
 
 import { validateSpec } from "@espace-devhub/shared/goal-specs";
 import { AnalysisEvents, type AnalysisEvent } from "./events.js";
+import { SPEC_RESPONSE_SCHEMA } from "./spec-schema.js";
 
 export interface GoalForClassification {
   id: string;
@@ -332,20 +333,32 @@ async function* classifyOneGoal(
     parentL1: goal.parentL1Title,
   });
 
-  const requestBody = {
+  // Prefer JSON-Schema response_format mode — locks every enum the
+  // catalogue advertises (provider, metric, window, cadence, etc.)
+  // so the model can't return hallucinated values like
+  // `uptime_compliance` for source.metric. The fallback below handles
+  // providers that don't support `json_schema` (older OpenRouter-routed
+  // models, GLM in certain modes) by retrying with the older
+  // `json_object` mode + an explicit error from the upstream provider.
+  const baseBody = {
     model: opts.model,
     messages: [
       { role: "system", content: SYSTEM_PROMPT },
       { role: "user", content: buildUserPrompt(goal) },
     ],
     temperature: 0.2,
-    response_format: { type: "json_object" },
     stream: true,
-  };
+  } as const;
 
-  let res: Awaited<ReturnType<typeof fetch>>;
-  try {
-    res = await fetch(opts.url, {
+  const buildBody = (responseFormat: unknown) => ({
+    ...baseBody,
+    response_format: responseFormat,
+  });
+
+  const requestWithFormat = async (
+    responseFormat: unknown,
+  ): Promise<Awaited<ReturnType<typeof fetch>>> =>
+    fetch(opts.url, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${opts.apiKey}`,
@@ -353,8 +366,15 @@ async function* classifyOneGoal(
         Accept: "text/event-stream",
         ...opts.extraHeaders,
       },
-      body: JSON.stringify(requestBody),
+      body: JSON.stringify(buildBody(responseFormat)),
       signal: opts.signal,
+    });
+
+  let res: Awaited<ReturnType<typeof fetch>>;
+  try {
+    res = await requestWithFormat({
+      type: "json_schema",
+      json_schema: SPEC_RESPONSE_SCHEMA,
     });
   } catch (err) {
     yield AnalysisEvents.goalFailed({
@@ -362,6 +382,32 @@ async function* classifyOneGoal(
       error: `Network error: ${err instanceof Error ? err.message : String(err)}`,
     });
     return;
+  }
+
+  // If the provider rejects json_schema (some return 400 with a
+  // "response_format type must be ..." error, others ignore it
+  // silently — we only retry on the explicit 400), fall back to the
+  // older json_object mode. The prompt-side enum reminders still keep
+  // the model honest, just without the provider-side schema lock.
+  if (res.status === 400) {
+    const errText = await res.clone().text().catch(() => "");
+    const looksLikeSchemaUnsupported =
+      /response_format/i.test(errText) ||
+      /json[_-]?schema/i.test(errText) ||
+      /unsupported/i.test(errText);
+    if (looksLikeSchemaUnsupported) {
+      try {
+        res = await requestWithFormat({ type: "json_object" });
+      } catch (err) {
+        yield AnalysisEvents.goalFailed({
+          goalId: goal.id,
+          error: `Network error on json_object fallback: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        });
+        return;
+      }
+    }
   }
 
   if (!res.ok) {

--- a/apps/api/src/modules/ai/classifier/spec-schema.ts
+++ b/apps/api/src/modules/ai/classifier/spec-schema.ts
@@ -1,0 +1,209 @@
+/**
+ * JSON Schema for the classifier's response, passed to OpenAI-compatible
+ * providers via `response_format.json_schema`. Locks down every enum
+ * the system prompt advertises so the model literally cannot emit a
+ * value outside the catalogue (no more hallucinated metrics like
+ * `uptime_compliance` or invented kinds like `goal-tracker`).
+ *
+ * What this enforces vs. the prompt:
+ *
+ *   The PROMPT explains widget→kind pairing, widget→metric pairing, and
+ *   semantic guidance for each metric. JSON Schema can't easily express
+ *   conditional "if widget is X then kind must be Y" rules without
+ *   making the schema unmanageable (and some providers' strict-mode
+ *   implementations choke on complex `if/then/else`). So:
+ *
+ *     - Enums are enforced by the schema (provider-side) — the model
+ *       literally can't return an unknown value
+ *     - Structural rules (widget↔kind, widget↔metric pairing) are
+ *       enforced by the prompt + by validateSpec() server-side
+ *
+ *   The two layers together close the gap: prompt drives intent, schema
+ *   enforces vocabulary, validator catches anything that slips through.
+ *
+ * Why STRICT mode (`strict: true`):
+ *
+ *   Strict requires every property listed in `properties` to also be
+ *   in `required`. Optional fields become required-as-nullable using
+ *   `["type", "null"]` unions. This shape is what OpenAI / Mistral /
+ *   GLM / OpenRouter agree on. The model emits explicit `null` for
+ *   sections that don't apply — slightly more verbose JSON but
+ *   completely unambiguous and friendly to dumb parsers.
+ */
+
+export const SPEC_RESPONSE_SCHEMA = {
+  name: "goal_spec",
+  strict: true,
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "kind",
+      "widget",
+      "reasoning",
+      "source",
+      "manual",
+      "context",
+      "delegated",
+    ],
+    properties: {
+      kind: {
+        type: "string",
+        enum: ["auto", "manual", "hybrid"],
+        description:
+          "Spec variant — must match the chosen widget's canonical kind " +
+          "(see system prompt).",
+      },
+      widget: {
+        type: "string",
+        enum: [
+          "MERGED_COUNT",
+          "REVIEW_ROUNDS",
+          "TURNAROUND",
+          "LINKAGE",
+          "TICKET_CYCLE",
+          "CODE_RUBRIC",
+          "COUNTER",
+          "SCALE",
+          "MILESTONE",
+          "DATE_LOG",
+          "FREE_TEXT",
+          "BEFORE_AFTER",
+        ],
+        description: "Widget kind from the catalogue.",
+      },
+      reasoning: {
+        type: "string",
+        description: "1-2 sentence explanation shown to the user.",
+      },
+      source: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: ["provider", "metric", "window", "target"],
+        properties: {
+          provider: {
+            type: "string",
+            enum: ["github", "gitlab", "jira", "combined"],
+          },
+          metric: {
+            type: "string",
+            enum: [
+              "merged_count",
+              "avg_rounds",
+              "median_turnaround",
+              "linkage_pct",
+              "ticket_cycle_time",
+            ],
+          },
+          window: {
+            type: "string",
+            enum: ["30d", "90d", "quarter"],
+          },
+          target: {
+            type: ["object", "null"],
+            additionalProperties: false,
+            required: ["op", "value"],
+            properties: {
+              op: { type: "string", enum: ["<=", ">=", "="] },
+              value: { type: "number" },
+            },
+          },
+        },
+        description:
+          "Required for AUTO widgets that read integration data " +
+          "(MERGED_COUNT, REVIEW_ROUNDS, TURNAROUND, LINKAGE, " +
+          "TICKET_CYCLE). MUST be null for CODE_RUBRIC and MANUAL widgets.",
+      },
+      manual: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: ["prompt", "cadence", "unit", "items", "target"],
+        properties: {
+          prompt: { type: "string" },
+          cadence: {
+            type: "string",
+            enum: [
+              "daily",
+              "weekly",
+              "biweekly",
+              "monthly",
+              "quarterly",
+              "per-incident",
+              "milestone",
+              "continuous",
+            ],
+          },
+          unit: { type: ["string", "null"] },
+          items: {
+            type: ["array", "null"],
+            items: { type: "string" },
+          },
+          target: {
+            type: ["object", "null"],
+            additionalProperties: false,
+            required: ["op", "value", "period"],
+            properties: {
+              op: { type: "string", enum: ["<=", ">=", "="] },
+              value: { type: "number" },
+              period: { type: ["string", "null"] },
+            },
+          },
+        },
+        description:
+          "Required for MANUAL widgets and the manual half of HYBRID. " +
+          "MUST be null for pure AUTO widgets.",
+      },
+      context: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: ["required", "questions"],
+        properties: {
+          required: { type: "boolean" },
+          questions: {
+            type: "array",
+            items: {
+              type: "object",
+              additionalProperties: false,
+              required: ["id", "prompt", "kind", "placeholder", "options"],
+              properties: {
+                id: { type: "string" },
+                prompt: { type: "string" },
+                kind: {
+                  type: "string",
+                  enum: ["text", "list", "number", "select"],
+                },
+                placeholder: { type: ["string", "null"] },
+                options: {
+                  type: ["array", "null"],
+                  items: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        description:
+          "Optional user-supplied context. Required for CODE_RUBRIC " +
+          "(must contain a question with id 'quality-standards'). " +
+          "Otherwise null unless tracking is meaningless without an " +
+          "answer.",
+      },
+      delegated: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: ["delegated", "judge", "note"],
+        properties: {
+          delegated: { type: "boolean" },
+          judge: {
+            type: "string",
+            enum: ["manager", "senior", "peer"],
+          },
+          note: { type: "string" },
+        },
+        description:
+          "Set when the goal is evaluated by a human judge. Even when " +
+          "delegated, source/manual should still be set so the user can " +
+          "opt into self-tracking.",
+      },
+    },
+  },
+} as const;


### PR DESCRIPTION
## Phase 3 of the AI + widget arc

Locks every enum the catalogue advertises at the provider's `response_format` layer. The model literally cannot return hallucinated values like `metric: "uptime_compliance"` anymore — the upstream provider rejects the response before it reaches us.

## What changes

- **`spec-schema.ts`** (new) — strict JSON Schema for the spec object. Every enum the prompt mentions is duplicated as an `enum: [...]` constraint:

  | Field | Locked values |
  |---|---|
  | `kind` | `auto` \| `manual` \| `hybrid` |
  | `widget` | all 12 catalogued widget kinds |
  | `source.provider` | `github` \| `gitlab` \| `jira` \| `combined` |
  | `source.metric` | the 5 valid metrics |
  | `source.window` | `30d` \| `90d` \| `quarter` |
  | `target.op` | `<=` \| `>=` \| `=` |
  | `manual.cadence` | 8 canonical cadences |
  | `context.questions[].kind` | `text` \| `list` \| `number` \| `select` |
  | `delegated.judge` | `manager` \| `senior` \| `peer` |

  Optional fields use `["type", "null"]` unions so the schema passes OpenAI/Mistral/GLM strict-mode validation (every property in `required` + `additionalProperties: false` everywhere).

- **`mistral-classifier.ts`** — sends `response_format: { type: "json_schema", json_schema: SPEC_RESPONSE_SCHEMA }` on every call.

- **Graceful fallback** — if the provider returns HTTP 400 with an error body mentioning `response_format` / `json_schema` / `unsupported`, we retry the same request with the older `{ type: "json_object" }` mode. Some OpenRouter-routed models don't yet speak json_schema; this keeps them usable with prompt-only constraints.

## How this kills the known bugs

**Goal `637720000016191544` (SLA L1)** kept emitting metrics outside the 5-value enum. With provider-side schema enforcement, the model literally can't return an off-list metric — the upstream call fails or coerces back to the catalogue before our validator even sees the spec.

**Goal `637720000016180026` (Test Env Setup)** kept pairing `{ widget: TURNAROUND, kind: manual }`. Schema doesn't enforce widget→kind pairing directly (that'd require complex `if/then/else` schemas that providers reject), but Phase 1's prompt rewrite + the schema's strict structure together steer the model away from the combination.

The two layers stay complementary:
- **Prompt** explains INTENT (when to pick which metric semantically + which kind pairs with which widget)
- **Schema** enforces VOCABULARY (what values are even allowed on the wire)

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Click "Analyse my goals" — all 12 goals classify successfully (was 10/12)
- [ ] No `Spec failed validation: source.metric:` error on goal `637720000016191544`
- [ ] No `widget X is auto but spec kind is manual` error on goal `637720000016180026`
- [ ] OpenRouter as the provider still works (either via json_schema if the chosen model supports it, or via the json_object fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)