### PR TITLE
feat(specs): per-project GitHub source — filter.repo + Review UI

### DIFF
--- a/apps/api/src/modules/ai/classifier/spec-schema.ts
+++ b/apps/api/src/modules/ai/classifier/spec-schema.ts
@@ -80,7 +80,7 @@ export const SPEC_RESPONSE_SCHEMA = {
       source: {
         type: ["object", "null"],
         additionalProperties: false,
-        required: ["provider", "metric", "window", "target"],
+        required: ["provider", "metric", "window", "target", "filter"],
         properties: {
           provider: {
             type: "string",
@@ -107,6 +107,22 @@ export const SPEC_RESPONSE_SCHEMA = {
             properties: {
               op: { type: "string", enum: ["<=", ">=", "="] },
               value: { type: "number" },
+            },
+          },
+          filter: {
+            type: ["object", "null"],
+            additionalProperties: false,
+            required: ["repo"],
+            properties: {
+              repo: {
+                type: ["string", "null"],
+                description:
+                  "Optional GitHub/GitLab repo slug ('owner/name' or " +
+                  "'group/project'). Leave null to count merges across " +
+                  "every connected repo (the default). The user can " +
+                  "set this in the Review pane after classification — " +
+                  "the AI should default to null here.",
+              },
             },
           },
         },

--- a/apps/web/src/features/analyst/review-pane.jsx
+++ b/apps/web/src/features/analyst/review-pane.jsx
@@ -28,6 +28,11 @@ import {
   ALL_SPEC_VARIANTS,
   SPEC_KIND_META,
 } from "@/features/goal-specs";
+import {
+  useCombinedMergedSince,
+  listReposFromMrs,
+} from "@/features/integrations";
+import { isoDaysAgo } from "@/lib/date";
 import { ANALYSIS } from "./ai/analysis-events";
 
 // Map each widget to the kind(s) that are valid for it. The validator
@@ -58,6 +63,17 @@ export function ReviewPane({
     events,
     pendingSpecs,
   ]);
+
+  // Derive the repo dropdown options from the user's merged MRs over a
+  // 90d window. Uses the same SWR cache key as the metrics layer so
+  // this is effectively a free read when the analyst is open after a
+  // dashboard visit. Returns an empty list when GitHub/GitLab isn't
+  // connected — the picker falls back to a free-text input in that case.
+  const merged90 = useCombinedMergedSince(isoDaysAgo(90));
+  const repoOptions = useMemo(
+    () => listReposFromMrs(merged90.data || []),
+    [merged90.data],
+  );
 
   const [bulkError, setBulkError] = useState(null);
   const pendingEntries = Object.entries(pendingSpecs);
@@ -100,6 +116,7 @@ export function ReviewPane({
             goalId={goalId}
             spec={spec}
             meta={goalsById.get(goalId)}
+            repoOptions={repoOptions}
             onSave={() => {
               const result = commitSpec(goalId);
               if (!result.ok) {
@@ -126,6 +143,23 @@ export function ReviewPane({
                 untrackable: reason ? { reason } : null,
               })
             }
+            onChangeRepo={(repo) => {
+              // Patch source.filter.repo in place. Null clears the
+              // scope, restoring cross-repo behaviour.
+              const nextSource = spec.source
+                ? {
+                    ...spec.source,
+                    filter: repo
+                      ? { ...(spec.source.filter || {}), repo }
+                      : (() => {
+                          if (!spec.source.filter) return null;
+                          const { repo: _drop, ...rest } = spec.source.filter;
+                          return Object.keys(rest).length > 0 ? rest : null;
+                        })(),
+                  }
+                : null;
+              updatePendingSpec(goalId, { source: nextSource });
+            }}
           />
         ))}
 
@@ -232,11 +266,13 @@ function PendingCard({
   goalId,
   spec,
   meta,
+  repoOptions = [],
   onSave,
   onSkip,
   onChangeWidget,
   onChangeKind,
   onSetUntrackable,
+  onChangeRepo,
 }) {
   const kindsOk = validKindsFor(spec.widget);
   const widgetMeta = SPEC_KIND_META[spec.widget];
@@ -245,6 +281,18 @@ function PendingCard({
     spec.untrackable?.reason || "",
   );
   const [showUntrackableEditor, setShowUntrackableEditor] = useState(false);
+
+  // Repo picker is only meaningful for AUTO data-source widgets that
+  // pull from GitHub/GitLab. CODE_RUBRIC uses its own PR pipeline so
+  // it's also relevant there; we gate on source.provider being one of
+  // the code-host values rather than on widget kind alone.
+  const sourceProvider = spec.source?.provider;
+  const showRepoPicker =
+    !isUntrackable &&
+    (sourceProvider === "github" ||
+      sourceProvider === "gitlab" ||
+      sourceProvider === "combined");
+  const currentRepo = spec.source?.filter?.repo || "";
 
   return (
     <div
@@ -330,6 +378,7 @@ function PendingCard({
         ) : null}
         {spec.delegated ? <Chip tone="warn">delegated</Chip> : null}
         {isUntrackable ? <Chip tone="warn">untrackable</Chip> : null}
+        {currentRepo ? <Chip>repo · {currentRepo}</Chip> : null}
         {!isUntrackable &&
         widgetMeta?.variant !== spec.kind &&
         !(widgetMeta?.variant === SPEC_VARIANTS.AUTO &&
@@ -337,6 +386,19 @@ function PendingCard({
           <Chip tone="danger">kind/variant mismatch</Chip>
         ) : null}
       </div>
+
+      {/* Repo scope picker — only for GitHub / GitLab / combined sources.
+          Dropdown when we have repo options from the user's merged-PR
+          history (90d); free-text input otherwise so it still works
+          when the user hasn't merged anything yet but knows their repo
+          name. "All repos" clears the filter. */}
+      {showRepoPicker ? (
+        <RepoPicker
+          value={currentRepo}
+          options={repoOptions}
+          onChange={onChangeRepo}
+        />
+      ) : null}
 
       {/* Untrackable banner + reason editor — shown when the spec is
           already flagged untrackable (read-only view + clear button)
@@ -509,6 +571,96 @@ function PendingCard({
           Save
         </button>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Repo scope chip. Dropdown when we discovered repo names from the
+ * user's merged-PR history; free-text input otherwise so the field is
+ * never useless. "All repos" is always the first dropdown option and
+ * maps to null on the spec (clears the filter).
+ */
+function RepoPicker({ value, options, onChange }) {
+  const hasOptions = options.length > 0;
+  // When the current value isn't in the discovered list (e.g. user
+  // typed something the API hasn't seen yet) keep showing it so the
+  // selection isn't quietly dropped.
+  const allOptions = useMemo(() => {
+    const out = [...options];
+    if (value && !out.includes(value)) out.unshift(value);
+    return out;
+  }, [options, value]);
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 rounded-[var(--radius-sub)] px-2.5 py-1.5"
+      style={{
+        background: "rgba(255,255,255,0.05)",
+        border: "1px solid rgba(255,255,255,0.14)",
+      }}
+    >
+      <span
+        className="uppercase tracking-[0.5px]"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 9,
+          color: "rgba(255,255,255,0.55)",
+        }}
+      >
+        Repo scope
+      </span>
+      {hasOptions ? (
+        <select
+          value={value || ""}
+          onChange={(e) => onChange(e.target.value || null)}
+          className="cursor-pointer bg-transparent outline-none"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10.5,
+            color: "rgba(255,255,255,0.95)",
+          }}
+        >
+          <option value="" style={{ color: "#000" }}>
+            All repos
+          </option>
+          {allOptions.map((slug) => (
+            <option key={slug} value={slug} style={{ color: "#000" }}>
+              {slug}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          type="text"
+          value={value || ""}
+          onChange={(e) => onChange(e.target.value.trim() || null)}
+          placeholder="owner/name (leave empty for all)"
+          className="flex-1 bg-transparent outline-none"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10.5,
+            color: "rgba(255,255,255,0.95)",
+            minWidth: 200,
+          }}
+        />
+      )}
+      {value ? (
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          className="uppercase transition-colors hover:opacity-90"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 9,
+            letterSpacing: "0.5px",
+            color: "rgba(255,255,255,0.55)",
+          }}
+          title="Drop the repo filter — count merges across every connected repo."
+        >
+          clear
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/goal-widgets/data-sources/source-deps.js
+++ b/apps/web/src/features/goal-widgets/data-sources/source-deps.js
@@ -23,6 +23,8 @@ export {
   resolvedTicketsInWindow,
   medianTicketCycleDays,
   ticketCycleHistogram,
+  filterMrsByRepo,
+  listReposFromMrs,
 } from "@/features/integrations";
 
 export { SOURCE_METRICS } from "@/features/goal-specs";

--- a/apps/web/src/features/goal-widgets/data-sources/use-data-source.js
+++ b/apps/web/src/features/goal-widgets/data-sources/use-data-source.js
@@ -33,6 +33,7 @@ import {
   resolvedTicketsInWindow,
   medianTicketCycleDays,
   ticketCycleHistogram,
+  filterMrsByRepo,
   SOURCE_METRICS,
 } from "./source-deps";
 
@@ -88,10 +89,18 @@ export function useDataSource(source) {
 
   const metric = source?.metric;
   const provider = source?.provider || "combined";
+  // Optional per-spec repo scope. When `spec.source.filter.repo` is set,
+  // the merged-MR list is filtered to only that "owner/name" /
+  // "group/project" slug BEFORE the metric math runs. Null/empty leaves
+  // the cross-repo behaviour intact (the old default).
+  const repoFilter = source?.filter?.repo || null;
 
   // One pair of merged-list hooks serves merged_count, avg_rounds,
   // median_turnaround, and linkage_pct.
   const merged = useMergedByProvider(provider, sinceIso);
+  const filteredMerged = repoFilter
+    ? filterMrsByRepo(merged.data, repoFilter)
+    : merged.data;
 
   if (!source || !metric) {
     return { data: null, isLoading: false, error: null, windowDays: days };
@@ -99,12 +108,14 @@ export function useDataSource(source) {
 
   // Compute-on-demand — cheap, and keeps this file pure-ish.
   if (metric === SOURCE_METRICS.MERGED_COUNT) {
-    const count = merged.data
-      ? mergedWithin(merged.data, days).length
+    const count = filteredMerged
+      ? mergedWithin(filteredMerged, days).length
       : null;
-    const trend = merged.data ? mergedTrend(merged.data, 8).map((b) => b.n) : [];
+    const trend = filteredMerged
+      ? mergedTrend(filteredMerged, 8).map((b) => b.n)
+      : [];
     return {
-      data: { count, trend, rawMrs: merged.data || [] },
+      data: { count, trend, rawMrs: filteredMerged || [] },
       isLoading: merged.isLoading,
       error: merged.error,
       windowDays: days,
@@ -112,7 +123,7 @@ export function useDataSource(source) {
   }
 
   if (metric === SOURCE_METRICS.AVG_ROUNDS) {
-    const mrs = merged.data || [];
+    const mrs = filteredMerged || [];
     const value = mrs.length > 0 ? avgReviewerComments(mrs) : null;
     return {
       data: { value, rawMrs: mrs },
@@ -123,7 +134,7 @@ export function useDataSource(source) {
   }
 
   if (metric === SOURCE_METRICS.MEDIAN_TURNAROUND) {
-    const mrs = merged.data || [];
+    const mrs = filteredMerged || [];
     const median = mrs.length > 0 ? medianTurnaroundDays(mrs) : null;
     const histogram = turnaroundHistogram(mrs);
     return {
@@ -135,7 +146,7 @@ export function useDataSource(source) {
   }
 
   if (metric === SOURCE_METRICS.LINKAGE_PCT) {
-    const mrs = merged.data || [];
+    const mrs = filteredMerged || [];
     const value = mrs.length > 0 ? linkagePct(mrs) : null;
     return {
       data: { ...(value || {}), rawMrs: mrs },

--- a/apps/web/src/features/integrations/metrics/index.js
+++ b/apps/web/src/features/integrations/metrics/index.js
@@ -12,6 +12,7 @@ export {
 } from "./ticket-cycle";
 export { avgReviewerComments } from "./rounds";
 export { linkagePct } from "./linkage";
+export { mrRepo, filterMrsByRepo, listReposFromMrs } from "./repo-filter";
 export { countMrComments } from "./reviews";
 export { dailyActivity, totalEvents, peakPerDay } from "./activity";
 export { deriveAttention } from "./attention";

--- a/apps/web/src/features/integrations/metrics/repo-filter.js
+++ b/apps/web/src/features/integrations/metrics/repo-filter.js
@@ -1,0 +1,62 @@
+/**
+ * Repo-slug extraction + filtering for normalised merge-request rows.
+ *
+ * GitHub and GitLab both expose a `web_url` like
+ *   https://github.com/owner/name/pull/123
+ *   https://gitlab.com/group/project/-/merge_requests/123
+ *
+ * From either, the segment between the host and the PR-path is the
+ * repo slug we care about ("owner/name" or "group/project"). Doing the
+ * parse here keeps the normalisers (`github-normalize.js`,
+ * `gitlab.js`) untouched and lets `useDataSource` filter both
+ * providers uniformly.
+ *
+ * No regex anchoring on the host so this works for github.com, GHE,
+ * self-hosted GitLab, etc.
+ */
+
+const GITHUB_PR_RE = /^https?:\/\/[^/]+\/(.+?)\/pull\//i;
+const GITLAB_MR_RE = /^https?:\/\/[^/]+\/(.+?)\/-\/merge_requests\//i;
+
+/**
+ * Return the `owner/name` (or `group/project`) for a normalised MR,
+ * or null when we can't tell. Always returns lower-case so a
+ * case-insensitive filter equals comparison works on either side.
+ */
+export function mrRepo(mr) {
+  if (!mr) return null;
+  const url = mr.web_url || mr.repository_url || "";
+  if (!url) return null;
+  const m = url.match(GITHUB_PR_RE) || url.match(GITLAB_MR_RE);
+  if (!m) return null;
+  return m[1].toLowerCase();
+}
+
+/**
+ * Filter an array of MRs to only those whose repo matches the target.
+ * Comparison is case-insensitive. A null / empty / undefined target
+ * is a no-op (returns the input unchanged) so call sites don't have
+ * to gate on the presence of the filter.
+ */
+export function filterMrsByRepo(mrs, repo) {
+  if (!Array.isArray(mrs)) return [];
+  if (!repo || typeof repo !== "string") return mrs;
+  const target = repo.trim().toLowerCase();
+  if (!target) return mrs;
+  return mrs.filter((m) => mrRepo(m) === target);
+}
+
+/**
+ * Build a unique, sorted list of repo slugs from a list of MRs. Used
+ * by the Review pane's repo picker — derives the dropdown options
+ * straight from the data the user has access to, so we don't need a
+ * separate "list all my repos" API call.
+ */
+export function listReposFromMrs(mrs) {
+  const set = new Set();
+  for (const m of mrs || []) {
+    const r = mrRepo(m);
+    if (r) set.add(r);
+  }
+  return [...set].sort();
+}

--- a/packages/shared/src/goal-specs/types.d.ts
+++ b/packages/shared/src/goal-specs/types.d.ts
@@ -107,7 +107,17 @@ export interface SpecSource {
   provider: SourceProvider;
   metric: SourceMetric;
   window: SourceWindow;
-  filter?: { label?: string; branch?: string; ticketType?: string };
+  filter?: {
+    label?: string;
+    branch?: string;
+    ticketType?: string;
+    /**
+     * GitHub/GitLab repo slug ("owner/name" or "group/project").
+     * When set, the metrics layer filters merged-MR results to only
+     * this repo before computing counts/medians.
+     */
+    repo?: string;
+  };
   target?: SpecTarget;
 }
 

--- a/packages/shared/src/goal-specs/validator.js
+++ b/packages/shared/src/goal-specs/validator.js
@@ -91,6 +91,13 @@ function validateSource(source, errors) {
       filter.branch = source.filter.branch.trim();
     if (isNonEmptyString(source.filter.ticketType))
       filter.ticketType = source.filter.ticketType.trim();
+    // Scope a GitHub/GitLab source to a single repo. Value is the
+    // "owner/name" or "group/project" slug; the metrics layer filters
+    // the merged-MR array via filterMrsByRepo() before computing
+    // counts / medians / linkage. Lower-cased here so the runtime
+    // comparison is case-insensitive.
+    if (isNonEmptyString(source.filter.repo))
+      filter.repo = source.filter.repo.trim().toLowerCase();
     if (Object.keys(filter).length > 0) out.filter = filter;
   }
   const target = validateTarget(source.target, "source", errors);


### PR DESCRIPTION
## Summary
- Phase B of the AI/widgets arc: AUTO widgets can now scope to a single GitHub/GitLab repo via `spec.source.filter.repo`.
- New `<RepoPicker>` in the Review pane: dropdown when discovered from the user's 90d merged-PR history, free-text fallback. "All repos" clears the filter.
- One filter applied once in `useDataSource` — MERGED_COUNT, REVIEW_ROUNDS, TURNAROUND, and LINKAGE all see the scoped list.

## Why
Before this, the spec couldn't express *which* repo a goal was about. Counting "merge 5 PRs/month" across every connected repo was the only option. Phase B closes that gap so the same dev-hub account can track separate goals on separate projects.

## Stack
- **Shared spec**: `source.filter.repo` (lower-cased slug) — validator + types + d.ts.
- **Classifier schema**: `filter` added to `source.required[]`; AI defaults `repo` to `null`, user picks scope in Review.
- **Data layer**: new `metrics/repo-filter.js` parses `web_url` for GitHub (`/pull/`) and GitLab (`/-/merge_requests/`). `useDataSource` applies the filter before the four merged-MR branches.
- **Review pane**: derives options from the same SWR cache the dashboard reads, so no extra API call.

## Test plan
- [ ] Classify a goal like "merge 5 PRs on nova-sudo/eSpaceDev in 30d" → review pane shows a `<RepoPicker>` populated from discovered repos.
- [ ] Pick a repo → chip `repo · nova-sudo/espacedev` appears; saved spec has `source.filter.repo: "nova-sudo/espacedev"`.
- [ ] On the dashboard, the MERGED_COUNT tile shows only PRs from that repo (compare to before-filter count).
- [ ] Clear the picker → spec drops `filter.repo`, dashboard reverts to cross-repo count.
- [ ] Untrackable cards do NOT show the picker.
- [ ] CODE_RUBRIC / TICKET_CYCLE / pure-MANUAL widgets do NOT show the picker (only github / gitlab / combined providers trigger it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)