### PR TITLE
feat(analyst): review/edit pane — buffer classifier specs before commit

### DIFF
--- a/apps/web/src/features/analyst/analyst-page.jsx
+++ b/apps/web/src/features/analyst/analyst-page.jsx
@@ -9,6 +9,7 @@ import {
 } from "@/features/goal-specs";
 import { useAnalyst, ANALYST_MODES } from "./analyst-provider";
 import { AnalysisStream } from "./analysis-stream";
+import { ReviewPane } from "./review-pane";
 import { useClassifyGoals, flattenGoalsForClassification } from "./use-classify-goals";
 import { AnalystChatMode } from "./analyst-chat-mode";
 import { AI_PROVIDERS, useAiProvider } from "./use-ai-provider";
@@ -38,16 +39,33 @@ export function AnalystPage() {
     start,
     abort,
     reset,
+    pendingSpecs,
+    pendingCount,
+    commitSpec,
+    commitAllPending,
+    discardSpec,
+    discardAllPending,
+    updatePendingSpec,
   } = useClassifyGoals();
 
-  // Auto-switch to analysis mode while running; back to widgets on complete
-  // only if the user is currently on analysis (don't steal focus if they
-  // moved to chat).
+  // Auto-switch to analysis mode while running. When the run finishes
+  // and we have pending specs that need review, flip to REVIEW so the
+  // user can vet / edit / discard before anything lands in the goal-
+  // specs store. (If `pendingCount` is 0 — e.g. all goals failed — we
+  // leave the user on ANALYSIS so they can see the failure list and
+  // retry.)
   useEffect(() => {
     if (phase === "running" && mode !== ANALYST_MODES.ANALYSIS) {
       setMode(ANALYST_MODES.ANALYSIS);
     }
-  }, [phase, mode, setMode]);
+    if (
+      phase === "complete" &&
+      pendingCount > 0 &&
+      (mode === ANALYST_MODES.ANALYSIS || mode === ANALYST_MODES.WIDGETS)
+    ) {
+      setMode(ANALYST_MODES.REVIEW);
+    }
+  }, [phase, mode, pendingCount, setMode]);
 
   function handleAnalyzeAll() {
     reset();
@@ -82,6 +100,25 @@ export function AnalystPage() {
         kind: goal.kind || "L2",
       },
     ]);
