### PR TITLE
feat(ai): context-driven re-analysis — opt-in reclassify with user answers

### DIFF
--- a/apps/api/src/modules/ai/classifier/mistral-classifier.ts
+++ b/apps/api/src/modules/ai/classifier/mistral-classifier.ts
@@ -27,12 +27,29 @@ import { validateSpec } from "@espace-devhub/shared/goal-specs";
 import { AnalysisEvents, type AnalysisEvent } from "./events.js";
 import { SPEC_RESPONSE_SCHEMA } from "./spec-schema.js";
 
+/**
+ * One Q→A pair from the user's saved goal-context answers. Front-end
+ * resolves the question id to its `prompt` text before sending — the
+ * classifier shouldn't need to know about our internal id slugs.
+ *
+ * Phase C: when present, this block is rendered into the user prompt
+ * BELOW the rubric so the classifier can use the user's own definitions
+ * for vague terms like "quality standards" or "success criteria" that
+ * a first-pass classification would have to ask about via `context`.
+ */
+export interface GoalContextAnswer {
+  prompt: string;
+  answer: string;
+}
+
 export interface GoalForClassification {
   id: string;
   title: string;
   description?: string;
   parentL1Title?: string;
   kind: "L1" | "L2";
+  /** Optional user-supplied context answers for re-analysis. */
+  contextAnswers?: GoalContextAnswer[];
 }
 
 export interface ClassifierConfig {
@@ -235,6 +252,22 @@ function buildSystemPrompt(): string {
     "MANUAL/SCALE widget with a vague prompt for a goal that can't really be",
     "measured is worse than admitting the gap.",
     "",
+    "═══ USER-SUPPLIED CONTEXT ════════════════════════════════════════",
+    "",
+    "Some calls include a \"User-supplied context (authoritative...)\" block",
+    "below the rubric. When present:",
+    "  • Treat those answers as the user's GROUND TRUTH for any vague",
+    "    concepts in the goal (\"quality standards\", \"success criteria\",",
+    "    \"agreed definitions\"). The user has already defined them — your",
+    "    job is to pick the widget that fits THAT definition.",
+    "  • Do NOT re-emit a `context.required: true` question asking the",
+    "    same thing back. The answer is already on the prompt.",
+    "  • The user's answers may push you AWAY from the widget a context-",
+    "    less classification would have picked. Example: a goal \"All code",
+    "    meets team standards\" with answers like \"PR must close a Jira",
+    "    ticket\" is closer to LINKAGE than CODE_RUBRIC. Use the answers",
+    "    as the strongest signal.",
+    "",
     "═══ OUTPUT SCHEMA ════════════════════════════════════════════════",
     "",
     "Return ONE JSON object. No prose, no markdown, no code fences. Shape:",
@@ -342,6 +375,26 @@ function buildUserPrompt(goal: GoalForClassification): string {
   ];
   if (goal.description) lines.push(`Description / rubric: ${goal.description}`);
   if (goal.parentL1Title) lines.push(`Parent L1 goal: ${goal.parentL1Title}`);
+  // Phase C: render the user's previously-supplied context answers as
+  // bullets BELOW the rubric. Marked "authoritative" so the model
+  // prefers these definitions to its own guess for vague terms. When
+  // present, the model should usually NOT re-emit a `context.required`
+  // block — the user has already answered.
+  if (goal.contextAnswers && goal.contextAnswers.length > 0) {
+    lines.push("");
+    lines.push("User-supplied context (authoritative — use these definitions):");
+    for (const { prompt, answer } of goal.contextAnswers) {
+      const trimmedPrompt = prompt.trim();
+      const trimmedAnswer = answer.trim();
+      if (!trimmedPrompt || !trimmedAnswer) continue;
+      lines.push(`  • ${trimmedPrompt}`);
+      // Indent multi-line answers two extra spaces so the bullet
+      // structure stays readable when the user pasted a list or rubric.
+      for (const ln of trimmedAnswer.split(/\r?\n/)) {
+        lines.push(`      ${ln}`);
+      }
+    }
+  }
   lines.push("", "Classify this goal. Respond with a single JSON object.");
   return lines.join("\n");
 }

--- a/apps/api/src/modules/ai/classify-controller.ts
+++ b/apps/api/src/modules/ai/classify-controller.ts
@@ -32,6 +32,16 @@ import {
 
 // ─── input schema ────────────────────────────────────────────────────
 
+// `contextAnswers` is the Phase C re-analysis input. The Q→A pairs let
+// the classifier refine its widget choice with the user's own
+// definitions for vague terms (e.g. "quality standards"). Bounded
+// generously so a long rubric-style answer fits, but capped per-entry
+// and per-array so a malformed client can't blow up the prompt.
+const contextAnswerSchema = z.object({
+  prompt: z.string().min(1).max(500),
+  answer: z.string().min(1).max(4_000),
+});
+
 const classifyGoalsSchema = z.object({
   goals: z
     .array(
@@ -41,6 +51,7 @@ const classifyGoalsSchema = z.object({
         description: z.string().max(8_000).optional(),
         parentL1Title: z.string().max(500).optional(),
         kind: z.enum(["L1", "L2"]).default("L1"),
+        contextAnswers: z.array(contextAnswerSchema).max(8).optional(),
       }),
     )
     .min(1)
@@ -115,6 +126,19 @@ export async function classifyGoalsHandler(
       ? { parentL1Title: g.parentL1Title.trim() }
       : {}),
     kind: g.kind,
+    // Phase C: trim each Q/A pair and drop empty pairs so the prompt
+    // builder sees a clean array. An empty resulting array means
+    // "no context supplied" and the prompt skips the block entirely.
+    ...(g.contextAnswers && g.contextAnswers.length > 0
+      ? {
+          contextAnswers: g.contextAnswers
+            .map((a) => ({
+              prompt: a.prompt.trim(),
+              answer: a.answer.trim(),
+            }))
+            .filter((a) => a.prompt && a.answer),
+        }
+      : {}),
   }));
 
   // Client disconnect → abort the classifier so in-flight fetches stop.

--- a/apps/web/src/features/analyst/index.js
+++ b/apps/web/src/features/analyst/index.js
@@ -20,3 +20,4 @@ export {
   CLASSIFY_PHASES,
   flattenGoalsForClassification,
 } from "./use-classify-goals";
+export { reclassifyOneGoal } from "./reclassify-one-goal";

--- a/apps/web/src/features/analyst/reclassify-one-goal.js
+++ b/apps/web/src/features/analyst/reclassify-one-goal.js
@@ -1,0 +1,159 @@
+"use client";
+
+/**
+ * One-shot single-goal re-classification.
+ *
+ * The full `useClassifyGoals` hook owns a live events log + a
+ * pendingSpecs buffer because the analyst page needs to render a
+ * process-reveal stream and a Review pane. The dashboard's
+ * ContextCollector doesn't need any of that — it just wants to send
+ * one goal + its saved context answers to the classifier, wait, and
+ * get a single spec back.
+ *
+ * This helper opens the same NDJSON endpoint, parses until it sees the
+ * GOAL_CLASSIFIED event for the goalId it submitted, and resolves
+ * with that spec. GOAL_FAILED rejects. COMPLETE without seeing either
+ * also rejects.
+ *
+ * Why not reuse the hook? Because the hook's state machine is tied to
+ * the analyst page's modes (RUNNING → COMPLETE → REVIEW), and pulling
+ * it into a dashboard tile would either:
+ *   (a) hijack the analyst's events log while the user is on the
+ *       dashboard, or
+ *   (b) duplicate every piece of state across two parallel hook copies.
+ *
+ * Keeping this as a thin Promise-returning function means the tile can
+ * `setBusy(true)` → await → `saveSpec(newSpec)` with no entanglement.
+ */
+
+import { ANALYSIS } from "./ai/analysis-events";
+
+/**
+ * Read a ReadableStream of NDJSON line-by-line. Identical to the
+ * reader inside `use-classify-goals.js` — duplicated here on purpose
+ * so this helper can be imported by code paths that don't pull in
+ * the full hook (avoids a circular-dep concern when the helper later
+ * gets used from goal-widgets, which is upstream of analyst features
+ * in our dependency graph).
+ */
+async function* readNdjson(stream) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let idx;
+      while ((idx = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, idx).trim();
+        buffer = buffer.slice(idx + 1);
+        if (!line) continue;
+        try {
+          yield JSON.parse(line);
+        } catch {
+          /* skip bad line */
+        }
+      }
+    }
+    const tail = buffer.trim();
+    if (tail) {
+      try {
+        yield JSON.parse(tail);
+      } catch {
+        /* ignore */
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Re-classify a single goal with optional user-supplied context.
+ *
+ * @param {object} args
+ * @param {object} args.goal — shape matches the classifier's input
+ *   schema: { id, title, description?, parentL1Title?, kind }.
+ * @param {Array<{prompt:string, answer:string}>} [args.contextAnswers] —
+ *   Q→A pairs resolved from the user's goal-context store. Empty pairs
+ *   are dropped on the server but skipping the array entirely is fine.
+ * @param {AbortSignal} [args.signal] — caller-owned abort signal.
+ *
+ * @returns {Promise<object>} the validated spec for `goal.id`. Throws
+ *   on network failure, classifier failure, or if the stream ends
+ *   without producing a spec for this goal.
+ */
+export async function reclassifyOneGoal({ goal, contextAnswers, signal }) {
+  if (!goal?.id) {
+    throw new Error("reclassifyOneGoal: goal.id is required");
+  }
+  const provider =
+    typeof localStorage !== "undefined"
+      ? localStorage.getItem("espace-devhub:ai-provider") || "mistral"
+      : "mistral";
+
+  // Build the request body. The API trims + filters empty Q/A pairs
+  // server-side so we don't repeat that here; we just pass through.
+  const body = {
+    goals: [
+      {
+        id: goal.id,
+        title: goal.title,
+        ...(goal.description ? { description: goal.description } : {}),
+        ...(goal.parentL1Title ? { parentL1Title: goal.parentL1Title } : {}),
+        kind: goal.kind || "L2",
+        ...(Array.isArray(contextAnswers) && contextAnswers.length > 0
+          ? { contextAnswers }
+          : {}),
+      },
+    ],
+    provider,
+  };
+
+  const res = await fetch("/api/v1/ai/classify-goals", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "x-ai-provider": provider,
+    },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({}));
+    throw new Error(
+      errBody?.error?.message ||
+        errBody?.error ||
+        `Classifier responded ${res.status}`,
+    );
+  }
+  if (!res.body) {
+    throw new Error("Classifier returned an empty stream.");
+  }
+
+  // Walk the stream until we see GOAL_CLASSIFIED (success) or
+  // GOAL_FAILED (failure) for this goal. We also surface a generic
+  // failure if the stream COMPLETEs without either — should never
+  // happen, but the analyst page handles the same case so we mirror
+  // it here.
+  for await (const evt of readNdjson(res.body)) {
+    if (
+      evt.type === ANALYSIS.GOAL_CLASSIFIED &&
+      evt.payload?.spec?.goalId === goal.id
+    ) {
+      return evt.payload.spec;
+    }
+    if (
+      evt.type === ANALYSIS.GOAL_FAILED &&
+      evt.payload?.goalId === goal.id
+    ) {
+      throw new Error(
+        evt.payload?.error || "Classifier failed to produce a spec.",
+      );
+    }
+  }
+  throw new Error("Classifier finished without producing a spec.");
+}

