### PR TITLE
feat(scorecard): click-to-expand sub-widget modal

### DIFF
--- a/apps/web/src/features/goal-widgets/widgets/scorecard-component-modal.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/scorecard-component-modal.jsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useEffect } from "react";
+import { GoalWidget } from "../goal-widget";
+import {
+  readContextFor,
+  saveContextFor,
+} from "@/features/goal-context";
+
+/**
+ * Modal that opens when a SCORECARD ComponentRow is clicked.
+ *
+ * Renders the FULL widget body — CodeRubricWidget's criteria editor +
+ * Grade button + PR list with verdicts; or INCIDENT_LOG's full
+ * incident logger; etc. — instead of the compact summary that lives
+ * in the row.
+ *
+ * Synthetic-spec strategy
+ * ───────────────────────
+ * We can't feed the component object directly to the widget Component
+ * — the standalone widgets expect a full ValidatedSpec shape with
+ * `goalId`, `title`, `context`, etc. So we synthesize one from the
+ * parent spec + the component:
+ *
+ *   goalId       = `${parentSpec.goalId}::sc${componentIndex}`
+ *   title        = component.label || pretty-printed widget kind
+ *   widget/kind  = component.widget/kind
+ *   source       = component.source
+ *   manual       = component.manual
+ *   context      = synthetic "quality-standards" question for
+ *                  CODE_RUBRIC so the ContextCollector route works
+ *   firstReviewOnly = component.firstReviewOnly
+ *
+ * The synthetic `goalId` is the same id the SCORECARD widget already
+ * uses for MANUAL components' `useGoalInputs` and for `useGradedPrs`'s
+ * `scopeKey`, so the data the user sees in the modal IS the data the
+ * scorecard scored.
+ *
+ * CODE_RUBRIC criteria seeding
+ * ────────────────────────────
+ * The standalone CodeRubricWidget reads its rubric criteria from the
+ * goal-context store keyed on `spec.goalId`. The scorecard editor
+ * stores criteria on `component.manual.items`. To bridge: on first
+ * modal mount we seed the synthetic goalId's context with the
+ * component's items. From that point on the goal-context store is
+ * authoritative — edits in the rubric widget land there, and the
+ * SCORECARD's aggregate (see `useRubricForSlot`) also reads from
+ * context, so changes round-trip without a second persistence step.
+ *
+ * Backdrop click + ESC close. Body click stops propagation so the
+ * widget's own buttons keep working.
+ */
+export function ScorecardComponentModal({
+  open,
+  onClose,
+  parentSpec,
+  parentGoal,
+  component,
+  index,
+}) {
+  const subGoalId =
+    parentSpec?.goalId && Number.isFinite(index)
+      ? `${parentSpec.goalId}::sc${index}`
+      : null;
+
+  // Seed criteria for CODE_RUBRIC if context is empty for this sub-id.
+  // Re-seeds when the modal re-opens for a DIFFERENT component (key on
+  // index + parent goal id). When the user edits criteria via the
+  // rubric widget's own ContextCollector, the saveContextFor() call
+  // there updates the store — we don't overwrite it on subsequent
+  // opens because the `if (existing length > 0)` check short-circuits.
+  useEffect(() => {
+    if (!open) return;
+    if (!subGoalId) return;
+    if (component?.widget !== "CODE_RUBRIC") return;
+    const existing = readContextFor(subGoalId);
+    const hasCriteria =
+      Array.isArray(existing["quality-standards"]) &&
+      existing["quality-standards"].length > 0;
+    if (hasCriteria) return;
+    const seed = component.manual?.items || [];
+    if (seed.length === 0) return;
+    saveContextFor(subGoalId, { "quality-standards": seed });
+  }, [open, subGoalId, component?.widget, component?.manual?.items]);
+
+  // ESC closes — bind globally for the duration the modal is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open || !component) return null;
+
+  const syntheticSpec = buildSyntheticSpec(parentSpec, component, index);
+  const syntheticGoal = {
+    ...(parentGoal || {}),
+    id: subGoalId,
+    title: syntheticSpec.title,
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${syntheticSpec.title} — full view`}
+      className="fixed inset-0 z-[120] flex items-center justify-center px-4 py-6"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose?.();
+      }}
+      style={{
+        background: "rgba(10, 10, 20, 0.55)",
+        backdropFilter: "blur(2px)",
+      }}
+    >
+      <div
+        className="flex max-h-[88vh] w-full max-w-[680px] flex-col overflow-hidden rounded-[var(--radius-tile)]"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "var(--accent)",
+          color: "var(--accent-on)",
+          boxShadow: "0 24px 72px rgba(0,0,0,0.35)",
+        }}
+      >
+        <ModalHeader
+          label={syntheticSpec.title}
+          parentTitle={parentGoal?.title || parentSpec?.title}
+          onClose={onClose}
+        />
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          {/* Route through GoalWidget rather than rendering the widget
+              Component directly — GoalWidget handles the
+              context-required → ContextCollector routing so a
+              CODE_RUBRIC component with empty criteria walks the user
+              through the same "define rubric" flow the standalone
+              widget uses. State lives under the synthetic goalId so
+              the SCORECARD's aggregate sees the edits immediately. */}
+          <GoalWidget
+            spec={syntheticSpec}
+            goal={syntheticGoal}
+            variant="light"
+            onRetry={null}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ModalHeader({ label, parentTitle, onClose }) {
+  return (
+    <div
+      className="flex items-center justify-between border-b px-4 py-3"
+      style={{ borderColor: "rgba(255,255,255,0.18)" }}
+    >
+      <div className="flex flex-col gap-0.5 truncate">
+        {parentTitle ? (
+          <span
+            className="uppercase tracking-[0.5px]"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 9.5,
+              color: "rgba(255,255,255,0.6)",
+            }}
+            title={parentTitle}
+          >
+            Scorecard · {truncate(parentTitle, 60)}
+          </span>
+        ) : null}
+        <span
+          className="font-semibold leading-none"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: 18,
+            letterSpacing: "-0.4px",
+          }}
+        >
+          {label}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close"
+        className="rounded-[var(--radius-sub)] px-2.5 py-1 transition-opacity hover:opacity-80"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          letterSpacing: "0.5px",
+          background: "transparent",
+          border: "1px solid rgba(255,255,255,0.35)",
+          color: "rgba(255,255,255,0.95)",
+        }}
+      >
+        ✕ ESC
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Translate a scorecard component into a full ValidatedSpec shape so
+ * the registered widget Component can render it like a standalone
+ * spec. Keep this in lockstep with `packages/shared/src/goal-specs`
+ * — anything the widget's body reads off the spec object needs a
+ * (sensible) default here.
+ */
+function buildSyntheticSpec(parentSpec, component, index) {
+  const subGoalId =
+    parentSpec?.goalId != null
+      ? `${parentSpec.goalId}::sc${index}`
+      : `scorecard-component-${index}`;
+  const widget = component?.widget || "MERGED_COUNT";
+  const title =
+    component?.label?.trim() || prettyWidget(widget) || "Component";
+
+  return {
+    schemaVersion: 1,
+    goalId: subGoalId,
+    title,
+    reasoning: "",
+    kind: component?.kind || "auto",
+    widget,
+    source: component?.source || null,
+    manual: component?.manual || null,
+    // CODE_RUBRIC needs context.questions[*].id === "quality-standards"
+    // for `resolveRubric(spec, answers)` to find the criteria. We
+    // attach the question here so the existing standalone widget
+    // logic just works — the criteria live in the goal-context store
+    // (seeded above) and the widget pulls them via useGoalContext.
+    context:
+      widget === "CODE_RUBRIC"
+        ? {
+            required: true,
+            questions: [
+              {
+                id: "quality-standards",
+                prompt: "What are your code quality standards?",
+                kind: "list",
+                placeholder: "e.g. test coverage, naming, docs",
+              },
+            ],
+          }
+        : null,
+    delegated: null,
+    untrackable: null,
+    scorecard: null,
+    firstReviewOnly: component?.firstReviewOnly === true,
+    classifiedAt: parentSpec?.classifiedAt || Date.now(),
+  };
+}
+
+function prettyWidget(widget) {
+  if (typeof widget !== "string") return "";
+  return widget
+    .toLowerCase()
+    .split("_")
+    .map((w) => w[0]?.toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function truncate(s, max) {
+  if (typeof s !== "string") return "";
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}

--- a/apps/web/src/features/goal-widgets/widgets/scorecard-widget.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/scorecard-widget.jsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { WidgetShell, TargetChip } from "../widget-shell";
 import { useDataSource } from "../data-sources/use-data-source";
 import { useGoalInputs } from "@/features/goal-inputs";
+import { useGoalContext } from "@/features/goal-context";
 import { useGradedPrs } from "@/features/grading";
 import {
   componentScore,
@@ -11,6 +12,7 @@ import {
   passingCount,
   extractValue,
 } from "./scorecard-aggregate";
+import { ScorecardComponentModal } from "./scorecard-component-modal";
 
 /**
  * SCORECARD widget — composite tile that aggregates 2–3 component
@@ -96,54 +98,80 @@ export function ScorecardWidget({
   const score = aggregateScore(scoredEntries, aggregate);
   const { pass, total } = passingCount(scoredEntries);
 
+  // #3: clicking a component row opens a modal with the FULL widget
+  // body — criteria editor + Grade button for CODE_RUBRIC, full
+  // incident logger for INCIDENT_LOG, etc. State lives on the
+  // SCORECARD widget so the modal can render with synthetic spec +
+  // goal that point at the same sub-id storage scope the
+  // ScorecardWidget already uses for its aggregate scoring.
+  const [activeIndex, setActiveIndex] = useState(null);
+  const activeComponent =
+    activeIndex != null ? components[activeIndex] : null;
+
   return (
-    <WidgetShell
-      spec={spec}
-      variant={variant}
-      label={`Scorecard · ${components.length} components`}
-      title={goal?.title || spec.title}
-      onRetry={onRetry}
-      className={className}
-    >
-      <div className="flex h-full flex-col gap-2">
-        <Headline score={score} pass={pass} total={total} variant={variant} />
-        <div
-          className="h-1.5 w-full overflow-hidden rounded-full"
-          style={{
-            background:
-              variant === "light"
-                ? "rgba(255,255,255,0.18)"
-                : "var(--border)",
-          }}
-        >
-          <div
-            className="h-full"
-            style={{
-              width: `${score ?? 0}%`,
-              background:
-                variant === "light" ? "#ffffff" : "var(--accent)",
-            }}
+    <>
+      <WidgetShell
+        spec={spec}
+        variant={variant}
+        label={`Scorecard · ${components.length} components`}
+        title={goal?.title || spec.title}
+        onRetry={onRetry}
+        className={className}
+      >
+        <div className="flex h-full flex-col gap-2">
+          <Headline
+            score={score}
+            pass={pass}
+            total={total}
+            variant={variant}
           />
-        </div>
-        <ul
-          className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto pr-1"
-          style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
-        >
-          {components.map((c, i) => (
-            <ComponentRow
-              key={`${c.widget}-${i}`}
-              component={c}
-              data={rows[i]?.data}
-              score={scoredEntries[i]?.score}
-              loading={scoredEntries[i]?.loading}
-              error={scoredEntries[i]?.error}
-              rubric={rows[i]?.rubric}
-              variant={variant}
+          <div
+            className="h-1.5 w-full overflow-hidden rounded-full"
+            style={{
+              background:
+                variant === "light"
+                  ? "rgba(255,255,255,0.18)"
+                  : "var(--border)",
+            }}
+          >
+            <div
+              className="h-full"
+              style={{
+                width: `${score ?? 0}%`,
+                background:
+                  variant === "light" ? "#ffffff" : "var(--accent)",
+              }}
             />
-          ))}
-        </ul>
-      </div>
-    </WidgetShell>
+          </div>
+          <ul
+            className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto pr-1"
+            style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+          >
+            {components.map((c, i) => (
+              <ComponentRow
+                key={`${c.widget}-${i}`}
+                component={c}
+                data={rows[i]?.data}
+                score={scoredEntries[i]?.score}
+                loading={scoredEntries[i]?.loading}
+                error={scoredEntries[i]?.error}
+                rubric={rows[i]?.rubric}
+                variant={variant}
+                onExpand={() => setActiveIndex(i)}
+              />
+            ))}
+          </ul>
+        </div>
+      </WidgetShell>
+      <ScorecardComponentModal
+        open={activeComponent != null}
+        onClose={() => setActiveIndex(null)}
+        parentSpec={spec}
+        parentGoal={goal}
+        component={activeComponent}
+        index={activeIndex ?? 0}
+      />
+    </>
   );
 }
 
@@ -197,6 +225,7 @@ function ComponentRow({
   error,
   rubric,
   variant,
+  onExpand,
 }) {
   const label =
     component?.label?.trim() ||
@@ -209,13 +238,28 @@ function ComponentRow({
 
   return (
     <li
-      className="flex flex-col gap-1 rounded-[var(--radius-sub)] px-2 py-1.5"
+      // Clicking the row opens the full sub-widget in a modal. The row
+      // stays a <li> for semantics; the click handler + keyboard
+      // handler give it button-like behaviour. We DON'T use a <button>
+      // wrapping the row because the rubric row has its own "Grade now"
+      // button inside, which would nest interactive elements.
+      role="button"
+      tabIndex={0}
+      onClick={onExpand}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onExpand?.();
+        }
+      }}
+      className="group flex cursor-pointer flex-col gap-1 rounded-[var(--radius-sub)] px-2 py-1.5 transition-colors"
       style={{
         background:
           variant === "light"
             ? "rgba(255,255,255,0.06)"
             : "var(--card-alt)",
       }}
+      title="Click to open the full widget"
     >
       <div className="flex items-baseline gap-2">
         <span
@@ -230,6 +274,22 @@ function ComponentRow({
           }}
         >
           {label}
+        </span>
+        <span
+          aria-hidden="true"
+          className="opacity-0 transition-opacity group-hover:opacity-100"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            color:
+              variant === "light"
+                ? "rgba(255,255,255,0.75)"
+                : "var(--muted-fg)",
+            letterSpacing: "0.5px",
+          }}
+          title="Open the full widget view"
+        >
+          expand ↗
         </span>
         <TargetChip target={target} unit={isPercent ? "%" : ""} variant={variant} />
         <span
@@ -350,7 +410,11 @@ function RubricRowFooter({ rubric, data, variant }) {
       {criteriaCount > 0 ? (
         <button
           type="button"
-          onClick={() => {
+          onClick={(e) => {
+            // The whole row is clickable to open the modal — stop
+            // propagation so clicking "Grade now" doesn't also pop
+            // the modal open.
+            e.stopPropagation();
             if (canGrade) rubric.gradeAll();
           }}
           disabled={!canGrade}
@@ -412,7 +476,25 @@ function isPercentMetric(widget) {
  */
 function useRubricForSlot(component, parentGoal, index) {
   const isRubric = component?.widget === "CODE_RUBRIC";
-  const criteria = isRubric ? component?.manual?.items || [] : [];
+  const subGoalId =
+    parentGoal?.id != null ? `${parentGoal.id}::sc${index}` : null;
+  // The modal seeds goal-context for the sub-id from
+  // component.manual.items, and the standalone rubric widget's
+  // "edit truths" flow writes back to the same context store. To
+  // keep the SCORECARD's aggregate score consistent with what the
+  // modal shows, we read criteria from the SAME source — context
+  // when set, manual.items as fallback (covers first render before
+  // the modal has ever opened).
+  const { answers } = useGoalContext(subGoalId);
+  const ctxCriteria = Array.isArray(answers?.["quality-standards"])
+    ? answers["quality-standards"]
+    : [];
+  const seedCriteria = component?.manual?.items || [];
+  const criteria = isRubric
+    ? ctxCriteria.length > 0
+      ? ctxCriteria
+      : seedCriteria
+    : [];
   const firstReviewOnly = isRubric && component?.firstReviewOnly === true;
   const scopeKey =
     isRubric && parentGoal?.id ? `sc${index}:${parentGoal.id}` : null;


### PR DESCRIPTION
## Summary
Clicking any SCORECARD component row now opens a modal showing the **FULL widget body** — CodeRubricWidget's criteria editor + Grade button + per-PR verdict list, or INCIDENT_LOG's full incident logger, etc. Previously the compact summary in the row was all you got.

## Approach
- Synthetic spec + goal built from the component. The synthetic `goalId = `${parentSpec.goalId}::sc${i}`` — same sub-id the scorecard already uses for storage scope, so the data you see in the modal IS the data the aggregate scored.
- Modal routes through `GoalWidget` (not the bare Component) so untrackable / delegated / context-collector routing just works. CODE_RUBRIC with empty criteria walks through the same "define rubric" flow the standalone widget uses.
- CODE_RUBRIC criteria seed: on first modal open, manual.items copies into goal-context for the sub-id. From there context is authoritative. The SCORECARD's `useRubricForSlot` reads criteria from context first (fallback to manual.items), so the aggregate updates the moment you edit criteria in the modal.

## UX
- Row is a `role="button"`. Enter/Space activates. Hover shows an "expand ↗" affordance.
- "Grade now" button inside rubric row stops propagation so it doesn't ALSO open the modal.
- Modal: backdrop click + ESC close. 88vh max with internal scroll.
- Breadcrumb shows parent goal + component label.

## Test plan
- [ ] Open a SCORECARD tile with a CODE_RUBRIC component → click the rubric row → modal opens showing the full rubric widget body (criteria, Grade-now button, PR list).
- [ ] If criteria are empty, modal shows the ContextCollector → fill criteria → save → modal re-routes to the rubric body. Aggregate score on the parent scorecard updates.
- [ ] Open a SCORECARD with an INCIDENT_LOG component → click → modal shows the full incident logger with severity dropdown, downtime input, log list.
- [ ] ESC closes. Backdrop click closes. Inner widget buttons (Grade now, Log incident, etc.) keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)