+  }
+
+  /**
+   * Re-run classification on one goal by id (used by the Review pane's
+   * "Retry" buttons for failed classifications). Looks up the full
+   * goal record from the flattened tree so we have title + rubric +
+   * parent context to send to the classifier.
+   */
+  function handleRetryGoalById(goalId) {
+    const flat = flattenGoalsForClassification(goals);
+    const goal = flat.find((g) => g.id === goalId);
+    if (!goal) return;
+    handleReAnalyzeGoal({
+      id: goal.id,
+      title: goal.title,
+      rubric: goal.description,
+      parentL1Title: goal.parentL1Title,
+      kind: goal.kind,
+    });
   }
 
   function handleAnalyzeRemaining() {
@@ -154,7 +191,24 @@ export function AnalystPage() {
             events={events}
             phase={phase}
             error={error}
+            onSwitchToGrid={() => {
+              // Skip Review when there's nothing to review (e.g. all
+              // failed) — go straight to the grid.
+              if (pendingCount > 0) setMode(ANALYST_MODES.REVIEW);
+              else setMode(ANALYST_MODES.WIDGETS);
+            }}
+          />
+        ) : mode === ANALYST_MODES.REVIEW ? (
+          <ReviewPane
+            pendingSpecs={pendingSpecs}
+            events={events}
+            commitSpec={commitSpec}
+            commitAllPending={commitAllPending}
+            discardSpec={discardSpec}
+            discardAllPending={discardAllPending}
+            updatePendingSpec={updatePendingSpec}
             onSwitchToGrid={() => setMode(ANALYST_MODES.WIDGETS)}
+            onRetryGoal={handleRetryGoalById}
           />
         ) : mode === ANALYST_MODES.CHAT ? (
           <AnalystChatMode />
@@ -300,6 +354,7 @@ function ModeToggle({ mode, onMode }) {
   const MODES = [
     [ANALYST_MODES.WIDGETS, "Widgets"],
     [ANALYST_MODES.ANALYSIS, "Analysis"],
+    [ANALYST_MODES.REVIEW, "Review"],
     [ANALYST_MODES.CHAT, "Chat"],
   ];
   return (

--- a/apps/web/src/features/analyst/analyst-provider.jsx
+++ b/apps/web/src/features/analyst/analyst-provider.jsx
@@ -19,6 +19,7 @@ const AnalystContext = createContext(null);
 
 export const ANALYST_MODES = Object.freeze({
   ANALYSIS: "analysis",
+  REVIEW: "review",
   WIDGETS: "widgets",
   CHAT: "chat",
 });

--- a/apps/web/src/features/analyst/review-pane.jsx
+++ b/apps/web/src/features/analyst/review-pane.jsx
@@ -1,0 +1,552 @@
+"use client";
+
+/**
+ * Review pane — shown after classification completes, before any spec
+ * is committed to the goal-specs store.
+ *
+ * Each pending spec is rendered as a card with:
+ *   - goal title + parent L1 breadcrumb
+ *   - the classifier's reasoning (one-liner)
+ *   - widget + kind dropdowns for inline override
+ *   - block summary (source for auto, manual for manual, …)
+ *   - per-card Save / Skip buttons
+ *
+ * Bulk actions at the top:
+ *   - "Save all"     — commits every pending spec, surfaces any
+ *                       validation failures as a list
+ *   - "Discard all"  — clears the buffer without committing anything
+ *
+ * Failed classifications (goals with no spec in the buffer) are listed
+ * in a separate "Failed to classify" strip at the bottom with a
+ * "Retry this goal" button that re-runs classifier on just that goal.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  SPEC_VARIANTS,
+  ALL_SPEC_KINDS,
+  ALL_SPEC_VARIANTS,
+  SPEC_KIND_META,
+} from "@/features/goal-specs";
+import { ANALYSIS } from "./ai/analysis-events";
+
+// Map each widget to the kind(s) that are valid for it. The validator
+// already enforces this; we duplicate it here so the kind dropdown
+// disables incompatible combinations BEFORE the user tries to save.
+function validKindsFor(widget) {
+  const meta = SPEC_KIND_META[widget];
+  if (!meta) return ALL_SPEC_VARIANTS;
+  if (meta.variant === SPEC_VARIANTS.MANUAL) return [SPEC_VARIANTS.MANUAL];
+  // AUTO widgets: pure auto (e.g. MERGED_COUNT, CODE_RUBRIC) OR hybrid
+  // (auto+manual). MANUAL kind is never valid here.
+  return [SPEC_VARIANTS.AUTO, SPEC_VARIANTS.HYBRID];
+}
+
+export function ReviewPane({
+  pendingSpecs,
+  events,
+  commitSpec,
+  commitAllPending,
+  discardSpec,
+  discardAllPending,
+  updatePendingSpec,
+  onSwitchToGrid,
+  onRetryGoal,
+}) {
+  const goalsById = useMemo(() => indexGoalMetaFromEvents(events), [events]);
+  const failed = useMemo(() => extractFailures(events, pendingSpecs), [
+    events,
+    pendingSpecs,
+  ]);
+
+  const [bulkError, setBulkError] = useState(null);
+  const pendingEntries = Object.entries(pendingSpecs);
+
+  const handleSaveAll = () => {
+    setBulkError(null);
+    const { saved, failed: rejectedSpecs } = commitAllPending();
+    if (rejectedSpecs.length > 0) {
+      setBulkError(
+        `${saved} saved, ${rejectedSpecs.length} rejected by validator. ` +
+          `Fix or skip the highlighted goals.`,
+      );
+    } else if (saved > 0) {
+      // Clean run — go to the widget grid.
+      onSwitchToGrid?.();
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      <BulkStrip
+        pendingCount={pendingEntries.length}
+        failedCount={failed.length}
+        bulkError={bulkError}
+        onSaveAll={handleSaveAll}
+        onDiscardAll={() => {
+          setBulkError(null);
+          discardAllPending();
+        }}
+      />
+
+      <div className="flex min-h-0 flex-1 flex-col gap-2.5 overflow-y-auto pr-1">
+        {pendingEntries.length === 0 && failed.length === 0 ? (
+          <EmptyPlaceholder onSwitchToGrid={onSwitchToGrid} />
+        ) : null}
+
+        {pendingEntries.map(([goalId, spec]) => (
+          <PendingCard
+            key={goalId}
+            goalId={goalId}
+            spec={spec}
+            meta={goalsById.get(goalId)}
+            onSave={() => {
+              const result = commitSpec(goalId);
+              if (!result.ok) {
+                setBulkError(
+                  `Validator rejected ${goalId.slice(-4)}: ${result.errors?.join(
+                    "; ",
+                  )}`,
+                );
+              } else {
+                setBulkError(null);
+              }
+            }}
+            onSkip={() => discardSpec(goalId)}
+            onChangeWidget={(widget) => {
+              const kindsOk = validKindsFor(widget);
+              const nextKind = kindsOk.includes(spec.kind)
+                ? spec.kind
+                : kindsOk[0];
+              updatePendingSpec(goalId, { widget, kind: nextKind });
+            }}
+            onChangeKind={(kind) => updatePendingSpec(goalId, { kind })}
+          />
+        ))}
+
+        {failed.length > 0 ? (
+          <FailedStrip failed={failed} goalsById={goalsById} onRetry={onRetryGoal} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function BulkStrip({
+  pendingCount,
+  failedCount,
+  bulkError,
+  onSaveAll,
+  onDiscardAll,
+}) {
+  return (
+    <div
+      className="flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-tile)] px-4 py-3"
+      style={{
+        background: "rgba(255,255,255,0.08)",
+        border: "1px solid rgba(255,255,255,0.18)",
+      }}
+    >
+      <div className="flex items-baseline gap-3">
+        <span
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: 22,
+            letterSpacing: "-0.4px",
+          }}
+        >
+          {pendingCount}
+        </span>
+        <span
+          className="uppercase tracking-[0.6px]"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10.5,
+            color: "rgba(255,255,255,0.75)",
+          }}
+        >
+          to review
+          {failedCount > 0 ? ` · ${failedCount} failed` : ""}
+        </span>
+      </div>
+
+      {bulkError ? (
+        <div
+          className="max-w-[420px] truncate"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            color: "#fca5a5",
+          }}
+          title={bulkError}
+        >
+          {bulkError}
+        </div>
+      ) : null}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onDiscardAll}
+          disabled={pendingCount === 0}
+          className="rounded-[var(--radius-sub)] px-3 py-1.5 uppercase transition-colors hover:bg-[rgba(255,255,255,0.14)]"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            letterSpacing: "0.5px",
+            color: "rgba(255,255,255,0.9)",
+            border: "1px solid rgba(255,255,255,0.2)",
+            opacity: pendingCount === 0 ? 0.4 : 1,
+          }}
+        >
+          Discard all
+        </button>
+        <button
+          type="button"
+          onClick={onSaveAll}
+          disabled={pendingCount === 0}
+          className="rounded-[var(--radius-sub)] px-3 py-1.5 font-bold uppercase"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10.5,
+            letterSpacing: "0.5px",
+            background: "#ffffff",
+            color: "var(--accent)",
+            opacity: pendingCount === 0 ? 0.4 : 1,
+          }}
+        >
+          Save all
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function PendingCard({
+  goalId,
+  spec,
+  meta,
+  onSave,
+  onSkip,
+  onChangeWidget,
+  onChangeKind,
+}) {
+  const kindsOk = validKindsFor(spec.widget);
+  const widgetMeta = SPEC_KIND_META[spec.widget];
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-[var(--radius-tile)] px-3.5 py-3"
+      style={{
+        background: "rgba(255,255,255,0.06)",
+        border: "1px solid rgba(255,255,255,0.14)",
+      }}
+    >
+      {/* Header: goal title + parent breadcrumb */}
+      <div className="flex flex-col gap-0.5">
+        {meta?.parentL1 ? (
+          <span
+            className="uppercase tracking-[0.5px]"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 9.5,
+              color: "rgba(255,255,255,0.6)",
+            }}
+            title={`Parent L1: ${meta.parentL1}`}
+          >
+            {truncate(meta.parentL1, 70)} /
+          </span>
+        ) : null}
+        <span
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: 14,
+            letterSpacing: "-0.2px",
+          }}
+          title={meta?.title || spec.title}
+        >
+          {meta?.title || spec.title}
+        </span>
+      </div>
+
+      {/* Reasoning */}
+      {spec.reasoning ? (
+        <div
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10.5,
+            lineHeight: 1.55,
+            color: "rgba(255,255,255,0.78)",
+          }}
+        >
+          {spec.reasoning}
+        </div>
+      ) : null}
+
+      {/* Inline edit dropdowns */}
+      <div className="flex flex-wrap items-center gap-2">
+        <FieldDropdown
+          label="widget"
+          value={spec.widget}
+          onChange={onChangeWidget}
+          options={ALL_SPEC_KINDS.map((k) => ({
+            value: k,
+            label: SPEC_KIND_META[k]?.label || k,
+          }))}
+        />
+        <FieldDropdown
+          label="kind"
+          value={spec.kind}
+          onChange={onChangeKind}
+          options={ALL_SPEC_VARIANTS.map((v) => ({
+            value: v,
+            label: v,
+            disabled: !kindsOk.includes(v),
+          }))}
+        />
+        {spec.source?.metric ? (
+          <Chip>{spec.source.metric}</Chip>
+        ) : null}
+        {spec.source?.window ? <Chip>{spec.source.window}</Chip> : null}
+        {spec.manual?.cadence ? (
+          <Chip>{spec.manual.cadence}</Chip>
+        ) : null}
+        {spec.delegated ? <Chip tone="warn">delegated</Chip> : null}
+        {widgetMeta?.variant !== spec.kind &&
+        !(widgetMeta?.variant === SPEC_VARIANTS.AUTO &&
+          spec.kind === SPEC_VARIANTS.HYBRID) ? (
+          <Chip tone="danger">kind/variant mismatch</Chip>
+        ) : null}
+      </div>
+
+      {/* Action row */}
+      <div className="mt-1 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={onSkip}
+          className="rounded-[var(--radius-sub)] px-2.5 py-1 uppercase transition-colors hover:bg-[rgba(255,255,255,0.14)]"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 9.5,
+            letterSpacing: "0.4px",
+            color: "rgba(255,255,255,0.7)",
+            border: "1px solid rgba(255,255,255,0.18)",
+          }}
+        >
+          Skip
+        </button>
+        <button
+          type="button"
+          onClick={onSave}
+          className="rounded-[var(--radius-sub)] px-2.5 py-1 font-bold uppercase"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 9.5,
+            letterSpacing: "0.4px",
+            background: "rgba(255,255,255,0.92)",
+            color: "var(--accent)",
+          }}
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function FieldDropdown({ label, value, onChange, options }) {
+  return (
+    <label
+      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1"
+      style={{
+        background: "rgba(255,255,255,0.1)",
+        border: "1px solid rgba(255,255,255,0.18)",
+      }}
+    >
+      <span
+        className="uppercase tracking-[0.5px]"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 9,
+          color: "rgba(255,255,255,0.55)",
+        }}
+      >
+        {label}
+      </span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="cursor-pointer bg-transparent outline-none"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10.5,
+          color: "rgba(255,255,255,0.95)",
+        }}
+      >
+        {options.map((opt) => (
+          <option
+            key={opt.value}
+            value={opt.value}
+            disabled={opt.disabled}
+            style={{ color: "#000" }}
+          >
+            {opt.label}
+            {opt.disabled ? " (incompatible)" : ""}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function Chip({ children, tone }) {
+  const style =
+    tone === "warn"
+      ? { background: "rgba(255,193,87,0.22)", color: "#fde68a" }
+      : tone === "danger"
+        ? { background: "rgba(239,68,68,0.22)", color: "#fecaca" }
+        : {
+            background: "rgba(255,255,255,0.14)",
+            color: "rgba(255,255,255,0.85)",
+          };
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-[2px] font-semibold uppercase"
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 9.5,
+        letterSpacing: "0.4px",
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function FailedStrip({ failed, goalsById, onRetry }) {
+  return (
+    <div
+      className="mt-2 flex flex-col gap-2 rounded-[var(--radius-tile)] px-3.5 py-3"
+      style={{
+        background: "rgba(239,68,68,0.10)",
+        border: "1px solid rgba(239,68,68,0.32)",
+      }}
+    >
+      <div
+        className="uppercase tracking-[0.5px]"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          color: "#fecaca",
+        }}
+      >
+        Failed to classify ({failed.length})
+      </div>
+      {failed.map((f) => (
+        <div
+          key={f.goalId}
+          className="flex items-center justify-between gap-2"
+        >
+          <div className="min-w-0 flex-1">
+            <div
+              className="truncate font-semibold"
+              style={{ fontFamily: "var(--font-display)", fontSize: 13 }}
+            >
+              {goalsById.get(f.goalId)?.title || f.goalId}
+            </div>
+            <div
+              className="truncate"
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                color: "rgba(255,255,255,0.72)",
+              }}
+              title={f.error}
+            >
+              {f.error}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => onRetry?.(f.goalId)}
+            className="rounded-[var(--radius-sub)] px-2.5 py-1 uppercase transition-colors hover:bg-[rgba(255,255,255,0.14)]"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 9.5,
+              letterSpacing: "0.4px",
+              color: "rgba(255,255,255,0.9)",
+              border: "1px solid rgba(255,255,255,0.2)",
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyPlaceholder({ onSwitchToGrid }) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-3 rounded-[var(--radius-tile)] p-8 text-center"
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        color: "rgba(255,255,255,0.7)",
+        border: "1px dashed rgba(255,255,255,0.2)",
+      }}
+    >
+      Nothing pending review.
+      <button
+        type="button"
+        onClick={onSwitchToGrid}
+        className="rounded-[var(--radius-sub)] px-3 py-1.5 font-bold uppercase"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          letterSpacing: "0.5px",
+          background: "#ffffff",
+          color: "var(--accent)",
+        }}
+      >
+        Go to widgets →
+      </button>
+    </div>
+  );
+}
+
+/** Build a lookup of goal metadata from the GOAL_STARTED event payloads. */
+function indexGoalMetaFromEvents(events) {
+  const byId = new Map();
+  for (const evt of events) {
+    if (evt.type === ANALYSIS.GOAL_STARTED) {
+      byId.set(evt.payload.goalId, {
+        title: evt.payload.title,
+        parentL1: evt.payload.parentL1,
+      });
+    }
+  }
+  return byId;
+}
+
+/** Pull goal-failed events whose goalId isn't in pendingSpecs. */
+function extractFailures(events, pendingSpecs) {
+  const out = [];
+  for (const evt of events) {
+    if (evt.type === ANALYSIS.GOAL_FAILED) {
+      if (!pendingSpecs[evt.payload.goalId]) {
+        out.push({ goalId: evt.payload.goalId, error: evt.payload.error });
+      }
+    }
+  }
+  return out;
+}
+
+function truncate(str, n) {
+  if (!str) return "";
+  return str.length > n ? `${str.slice(0, n - 1)}…` : str;
+}