--- a/apps/web/src/features/goal-widgets/goal-widget.jsx
+++ b/apps/web/src/features/goal-widgets/goal-widget.jsx
@@ -32,6 +32,14 @@ import { UntrackableCard } from "./state-shells/untrackable-card";
 import { ContextCollector } from "./state-shells/context-collector";
 import { useIsContextComplete } from "@/features/goal-context";
 import { saveSpec } from "@/features/goal-specs";
+// Import directly (not via @/features/analyst) to keep the dep edge
+// goal-widgets → analyst one-way at the module level. analyst-page.jsx
+// pulls GoalWidgetsGrid from @/features/goal-widgets so taking the
+// barrel path here would close a cycle; ES-module cycles often work
+// but can hand back `undefined` to whichever side initialised first.
+// reclassify-one-goal.js itself only depends on `./ai/analysis-events`,
+// which is below both features in our dep graph.
+import { reclassifyOneGoal } from "@/features/analyst/reclassify-one-goal";
 
 export function GoalWidget({ spec, goal, variant = "light", className, onRetry }) {
   // User override — force the collector to re-open even after answers exist.
@@ -94,6 +102,17 @@ export function GoalWidget({ spec, goal, variant = "light", className, onRetry }
         // path), which made it look like Save did nothing AND made
         // the rubric widget's regrade button unreachable.
         onSaved={() => setForceEditContext(false)}
+        // Phase C: opt-in "Re-analyze with these answers". Send the
+        // freshly-serialised Q/A pairs to the classifier and replace
+        // this goal's spec with the new one — which may pick a
+        // DIFFERENT widget if the user's definitions point elsewhere
+        // (e.g. CODE_RUBRIC → LINKAGE when the user defined "quality"
+        // as "PR closes a Jira ticket"). Errors propagate up to the
+        // collector via the rejected promise so the inline banner
+        // shows what went wrong.
+        onReclassify={async (pairs) => {
+          await runReclassify(spec, goal, pairs);
+        }}
       />
     );
   }
