### PR TITLE
feat(scorecard): CODE_RUBRIC as component + first-review-only scope

### DIFF
--- a/apps/api/src/modules/ai/classifier/mistral-classifier.ts
+++ b/apps/api/src/modules/ai/classifier/mistral-classifier.ts
@@ -236,8 +236,20 @@ function buildSystemPrompt(): string {
     "  - \"hybrid\" if any component is MANUAL",
     "The top-level `source` and `manual` MUST be null — components own",
     "the data. SCORECARD components CANNOT themselves be SCORECARD",
-    "(no nesting). CODE_RUBRIC is also forbidden as a component (it",
-    "renders its own UI lane).",
+    "(no nesting). CODE_RUBRIC IS allowed as a component — when used",
+    "inside a SCORECARD, the component carries its rubric criteria as",
+    "`manual.items: [<criterion>, ...]` and the SCORECARD widget grades",
+    "them inline via the same /api/v1/ai/grade-pr endpoint as the",
+    "standalone CODE_RUBRIC widget.",
+    "",
+    "`firstReviewOnly` flag (CODE_RUBRIC only) — set to `true` when the",
+    "goal explicitly says \"on first review\" / \"first-round review\" /",
+    "\"before fixes are applied\" / \"agreed quality on first review\".",
+    "Filters grading to comments BEFORE author rework, so the rubric",
+    "judges code quality at the first-review moment, not at merge time.",
+    "Default: false / null. Set this on the SPEC for standalone",
+    "CODE_RUBRIC; set it on the COMPONENT for CODE_RUBRIC inside a",
+    "SCORECARD.",
     "",
     "═══ SOURCE BLOCK ═════════════════════════════════════════════════",
     "",
@@ -454,23 +466,29 @@ function buildSystemPrompt(): string {
     "",
     'Goal: "Ensure ≥85% of deliverables meet agreed quality standards on ' +
       'first review AND maintain ≤10% post-delivery defects per quarter."',
-    "→ Two distinct quantitative targets in one goal. Use SCORECARD",
-    "  with two components: first-review pass rate (auto) and post-",
-    "  delivery defect count (manual, per-incident logger).",
+    "→ Two distinct quantitative targets in one goal. The quality half",
+    "  is RUBRIC-style (subjective criteria → AI grades each PR), not",
+    "  a thin pass-rate proxy. The defect half is a manual incident log.",
+    "  Set the rubric component's firstReviewOnly to true so the AI",
+    "  judges quality at the first-review moment, not at merge time.",
     "  {",
     '    "kind": "hybrid", "widget": "SCORECARD",',
-    '    "reasoning": "One scorecard with two halves: PR pass-rate is ' +
-      'auto-measurable; post-delivery defects need a manual log per incident.",',
+    '    "reasoning": "Quality is rubric-graded against the team\'s ' +
+      'criteria at first review; defects are manually logged per incident. ' +
+      'Weighted 60/40.",',
     '    "source": null, "manual": null,',
     '    "scorecard": {',
     '      "aggregate": "weighted",',
     '      "components": [',
     "        {",
-    '          "label": "Quality on first review", "weight": 60,',
-    '          "widget": "FIRST_PASS_RATE", "kind": "auto",',
-    '          "source": { "provider": "combined", "metric": "first_pass_rate",',
-    '                      "window": "quarter", "target": { "op": ">=", "value": 85 } },',
-    '          "manual": null',
+    '          "label": "Quality (rubric)", "weight": 60,',
+    '          "widget": "CODE_RUBRIC", "kind": "auto",',
+    '          "firstReviewOnly": true,',
+    '          "source": null,',
+    '          "manual": { "prompt": "Quality criteria",',
+    '                      "cadence": "continuous",',
+    '                      "items": ["meaningful tests", "no any types",',
+    '                                "all branches handled"] }',
     "        },",
     "        {",
     '          "label": "Post-delivery defects", "weight": 40,',
@@ -818,6 +836,10 @@ async function* classifyOneGoal(
     // scorecard payload still fails validation because the candidate
     // object drops the block before validateSpec sees it.
     scorecard: obj.scorecard ?? null,
+    // Phase F: top-level firstReviewOnly for standalone CODE_RUBRIC.
+    // Component-level firstReviewOnly lives inside scorecard.components
+    // and is threaded by the shared validator.
+    firstReviewOnly: obj.firstReviewOnly === true,
     classifiedAt: Date.now(),
   };
   // Safety net for SCORECARD: when the model picks the widget but

--- a/apps/api/src/modules/ai/classifier/spec-schema.ts
+++ b/apps/api/src/modules/ai/classifier/spec-schema.ts
@@ -47,6 +47,7 @@ export const SPEC_RESPONSE_SCHEMA = {
       "delegated",
       "untrackable",
       "scorecard",
+      "firstReviewOnly",
     ],
     properties: {
       kind: {
@@ -265,6 +266,16 @@ export const SPEC_RESPONSE_SCHEMA = {
           "stays editable; when the user unflags untrackable later, the " +
           "widget choice resurfaces as a starting point.",
       },
+      firstReviewOnly: {
+        type: ["boolean", "null"],
+        description:
+          "When true on a CODE_RUBRIC spec, the grader filters PR " +
+          "comments to the FIRST review round only (everything up to " +
+          "and including the first reviewer comment). Lets the rubric " +
+          "judge code quality at first review, before iterative " +
+          "fixes mask the original state. Ignored for non-CODE_RUBRIC " +
+          "widgets.",
+      },
       scorecard: {
         type: ["object", "null"],
         additionalProperties: false,
@@ -291,10 +302,17 @@ export const SPEC_RESPONSE_SCHEMA = {
                 "kind",
                 "source",
                 "manual",
+                "firstReviewOnly",
               ],
               properties: {
                 label: { type: ["string", "null"] },
                 weight: { type: "number" },
+                firstReviewOnly: {
+                  type: ["boolean", "null"],
+                  description:
+                    "Mirror of the top-level field — only meaningful " +
+                    "on a CODE_RUBRIC component.",
+                },
                 widget: {
                   type: "string",
                   enum: [

--- a/apps/web/src/features/analyst/review-pane.jsx
+++ b/apps/web/src/features/analyst/review-pane.jsx
@@ -930,9 +930,11 @@ function JobPicker({ value, options, onChange }) {
 // ─── SCORECARD sub-editor ─────────────────────────────────────────
 
 const SCORECARD_COMPONENT_WIDGETS = ALL_SPEC_KINDS.filter(
-  // SCORECARD inside SCORECARD is invalid; CODE_RUBRIC has its own
-  // UI lane and isn't useful as a scorecard component.
-  (k) => k !== "SCORECARD" && k !== "CODE_RUBRIC",
+  // SCORECARD inside SCORECARD is invalid (no nesting). Phase F
+  // restores CODE_RUBRIC as a valid component — the editor below
+  // surfaces an inline criteria textarea + first-review toggle so
+  // the user can drive rubric grading from inside a SCORECARD.
+  (k) => k !== "SCORECARD",
 );
 
 const SCORECARD_MAX_COMPONENTS = 3;
@@ -1064,8 +1066,20 @@ function ComponentEditorRow({ index, component, onPatch, onRemove, canRemove }) 
     const meta = SPEC_KIND_META[widget];
     const variant = meta?.variant || SPEC_VARIANTS.AUTO;
     const patch = { widget, kind: variant };
-    // Reset source/manual to sensible defaults for the new widget.
-    if (variant === SPEC_VARIANTS.AUTO) {
+    if (widget === "CODE_RUBRIC") {
+      // CODE_RUBRIC is meta-AUTO but uses neither source nor a
+      // standard manual block — it reads grading criteria from
+      // `manual.items` here (component scope) and runs the
+      // /api/v1/ai/grade-pr endpoint. Empty items array is a
+      // valid starting point; the RubricCriteriaEditor below
+      // surfaces a textarea so the user can fill it in.
+      patch.source = null;
+      patch.manual = {
+        prompt: "Grade against rubric",
+        cadence: "continuous",
+        items: [],
+      };
+    } else if (variant === SPEC_VARIANTS.AUTO) {
       patch.source = defaultSourceFor(widget);
       patch.manual = null;
     } else {
@@ -1231,6 +1245,109 @@ function ComponentEditorRow({ index, component, onPatch, onRemove, canRemove }) 
           />
         </label>
       </div>
+      {/* Phase F: rubric criteria + first-review toggle, only when
+          this component is CODE_RUBRIC. The criteria live on the
+          component's `manual.items` array (re-uses the existing
+          field — semantically: "the list of grader criteria"). */}
+      {component.widget === "CODE_RUBRIC" ? (
+        <RubricCriteriaEditor
+          criteria={component.manual?.items || []}
+          firstReviewOnly={component.firstReviewOnly === true}
+          onPatchCriteria={(items) =>
+            onPatch({
+              manual: {
+                ...(component.manual || {
+                  prompt: "Grade against rubric",
+                  cadence: "continuous",
+                }),
+                items,
+              },
+            })
+          }
+          onToggleFirstReviewOnly={(next) =>
+            onPatch({ firstReviewOnly: next })
+          }
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Inline criteria editor used by CODE_RUBRIC scorecard components.
+ *
+ * Lives inside the ScorecardEditor row so the user can author the
+ * rubric criteria in-place — no need to leave the Review pane and
+ * round-trip through the dashboard's ContextCollector. Items are
+ * stored on the component's `manual.items` array; the grader reads
+ * them via the same code path as the standalone CODE_RUBRIC widget
+ * uses for `spec.context.answers`.
+ *
+ * The "first-review only" toggle flips the component's
+ * `firstReviewOnly` boolean. When set, the grading client filters
+ * each PR's comments to the first-review cluster before sending to
+ * the AI grader (see `firstReviewComments`).
+ *
+ * Multi-line textarea on purpose: one criterion per line, copy-pastable
+ * straight from a markdown doc.
+ */
+function RubricCriteriaEditor({
+  criteria,
+  firstReviewOnly,
+  onPatchCriteria,
+  onToggleFirstReviewOnly,
+}) {
+  const text = (criteria || []).join("\n");
+  return (
+    <div className="flex flex-col gap-1.5 border-t border-white/10 pt-1.5">
+      <span
+        className="uppercase tracking-[0.5px]"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 9,
+          color: "rgba(255,255,255,0.55)",
+        }}
+      >
+        Rubric criteria — one per line
+      </span>
+      <textarea
+        rows={3}
+        value={text}
+        onChange={(e) => {
+          const items = e.target.value
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter(Boolean);
+          onPatchCriteria(items);
+        }}
+        placeholder="meaningful tests&#10;no any types&#10;all branches handled"
+        className="w-full bg-transparent outline-none"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10.5,
+          color: "rgba(255,255,255,0.95)",
+          border: "1px solid rgba(255,255,255,0.18)",
+          borderRadius: "var(--radius-sub)",
+          padding: "4px 6px",
+          resize: "vertical",
+        }}
+      />
+      <label
+        className="flex items-center gap-1.5"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          color: "rgba(255,255,255,0.78)",
+        }}
+        title="Grade each PR against its FIRST review-round comments only — the rubric judges code quality at the moment of first review, not after iterative fixes."
+      >
+        <input
+          type="checkbox"
+          checked={firstReviewOnly}
+          onChange={(e) => onToggleFirstReviewOnly(e.target.checked)}
+        />
+        <span>Grade first-review state only</span>
+      </label>
     </div>
   );
 }

--- a/apps/web/src/features/goal-widgets/widgets/scorecard-aggregate.js
+++ b/apps/web/src/features/goal-widgets/widgets/scorecard-aggregate.js
@@ -89,9 +89,27 @@ export function extractValue(component, data) {
     case "RECURRING_MILESTONE":
       return safeNum(data.pct);
 
+    // Phase F: CODE_RUBRIC components surface their pass-rate as
+    // the score. `data.pct` is computed by the SCORECARD widget
+    // from the local verdicts cache via `useGradedPrs.summary`.
+    case "CODE_RUBRIC":
+      return safeNum(data.pct);
+
     default:
       return null;
   }
+}
+
+/**
+ * For score targets we synthesize a default 100% target when the
+ * CODE_RUBRIC component doesn't carry one — the user's framing is
+ * "we want a high rubric pass rate", and 100% is the natural
+ * ceiling. The aggregate function still respects an explicit target
+ * if the user sets one.
+ */
+export function defaultTargetFor(widget) {
+  if (widget === "CODE_RUBRIC") return { op: ">=", value: 100 };
+  return null;
 }
 
 /**
@@ -127,7 +145,15 @@ export function pctOfTarget(value, target) {
  * separately.
  */
 export function componentScore(component, data) {
-  const target = component?.source?.target || component?.manual?.target;
+  // CODE_RUBRIC's "value" IS its pass-rate (0-100%), so a target is
+  // optional — when missing, we default to "≥ 100%" so the score
+  // matches what the standalone CodeRubricWidget already displays.
+  // Other widgets require an explicit target; null target → null
+  // score and the aggregate skips this component.
+  const target =
+    component?.source?.target ||
+    component?.manual?.target ||
+    defaultTargetFor(component?.widget);
   if (!target) return null;
   const value = extractValue(component, data);
   return pctOfTarget(value, target);

--- a/apps/web/src/features/goal-widgets/widgets/scorecard-widget.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/scorecard-widget.jsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { WidgetShell, TargetChip } from "../widget-shell";
 import { useDataSource } from "../data-sources/use-data-source";
 import { useGoalInputs } from "@/features/goal-inputs";
+import { useGradedPrs } from "@/features/grading";
 import {
   componentScore,
   aggregateScore,
@@ -64,7 +65,22 @@ export function ScorecardWidget({
   const row0 = useComponentData(components[0] || null, goal, 0);
   const row1 = useComponentData(components[1] || null, goal, 1);
   const row2 = useComponentData(components[2] || null, goal, 2);
-  const rows = [row0, row1, row2].slice(0, components.length);
+
+  // Phase F: per-component CODE_RUBRIC grading. Always invokes 3
+  // useGradedPrs calls (mirroring the component-data slots). Each
+  // call gates on `enabled` — only the slot that actually carries a
+  // CODE_RUBRIC component does any fetching/grading. Each call gets
+  // a unique `scopeKey` derived from the parent goal id + slot
+  // index so verdicts for different components don't collide in the
+  // local cache.
+  const rubric0 = useRubricForSlot(components[0], goal, 0);
+  const rubric1 = useRubricForSlot(components[1], goal, 1);
+  const rubric2 = useRubricForSlot(components[2], goal, 2);
+  const rubrics = [rubric0, rubric1, rubric2];
+
+  const rows = [row0, row1, row2]
+    .slice(0, components.length)
+    .map((row, i) => mergeRubricIntoRow(row, components[i], rubrics[i]));
 
   const scoredEntries = useMemo(
     () =>
@@ -121,6 +137,7 @@ export function ScorecardWidget({
               score={scoredEntries[i]?.score}
               loading={scoredEntries[i]?.loading}
               error={scoredEntries[i]?.error}
+              rubric={rows[i]?.rubric}
               variant={variant}
             />
           ))}
@@ -172,7 +189,15 @@ function Headline({ score, pass, total, variant }) {
  * embedding the full widget body to keep the row compact + scannable
  * — a SCORECARD with 3 full widget tiles inside would be unreadable.
  */
-function ComponentRow({ component, data, score, loading, error, variant }) {
+function ComponentRow({
+  component,
+  data,
+  score,
+  loading,
+  error,
+  rubric,
+  variant,
+}) {
   const label =
     component?.label?.trim() ||
     component?.widget?.replace(/_/g, " ").toLowerCase() ||
@@ -180,6 +205,7 @@ function ComponentRow({ component, data, score, loading, error, variant }) {
   const target = component?.source?.target || component?.manual?.target;
   const value = extractValue(component, data);
   const isPercent = isPercentMetric(component?.widget);
+  const isRubric = component?.widget === "CODE_RUBRIC";
 
   return (
     <li
@@ -263,9 +289,93 @@ function ComponentRow({ component, data, score, loading, error, variant }) {
           }}
         >
           {weightCopy(component?.weight)}
+          {component?.firstReviewOnly ? " · first-review only" : ""}
         </span>
       </div>
+      {isRubric ? (
+        <RubricRowFooter
+          rubric={rubric}
+          data={data}
+          variant={variant}
+        />
+      ) : null}
     </li>
+  );
+}
+
+/**
+ * Footer strip for a CODE_RUBRIC component row: shows criteria
+ * count, ungraded count, and a "Grade now" button. The button calls
+ * the slot's imperative `gradeAll` — the same function the
+ * standalone CodeRubricWidget uses. Progress is reported live; on
+ * completion the verdicts land in the local store and the parent
+ * SCORECARD re-renders with the new pass-rate folded into the
+ * aggregate.
+ *
+ * Rendered conditionally only for CODE_RUBRIC components — the
+ * regular ComponentRow stays compact for AUTO/MANUAL components.
+ */
+function RubricRowFooter({ rubric, data, variant }) {
+  if (!rubric) return null;
+  const muted =
+    variant === "light"
+      ? "rgba(255,255,255,0.6)"
+      : "var(--dim-fg)";
+  const isRunning = rubric.progress?.running === true;
+  const criteriaCount = rubric.criteriaCount ?? 0;
+  const ungraded = data?.ungraded ?? 0;
+  const total = (data?.total ?? 0) + ungraded + (data?.errored ?? 0);
+  const canGrade =
+    !isRunning &&
+    rubric.hasGithub &&
+    criteriaCount > 0 &&
+    typeof rubric.gradeAll === "function";
+  return (
+    <div
+      className="flex items-center justify-between gap-2"
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 9.5,
+        color: muted,
+        letterSpacing: "0.3px",
+      }}
+    >
+      <span>
+        {criteriaCount === 0
+          ? "no criteria yet — edit in Review pane"
+          : `${criteriaCount} criteri${criteriaCount === 1 ? "on" : "a"} · ` +
+            `${data?.pass ?? 0}/${total} graded` +
+            (ungraded > 0 ? ` · ${ungraded} ungraded` : "")}
+      </span>
+      {criteriaCount > 0 ? (
+        <button
+          type="button"
+          onClick={() => {
+            if (canGrade) rubric.gradeAll();
+          }}
+          disabled={!canGrade}
+          className="uppercase tracking-[0.5px] transition-opacity disabled:opacity-40"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 9.5,
+            letterSpacing: "0.5px",
+            color: variant === "light" ? "#ffffff" : "var(--fg)",
+            background: "transparent",
+            border:
+              variant === "light"
+                ? "1px solid rgba(255,255,255,0.35)"
+                : "1px solid var(--border)",
+            borderRadius: "var(--radius-sub)",
+            padding: "2px 6px",
+            cursor: canGrade ? "pointer" : "not-allowed",
+          }}
+        >
+          {isRunning
+            ? `Grading… ${rubric.progress?.done ?? 0}/${rubric.progress?.total ?? 0}`
+            : "Grade now"}
+        </button>
+      ) : null}
+    </div>
   );
 }
 
@@ -280,8 +390,79 @@ function isPercentMetric(widget) {
     widget === "LINKAGE" ||
     widget === "BUILD_PASS_RATE" ||
     widget === "MILESTONE" ||
-    widget === "RECURRING_MILESTONE"
+    widget === "RECURRING_MILESTONE" ||
+    widget === "CODE_RUBRIC"
   );
+}
+
+/**
+ * Phase F: per-slot rubric grading for SCORECARD CODE_RUBRIC
+ * components.
+ *
+ * Always invoked exactly 3 times per render (once per max-component
+ * slot) so React's hook count stays stable regardless of how many
+ * actual components the user has configured. Slots that aren't
+ * CODE_RUBRIC pass `enabled: false` and short-circuit internally
+ * — useGradedPrs still runs all its internal hooks but doesn't
+ * fetch or grade.
+ *
+ * Each grading slot gets a unique `scopeKey` derived from the
+ * parent goal id + slot index so verdicts for different components
+ * (or different SCORECARDs) never collide in the local store.
+ */
+function useRubricForSlot(component, parentGoal, index) {
+  const isRubric = component?.widget === "CODE_RUBRIC";
+  const criteria = isRubric ? component?.manual?.items || [] : [];
+  const firstReviewOnly = isRubric && component?.firstReviewOnly === true;
+  const scopeKey =
+    isRubric && parentGoal?.id ? `sc${index}:${parentGoal.id}` : null;
+  return useGradedPrs(
+    isRubric && parentGoal?.id
+      ? { goalId: parentGoal.id, context: { questions: [] } }
+      : { goalId: null, context: { questions: [] } },
+    {
+      enabled: isRubric && criteria.length > 0,
+      criteriaOverride: criteria,
+      firstReviewOnly,
+      scopeKey,
+    },
+  );
+}
+
+/**
+ * Fold a rubric slot's `summary` into the component-data row so the
+ * downstream extractValue / componentScore path can read `data.pct`
+ * uniformly. When the slot isn't a CODE_RUBRIC component, the
+ * underlying useGradedPrs ran with `enabled: false` and the rubric
+ * summary is empty — we leave the row's data alone in that case.
+ *
+ * The merge also surfaces `rubric` (criteria), `progress`, and
+ * `gradeAll` so the SCORECARD's ComponentRow can offer a "Grade now"
+ * affordance specific to this slot.
+ */
+function mergeRubricIntoRow(row, component, rubric) {
+  if (component?.widget !== "CODE_RUBRIC") return row;
+  return {
+    ...(row || {}),
+    data: {
+      ...(row?.data || {}),
+      pct: rubric.summary?.pct ?? null,
+      pass: rubric.summary?.pass ?? 0,
+      total: rubric.summary?.total ?? 0,
+      ungraded: rubric.summary?.ungraded ?? 0,
+      errored: rubric.summary?.errored ?? 0,
+    },
+    isLoading: rubric.isListLoading,
+    error: rubric.listError,
+    // Forward the imperative grader + per-slot progress so the
+    // ComponentRow can render a "Grade now" button + progress chip.
+    rubric: {
+      criteriaCount: (rubric.rubric || []).length,
+      gradeAll: rubric.gradeAll,
+      progress: rubric.progress,
+      hasGithub: rubric.hasGithub,
+    },
+  };
 }
 
 /**

--- a/apps/web/src/features/grading/first-review-comments.js
+++ b/apps/web/src/features/grading/first-review-comments.js
@@ -1,0 +1,64 @@
+/**
+ * Filter a PR's comments down to the FIRST review round.
+ *
+ * Definition
+ * ──────────
+ * A "first review round" runs from PR open until the first author
+ * response after the first reviewer comment. After the author pushes
+ * fixes or replies, round 2 begins.
+ *
+ * We can't always tell when the author "responded" — author replies
+ * via the API look like any other comment, and code pushes don't
+ * appear as comments at all. So this filter takes a conservative,
+ * easy-to-reason-about cut:
+ *
+ *   Include every comment up to AND INCLUDING the FIRST reviewer
+ *   comment. Comments authored by the PR author (even if posted
+ *   before the first review) are kept too — they're the PR's own
+ *   description / context, which the AI rubric grader can use.
+ *
+ * That captures "the state at first review" with no false positives
+ * (we never accidentally include round-2 reviewer feedback) at the
+ * cost of dropping reviewer comments clustered immediately after the
+ * first (e.g. a reviewer who left 3 line-comments in 2 minutes). For
+ * MVP this is the right trade-off: under-include rather than mix
+ * rounds. A clustering heuristic ("comments within N minutes of the
+ * first reviewer comment") could refine this later.
+ *
+ * @param {Array<{createdAt?: string, user?: string}>} comments
+ * @param {string|null|undefined} prAuthor — the PR's author login,
+ *   used to distinguish reviewer comments from author replies. When
+ *   unknown, we fall back to the first comment of any kind as the
+ *   "first review" marker (legacy permissive behaviour).
+ * @returns {Array} a NEW array with the same comment shape. Original
+ *   ordering preserved. Empty input returns empty output.
+ */
+export function firstReviewComments(comments, prAuthor) {
+  if (!Array.isArray(comments) || comments.length === 0) return [];
+
+  // Sort defensively — the GitHub API usually returns oldest-first
+  // but we don't trust the upstream ordering for grading correctness.
+  const sorted = [...comments]
+    .filter((c) => c && typeof c.createdAt === "string")
+    .map((c) => ({ c, ts: Date.parse(c.createdAt) }))
+    .filter((e) => Number.isFinite(e.ts))
+    .sort((a, b) => a.ts - b.ts);
+
+  // Locate the first NON-AUTHOR comment. If we don't know the author,
+  // any first comment counts (legacy behaviour matches what
+  // computePrReviewTiming does when author is unknown).
+  const firstReviewIndex = sorted.findIndex(
+    ({ c }) => !prAuthor || (c.user && c.user !== prAuthor),
+  );
+
+  if (firstReviewIndex < 0) {
+    // No reviewer comment ever — the author may have written a long
+    // description but no review happened. Return everything; there's
+    // no "round 1" to clip to, and dropping the author description
+    // would starve the grader of context.
+    return sorted.map(({ c }) => c);
+  }
+
+  // Include everything UP TO AND INCLUDING the first reviewer comment.
+  return sorted.slice(0, firstReviewIndex + 1).map(({ c }) => c);
+}

--- a/apps/web/src/features/grading/rubric-hash.js
+++ b/apps/web/src/features/grading/rubric-hash.js
@@ -8,11 +8,17 @@
  * Not a cryptographic hash; we just need determinism and collision avoidance
  * in the practical case (a handful of short strings per user). Simple
  * "djb2"-style rolling hash is enough and has no bundle cost.
+ *
+ * Phase F adds the optional `scopeTag` parameter so verdicts graded under
+ * different evaluation scopes (e.g. "full PR" vs. "first review only")
+ * don't collide in the local cache. Callers pass null/undefined for the
+ * legacy un-scoped behaviour.
  */
 
-export function rubricHash(rubric) {
+export function rubricHash(rubric, scopeTag) {
   const normalized = normalizeRubric(rubric);
-  return djb2(normalized.join("\u0001")).toString(16);
+  const tag = typeof scopeTag === "string" && scopeTag ? `|${scopeTag}` : "";
+  return djb2(normalized.join("") + tag).toString(16);
 }
 
 export function normalizeRubric(rubric) {

--- a/apps/web/src/features/grading/use-graded-prs.js
+++ b/apps/web/src/features/grading/use-graded-prs.js
@@ -27,6 +27,7 @@ import {
   saveVerdict,
 } from "./grading-store";
 import { normalizeRubric, rubricHash } from "./rubric-hash";
+import { firstReviewComments } from "./first-review-comments";
 
 /** Concurrency cap for grading calls — honour Mistral rate limits. */
 const GRADE_CONCURRENCY = 3;
@@ -81,7 +82,26 @@ function getStoreSnapshot() {
     : "";
 }
 
-export function useGradedPrs(spec) {
+/**
+ * @typedef {Object} GradedPrsOptions
+ * @property {string[]} [criteriaOverride] — bypass `spec.context.answers`
+ *   and use this list of criteria instead. Used by SCORECARD CODE_RUBRIC
+ *   components, which carry their criteria on `component.manual.items`
+ *   rather than in the goal-context store.
+ * @property {boolean} [firstReviewOnly] — override the spec-level flag.
+ *   When set, the grader filters PR comments to the first-review
+ *   cluster before sending to the AI.
+ * @property {string} [scopeKey] — extra tag mixed into the verdict
+ *   cache key so two different scopes (e.g. two CODE_RUBRIC components
+ *   on one SCORECARD) don't collide. Pass `null`/`undefined` for legacy
+ *   un-scoped behaviour.
+ * @property {boolean} [enabled] — set to `false` to make the hook
+ *   short-circuit (returns empty data). Useful inside SCORECARD widgets
+ *   that need a stable count of hook calls but don't always have a
+ *   CODE_RUBRIC component to grade.
+ */
+
+export function useGradedPrs(spec, options = {}) {
   const { isConnected } = useIntegrations();
   // Capture the CONNECTION BOOLEAN up front. `isConnected` is a new function
   // reference on every `useIntegrations()` call, so passing it directly into
@@ -89,10 +109,36 @@ export function useGradedPrs(spec) {
   // every render → new fetch → state update → re-render → repeat). Boolean
   // comparison via React's default equality is the correct stable signal.
   const githubConnected = isConnected("github");
+  // Phase F: hook options. The `enabled` gate runs OUTSIDE the hook
+  // body's React calls — every useState/useEffect below still runs
+  // unconditionally so hook rules are satisfied, but expensive work
+  // (PR list fetch, grade-all loop) checks `enabled` and short-circuits.
+  const enabled = options.enabled !== false;
+  const scopeKey = options.scopeKey || null;
 
   const { answers } = useGoalContext(spec?.goalId);
-  const rubric = useMemo(() => resolveRubric(spec, answers), [spec, answers]);
-  const hash = useMemo(() => rubricHash(rubric), [rubric]);
+  const rubric = useMemo(() => {
+    if (Array.isArray(options.criteriaOverride)) {
+      return normalizeRubric(options.criteriaOverride);
+    }
+    return resolveRubric(spec, answers);
+  }, [spec, answers, options.criteriaOverride]);
+  // Phase F: when `spec.firstReviewOnly` is set on a CODE_RUBRIC spec,
+  // OR when the caller passes `firstReviewOnly` in options (used by
+  // SCORECARD CODE_RUBRIC components), grading filters PR comments to
+  // the first-review cluster before sending to the AI grader. The
+  // hash mixes the flag + the scope key in so verdicts graded with
+  // vs. without the scope filter don't collide in the local cache.
+  const firstReviewOnly =
+    options.firstReviewOnly !== undefined
+      ? options.firstReviewOnly === true
+      : spec?.firstReviewOnly === true;
+  const hash = useMemo(() => {
+    const tagBits = [];
+    if (scopeKey) tagBits.push(scopeKey);
+    if (firstReviewOnly) tagBits.push("fr1");
+    return rubricHash(rubric, tagBits.length > 0 ? tagBits.join(":") : null);
+  }, [rubric, scopeKey, firstReviewOnly]);
 
   // Subscribe to grading store changes so we re-render when verdicts land.
   // Capture the snapshot value — `verdictsByPr` memo below uses it as a
@@ -123,7 +169,9 @@ export function useGradedPrs(spec) {
   // without needing the effect's dep on a ref (which wouldn't trigger).
   const [refreshTick, setRefreshTick] = useState(0);
   useEffect(() => {
-    if (!githubConnected) {
+    // Phase F: respect the `enabled` gate. Disabled hooks still run
+    // the effect (React rules) but don't fetch.
+    if (!githubConnected || !enabled) {
       setPrs([]);
       setListError(null);
       setIsListLoading(false);
@@ -152,7 +200,7 @@ export function useGradedPrs(spec) {
     return () => {
       cancelled = true;
     };
-  }, [githubConnected, refreshTick]);
+  }, [githubConnected, refreshTick, enabled]);
 
   const refreshList = useCallback(() => {
     setRefreshTick((n) => n + 1);
@@ -203,6 +251,15 @@ export function useGradedPrs(spec) {
               typeof localStorage !== "undefined"
                 ? localStorage.getItem("espace-devhub:ai-provider") || "mistral"
                 : "mistral";
+            // Phase F: when firstReviewOnly is set, clip comments
+            // to the first-review cluster BEFORE sending. The grader
+            // sees only the PR body + the first reviewer comment
+            // (plus the author's own pre-review messages), so the
+            // rubric judges code quality at first review, not at
+            // merge time after iterative fixes.
+            const commentsForGrading = firstReviewOnly
+              ? firstReviewComments(details.comments, pr.author)
+              : details.comments;
             const res = await fetch("/api/v1/ai/grade-pr", {
               method: "POST",
               credentials: "include",
@@ -215,7 +272,7 @@ export function useGradedPrs(spec) {
                   id: pr.id,
                   title: details.title || pr.title,
                   body: details.body,
-                  comments: details.comments,
+                  comments: commentsForGrading,
                 },
                 rubric,
                 provider: aiProvider,

--- a/packages/shared/src/goal-specs/validator.js
+++ b/packages/shared/src/goal-specs/validator.js
@@ -328,6 +328,13 @@ function validateScorecard(scorecard, errors) {
       kind,
       source,
       manual,
+      // Phase F: CODE_RUBRIC components can opt into "first review
+      // only" scope so the rubric judges quality at the moment of
+      // first review (before iterative fixes mask the original
+      // state). Boolean defaulting to false; only meaningful when
+      // widget is CODE_RUBRIC but accepted on any component for
+      // forward-compatibility.
+      ...(c.firstReviewOnly === true ? { firstReviewOnly: true } : {}),
     });
   });
 
@@ -510,6 +517,10 @@ export function validateSpec(obj) {
     delegated,
     untrackable,
     scorecard,
+    // Phase F: top-level firstReviewOnly applies to standalone
+    // CODE_RUBRIC specs. Optional boolean, false-by-default — kept
+    // as undefined when not set so older specs serialise identically.
+    ...(obj.firstReviewOnly === true ? { firstReviewOnly: true } : {}),
     classifiedAt:
       typeof obj.classifiedAt === "number" && obj.classifiedAt > 0
         ? obj.classifiedAt


### PR DESCRIPTION
## Summary
Phase F. Two extensions so your "≥85% quality on first review AND ≤10% defects per quarter" goal can live as one SCORECARD tile with rubric-driven quality scoring:

1. **CODE_RUBRIC re-enabled as a SCORECARD component.** Criteria stored on `component.manual.items`. Inline `<RubricCriteriaEditor>` in the ScorecardEditor — textarea, one per line, no need to leave the Review pane.
2. **`firstReviewOnly` scope flag** on both standalone CODE_RUBRIC specs and on per-component CODE_RUBRIC inside SCORECARD. When set, the grader filters PR comments to the first-review cluster (everything up to AND INCLUDING the first non-author comment) before sending to the AI.

## Architectural changes
- `useGradedPrs(spec, options)` — new options bag (`criteriaOverride`, `firstReviewOnly`, `scopeKey`, `enabled`). Lets a SCORECARD widget always invoke 3 grading hooks (matching MAX_COMPONENTS) with each slot's state independently scoped + cached.
- `rubricHash(rubric, scopeTag)` mixes the scope key + first-review flag into the verdict cache key so flipping the flag, or grading two CODE_RUBRIC components in the same SCORECARD, never reuses stale verdicts.
- `firstReviewComments(comments, prAuthor)` — new helper. Conservative "up to and including the first non-author comment" cut — never accidentally mixes round-2 feedback.
- SCORECARD widget's `mergeRubricIntoRow` folds the rubric summary's `pct` into the slot's data so `extractValue` reads it uniformly with other widget data. Per-row footer renders "{N} criteria · M/T graded" + a "Grade now" button that calls the slot's imperative grader.
- `componentScore()` falls back to `>=100%` default target for CODE_RUBRIC when none is set — score then matches what the standalone CodeRubricWidget displays.

## Classifier
- Prompt's COMPOSITE section now allows CODE_RUBRIC as a component and explains the `firstReviewOnly` flag.
- Worked example updated to use CODE_RUBRIC (60% weight) + INCIDENT_LOG (40%) for your actual goal, with `firstReviewOnly: true` on the rubric half.

## Test plan
- [ ] Switch a scorecard component to CODE_RUBRIC in Review pane → criteria textarea + first-review checkbox appear inline.
- [ ] Re-classify "≥85% quality on first review AND ≤10% defects" → SCORECARD spec lands with CODE_RUBRIC (firstReviewOnly true) + INCIDENT_LOG components.
- [ ] On the dashboard, SCORECARD tile shows the rubric row with "{N} criteria · 0/T graded · Grade now" footer. Click → grading runs with live progress; verdicts land; pass-rate updates; aggregate weighted score reflects the new value.
- [ ] Toggle `firstReviewOnly` on/off → re-grading runs (hash changes) and verdicts under the two scopes don't collide.
- [ ] Standalone CODE_RUBRIC widget still works for goals that aren't SCORECARDs — `firstReviewOnly` flag honoured there too.
- [ ] Validator + JSON Schema both accept the new field; old specs (without the flag) still validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)