--- a/apps/web/src/features/analyst/use-classify-goals.js
+++ b/apps/web/src/features/analyst/use-classify-goals.js
@@ -23,6 +23,22 @@ import { markAnalyzedAt, saveSpec } from "@/features/goal-specs";
 import { ANALYSIS } from "./ai/analysis-events";
 
 /**
+ * Pending-spec buffer.
+ *
+ * Before the review/edit UI shipped, GOAL_CLASSIFIED events were saved
+ * immediately via saveSpec(), so a single bad classification went
+ * straight to the user's dashboard. Now we buffer them in
+ * `pendingSpecs` and surface a Review view that lets the user inspect,
+ * edit, or discard each spec before committing.
+ *
+ * `pendingSpecs` is a plain object keyed by goalId rather than a Map so
+ * React's value-equality re-render check works on Object.is(prev,next)
+ * — every mutation goes through `{ ...prev, [id]: next }` and creates a
+ * new reference. (Using a Map would require manually creating a fresh
+ * Map each update too, so the object form is slightly less ceremony.)
+ */
+
+/**
  * Flatten the L1/L2 tree into the classifier's input shape.
  *
  * The `description` field we ship is a RICHLY-STRUCTURED block that
@@ -177,6 +193,9 @@ export function useClassifyGoals() {
   const [events, setEvents] = useState([]);
   const [phase, setPhase] = useState(PHASES.IDLE);
   const [error, setError] = useState(null);
+  // Buffer for classified specs that haven't been committed yet. See
+  // the module-level comment for the rationale.
+  const [pendingSpecs, setPendingSpecs] = useState(/** @type {Record<string, object>} */ ({}));
   const abortRef = useRef(null);
   const mountedRef = useRef(true);
 