@@ -174,4 +193,42 @@ function toggleDelegated(spec, value) {
  */
 function clearUntrackable(spec) {
   saveSpec({ ...spec, untrackable: null });
+}
+
+/**
+ * Re-classify a single goal with the user's freshly-saved context
+ * answers folded into the prompt. On success the new spec replaces
+ * the existing one in the goal-specs store — which causes the
+ * `<GoalWidget>` to re-render and the new widget body (possibly a
+ * different widget kind) to take the slot.
+ *
+ * Implementation notes:
+ *  - `useCallback` would be appropriate here if React lifted closures
+ *    out of the JSX, but since the parent component already memoises
+ *    the JSX via React's normal re-render path AND the underlying
+ *    `reclassifyOneGoal` opens a one-shot fetch per call, a fresh
+ *    arrow per render is fine — the user can only click the button
+ *    after a network round-trip.
+ *  - We deliberately DON'T merge the new spec on top of the old one
+ *    (`{ ...oldSpec, ...newSpec }`) because the classifier may have
+ *    changed widget + kind + source + manual + context together; a
+ *    field-by-field merge would leave a half-old / half-new spec
+ *    that violates the variant↔widget pairing the validator enforces.
+ *    The classifier returns a complete spec; we save that.
+ *  - The `goal.title` / `goal.rubric` / `goal.kind` fields are pulled
+ *    from the goal prop the dashboard already passes in — same source
+ *    of truth as the analyst's `flattenGoalsForClassification`.
+ */
+async function runReclassify(spec, goal, contextAnswers) {
+  const result = await reclassifyOneGoal({
+    goal: {
+      id: spec.goalId,
+      title: goal?.title || spec.title || "(untitled)",
+      description: goal?.rubric || goal?.description || "",
+      parentL1Title: goal?.parentL1Title,
+      kind: goal?.kind || "L2",
+    },
+    contextAnswers,
+  });
+  saveSpec(result);
 }

--- a/apps/web/src/features/goal-widgets/state-shells/context-collector.jsx
+++ b/apps/web/src/features/goal-widgets/state-shells/context-collector.jsx
@@ -16,6 +16,13 @@ import { useGoalContext } from "@/features/goal-context";
  * UI contract: stays visually consistent with every other widget tile.
  * Inputs are inverse-themed on section 5 / analyst page (`variant="light"`)
  * and default-themed on a regular dashboard tile (`variant="dark"`).
+ *
+ * Phase C: when `onReclassify` is provided, an opt-in
+ * "Re-analyze with these answers" button appears next to "Save".
+ * Clicking it commits the draft AND triggers a single-goal
+ * classifier run with the answers folded into the prompt — the
+ * classifier can then pick a different widget if the user's
+ * definitions point somewhere else.
  */
 export function ContextCollector({
   spec,
@@ -24,12 +31,20 @@ export function ContextCollector({
   className,
   onRetry,
   onSaved,
+  onReclassify,
 }) {
   const { answers, setAnswers } = useGoalContext(spec.goalId);
   const questions = spec.context?.questions || [];
   // Local draft — persist only on blur / submit so every keystroke doesn't
   // fire a localStorage write.
   const [draft, setDraft] = useState(() => seedDraft(questions, answers));
+  // Re-analysis state. `busy` disables both buttons; `reclassifyError`
+  // shows a one-line inline message under the form on failure (e.g.
+  // upstream provider error). On success we just hand off to onSaved()
+  // — the parent will swap the widget body to the (possibly different)
+  // new widget.
+  const [busy, setBusy] = useState(false);
+  const [reclassifyError, setReclassifyError] = useState(null);
 
   function update(id, value) {
     setDraft((d) => ({ ...d, [id]: value }));
@@ -45,6 +60,30 @@ export function ContextCollector({
   function commit() {
     const normalized = normalizeAnswers(questions, draft);
     setAnswers(normalized);
+    return normalized;
+  }
+
+  async function handleReclassify() {
+    if (!onReclassify || busy) return;
+    setReclassifyError(null);
+    setBusy(true);
+    try {
+      // Always commit the draft first so the spec switch doesn't
+      // strand the user's typed answers if they immediately edit
+      // again. The parent receives the SAME serialised Q/A pairs the
+      // server prompt will see, so the back-end + front-end stay
+      // in sync about what the model was actually asked.
+      const normalized = commit();
+      const pairs = buildAnswerPairs(questions, normalized);
+      await onReclassify(pairs);
+      // Parent saved the new spec; widget body now renders whatever
+      // the classifier chose this time.
+      onSaved?.();
+    } catch (err) {
+      setReclassifyError(err?.message || String(err));
+    } finally {
+      setBusy(false);
+    }
   }
 
   return (
@@ -93,22 +132,107 @@ export function ContextCollector({
             />
           ))}
         </div>
-        <button
-          type="submit"
-          className="self-start rounded-[var(--radius-sub)] px-3 py-1.5 font-bold uppercase transition-opacity"
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: 10.5,
-            letterSpacing: "0.5px",
-            background: variant === "light" ? "#ffffff" : "var(--accent)",
-            color: variant === "light" ? "var(--accent)" : "var(--accent-on)",
-          }}
-        >
-          Save answers
-        </button>
+        {reclassifyError ? (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              color: variant === "light" ? "#ffd5d5" : "var(--danger)",
+              lineHeight: 1.4,
+            }}
+          >
+            Re-analyze failed: {reclassifyError}
+          </div>
+        ) : null}
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded-[var(--radius-sub)] px-3 py-1.5 font-bold uppercase transition-opacity"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10.5,
+              letterSpacing: "0.5px",
+              background:
+                variant === "light" ? "#ffffff" : "var(--accent)",
+              color:
+                variant === "light" ? "var(--accent)" : "var(--accent-on)",
+              opacity: busy ? 0.55 : 1,
+              cursor: busy ? "not-allowed" : "pointer",
+            }}
+          >
+            Save answers
+          </button>
+          {/* Re-analyze is an OPT-IN escalation — only rendered when the
+              parent (GoalWidget on the dashboard) supplies onReclassify.
+              The Review pane and other contexts that show this collector
+              without a reclassify path simply don't pass the prop, so
+              the button never appears. */}
+          {onReclassify ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={handleReclassify}
+              className="rounded-[var(--radius-sub)] px-3 py-1.5 font-bold uppercase transition-opacity"
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 10.5,
+                letterSpacing: "0.5px",
+                background: "transparent",
+                color: variant === "light" ? "#ffffff" : "var(--fg)",
+                border:
+                  variant === "light"
+                    ? "1px solid rgba(255,255,255,0.55)"
+                    : "1px solid var(--border)",
+                opacity: busy ? 0.55 : 1,
+                cursor: busy ? "not-allowed" : "pointer",
+              }}
+              title="Re-run the AI classifier with your answers so it can pick a different widget if the answers point elsewhere."
+            >
+              {busy ? "Re-analyzing…" : "Re-analyze with these answers"}
+            </button>
+          ) : null}
+        </div>
       </form>
     </WidgetShell>
   );
+}
+
+/**
+ * Build the Q→A pairs the classifier sees on the prompt. Each entry
+ * pairs the human-readable question text with a single serialised
+ * string answer (lists are joined with newlines so the prompt formatter
+ * can render them as nested bullets). Empty answers are filtered out
+ * so the prompt doesn't show "  • What's your standard?\n      "
+ * lines that confuse the model.
+ */
+function buildAnswerPairs(questions, normalizedAnswers) {
+  const out = [];
+  for (const q of questions) {
+    const raw = normalizedAnswers[q.id];
+    const answer = serializeAnswer(raw, q.kind);
+    if (!answer) continue;
+    out.push({
+      prompt: q.prompt,
+      answer,
+    });
+  }
+  return out;
+}
+
+function serializeAnswer(value, kind) {
+  if (value == null) return "";
+  if (kind === "list") {
+    return Array.isArray(value)
+      ? value.map((s) => String(s).trim()).filter(Boolean).join("\n")
+      : "";
+  }
+  if (kind === "number") {
+    return typeof value === "number" && !Number.isNaN(value)
+      ? String(value)
+      : "";
+  }
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function QuestionField({ question: q, value, onChange, onBlur, variant }) {


### PR DESCRIPTION
## Summary
- Phase C of the AI/widgets arc. After the user answers `context.required` questions, an opt-in **Re-analyze with these answers** button asks the classifier to pick again with the answers folded into the prompt.
- The classifier can switch widget kinds (e.g. CODE_RUBRIC → LINKAGE) when the user's definitions point elsewhere.
- One-shot helper (`reclassifyOneGoal`) so the dashboard tile doesn't hijack the analyst's pendingSpecs buffer.

## Why
The first-pass classifier sees `Title + Description + Rubric` and asks the user to define vague terms via `context.required`. Until now those answers were a write-only side-channel — saved to the goal-context store, used by widget bodies, but never seen by the AI. Phase C closes that loop: the answers become input to a second classifier pass.

## Stack
- **API**: `GoalForClassification` gains optional `contextAnswers: { prompt, answer }[]`. Route schema validates + trims + drops empty pairs.
- **Prompt**: bulleted authoritative-context block injected below the rubric. System prompt gets a 5-line `USER-SUPPLIED CONTEXT` section telling the model the answers are ground truth and may push it away from the context-less first guess.
- **Web helper** (`reclassify-one-goal.js`): thin Promise-returning function. Opens the NDJSON endpoint, watches for GOAL_CLASSIFIED / GOAL_FAILED for the submitted goalId, resolves with the spec.
- **ContextCollector**: opt-in second button + inline error banner + busy state. Only renders when the parent supplies `onReclassify`.
- **GoalWidget**: wires the path. Imports `reclassify-one-goal` directly (not via the analyst barrel) to keep goal-widgets → analyst a one-way dep edge.

## Test plan
- [ ] CODE_RUBRIC goal "All code meets team standards" → fill `quality-standards` with "every PR must close a Jira ticket" → click Re-analyze → classifier flips to LINKAGE.
- [ ] Network failure mid-stream → inline "Re-analyze failed: …" banner, original spec stays put, button re-enables.
- [ ] "Save answers" still saves without reclassifying (the button is the only escalation).
- [ ] No `onReclassify` prop → button doesn't render (back-compat for any other consumer of `<ContextCollector>`).
- [ ] Server side: classifier sees the bulleted "User-supplied context (authoritative…)" block when answers are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)