@@ -210,6 +229,77 @@ export function useClassifyGoals() {
     setEvents([]);
     setPhase(PHASES.IDLE);
     setError(null);
+    setPendingSpecs({});
+  }, []);
+
+  /**
+   * Commit a single pending spec to the goal-specs store + remove it
+   * from the pending buffer. Returns the validateSpec result so callers
+   * can surface validation errors inline.
+   */
+  const commitSpec = useCallback((goalId) => {
+    const spec = pendingSpecs[goalId];
+    if (!spec) return { ok: false, errors: ["spec not in pending buffer"] };
+    const result = saveSpec(spec);
+    if (result.ok) {
+      setPendingSpecs((prev) => {
+        const next = { ...prev };
+        delete next[goalId];
+        return next;
+      });
+    }
+    return result;
+  }, [pendingSpecs]);
+
+  /**
+   * Commit every pending spec at once. Returns { saved, failed } so the
+   * UI can show how many landed vs. were rejected by the validator.
+   */
+  const commitAllPending = useCallback(() => {
+    const ids = Object.keys(pendingSpecs);
+    let saved = 0;
+    const failed = [];
+    for (const id of ids) {
+      const result = saveSpec(pendingSpecs[id]);
+      if (result.ok) saved += 1;
+      else failed.push({ goalId: id, errors: result.errors });
+    }
+    setPendingSpecs((prev) => {
+      const next = { ...prev };
+      const stillFailed = new Set(failed.map((f) => f.goalId));
+      for (const id of Object.keys(next)) {
+        if (!stillFailed.has(id)) delete next[id];
+      }
+      return next;
+    });
+    return { saved, failed };
+  }, [pendingSpecs]);
+
+  /** Discard a single pending spec without saving. */
+  const discardSpec = useCallback((goalId) => {
+    setPendingSpecs((prev) => {
+      const next = { ...prev };
+      delete next[goalId];
+      return next;
+    });
+  }, []);
+
+  /** Discard every pending spec. */
+  const discardAllPending = useCallback(() => {
+    setPendingSpecs({});
+  }, []);
+
+  /**
+   * Apply a partial update to a pending spec (shallow merge at the top
+   * level). Used by the review UI's inline edit dropdowns — e.g. when
+   * switching widget kind we patch `{ widget: "SCALE", kind: "manual" }`
+   * and the rest of the spec stays put.
+   */
+  const updatePendingSpec = useCallback((goalId, patch) => {
+    setPendingSpecs((prev) => {
+      if (!prev[goalId]) return prev;
+      return { ...prev, [goalId]: { ...prev[goalId], ...patch } };
+    });
   }, []);
 
   const abort = useCallback(() => {
@@ -284,10 +374,14 @@ export function useClassifyGoals() {
         }
         for await (const evt of readNdjson(res.body)) {
           if (!mountedRef.current) break;
-          // Persist classified specs immediately so downstream consumers
-          // (dashboard section 5, analyst grid) update in real time.
+          // BUFFER, don't save. The Review pane lets the user accept /
+          // edit / discard each classification before it lands in the
+          // goal-specs store. `markAnalyzedAt` still fires on COMPLETE
+          // so the header's "last run" timestamp updates as soon as the
+          // run finishes (not when the user finally commits).
           if (evt.type === ANALYSIS.GOAL_CLASSIFIED && evt.payload?.spec) {
-            saveSpec(evt.payload.spec);
+            const spec = evt.payload.spec;
+            setPendingSpecs((prev) => ({ ...prev, [spec.goalId]: spec }));
           }
           setEvents((prev) => [...prev, evt]);
           if (evt.type === ANALYSIS.COMPLETE) {
@@ -319,5 +413,13 @@ export function useClassifyGoals() {
     start,
     abort,
     reset,
+    // Review/edit surface
+    pendingSpecs,
+    pendingCount: Object.keys(pendingSpecs).length,
+    commitSpec,
+    commitAllPending,
+    discardSpec,
+    discardAllPending,
+    updatePendingSpec,
   };
 }


### PR DESCRIPTION
## Phase 4 of the AI + widget arc — final phase

Previously, every `GOAL_CLASSIFIED` event landed straight in the goal-specs store. One bad classification required a manual *Re-analyze goal* round-trip to undo. Now classifier output buffers in a pending state and the user gets a Review surface to vet, edit, or discard before anything commits.

## What changes

### Hook (`use-classify-goals.js`)

- New `pendingSpecs` state: `{ [goalId]: spec }`. `reset()` clears it.
- `GOAL_CLASSIFIED` no longer calls `saveSpec` — it adds to `pendingSpecs` instead. `markAnalyzedAt` still fires on `COMPLETE` so the header's *last run* timestamp updates promptly.
- Five new methods exposed:

  | Method | Effect |
  |---|---|
  | `commitSpec(goalId)` | `saveSpec` one + remove from pending |
  | `commitAllPending()` | `saveSpec` everything; returns `{ saved, failed: [{goalId, errors}] }` |
  | `discardSpec(goalId)` | Drop one without saving |
  | `discardAllPending()` | Clear the buffer |
  | `updatePendingSpec(id, patch)` | Shallow merge into a pending spec (used by inline dropdowns) |

### `ANALYST_MODES.REVIEW` + page wiring

- When `phase` transitions to `complete` and `pendingCount > 0`, mode auto-switches to `REVIEW`.
- When the run ends with zero pending (e.g. all goals failed), we stay on `ANALYSIS` so the user can see the failure list.
- Review tab added to the ModeToggle for manual navigation.

### `review-pane.jsx` (new)

Card-per-spec layout:
- Goal title + parent L1 breadcrumb
- Classifier reasoning (the model's one-line explanation)
- **Inline widget dropdown** (12 options) + **kind dropdown** (3 options, with incompatible kinds visibly disabled per widget variant — e.g. you can't pick `manual` kind for a `TURNAROUND` widget)
- Block summary chips: `source.metric`, `source.window`, `manual.cadence`, `delegated`, plus a red `kind/variant mismatch` chip if the model emitted something the validator would reject
- Per-card **Save** / **Skip**

**Bulk strip** at the top: pendingCount, failedCount, Save all, Discard all. Save all routes through `commitAllPending()` and surfaces per-goal validator rejections inline.

**Failed strip** at the bottom: goals from `GOAL_FAILED` events that never reached pending. Each has a **Retry** button that re-runs the classifier on just that goal (reusing `handleReAnalyzeGoal` via a new lookup helper).

## Behavioural change worth flagging

Specs no longer reach the widget grid until the user explicitly commits them. **This is the whole point** — a bad classification can be fixed BEFORE it pollutes the dashboard. The trade-off is one extra click per run; the gain is no more "re-analyze just to delete a wrong widget" cycles.

## Test plan

- [x] `next build --experimental-build-mode=compile` passes
- [ ] Click "Analyse my goals" → phase ticks through analyzing → REVIEW mode auto-opens with 12 cards (or however many classified)
- [ ] Failed classifications appear in the bottom red strip with a Retry button
- [ ] Changing `widget` via dropdown auto-snaps `kind` to a compatible value
- [ ] Per-card **Save** removes the card and `useGoalWidgetItems()` picks it up in WIDGETS mode
- [ ] Per-card **Skip** removes the card without saving
- [ ] **Save all** commits everything and jumps to WIDGETS mode if clean; surfaces inline errors if any spec fails validation
- [ ] **Discard all** wipes the buffer
- [ ] **Retry** on a failed card re-runs that single goal through the classifier

## Where the AI + widget arc ends

| Phase | Status |
|---|---|
| Phase 1 — Tighten classifier prompt (#72) | ✅ |
| Phase 2 — Finish TICKET_CYCLE widget (#73) | ✅ |
| Phase 3 — JSON Schema response_format (#74) | ✅ |
| Phase 4 — Review/edit UI (this PR) | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)