### PR TITLE
feat(deploy): single-Vercel deploy via Express-in-serverless catch-all

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,15 @@
   "private": true,
   "type": "module",
   "description": "eSpace Dev Hub — Express + MongoDB backend service.",
-  "main": "dist/server.js",
+  "main": "dist/serverless.js",
+  "types": "dist/serverless.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/serverless.d.ts",
+      "default": "./dist/serverless.js"
+    },
+    "./server": "./dist/server.js"
+  },
   "engines": {
     "node": ">=20"
   },

--- a/apps/api/src/serverless.ts
+++ b/apps/api/src/serverless.ts
@@ -1,0 +1,28 @@
+/**
+ * Serverless entry point — re-exports the Express factory + the
+ * lazy-init helpers that the Vercel catch-all adapter needs.
+ *
+ * Why a dedicated barrel
+ * ──────────────────────
+ * `apps/api/src/server.ts` is the long-running boot path: it builds
+ * the app, listens on a port, wires graceful shutdown. None of that
+ * makes sense in a serverless invocation — Vercel calls our handler
+ * once per request, then the container hibernates between calls.
+ *
+ * The catch-all (`apps/web/src/pages/api/v1/[...path].ts`) needs:
+ *   - `buildApp()` — sync factory; produces an Express Application
+ *     that can be invoked as `app(req, res)` per request.
+ *   - `connect()` + `bootstrap()` + `seedDefaultOrg()` — the same
+ *     boot pipeline `server.ts` runs once, but called from the
+ *     adapter on first cold start so each fresh container primes
+ *     its Mongo pool + ensures collection validators + indexes.
+ *
+ * Keeping the surface narrow lets the consumer (apps/web) drop a
+ * stable import path into the adapter without reaching into
+ * `db/*` directly.
+ */
+
+export { buildApp } from "./app.js";
+export { connect, disconnect, getDb } from "./db/client.js";
+export { bootstrap } from "./db/collections.js";
+export { seedDefaultOrg } from "./db/seed.js";

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "scripts"]

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -3,11 +3,19 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// API service location. Defaults to localhost:4000 in dev. In prod the
-// API is reverse-proxied at the same origin (no rewrite needed) — set
-// NEXT_PUBLIC_API_URL only when frontend and API live on different
-// origins.
-const API_ORIGIN = process.env.API_ORIGIN || "http://localhost:4000";
+// API service location.
+//
+// When `API_ORIGIN` is set (e.g. local dev with `apps/api` running on
+// :4000, or a deployment where the API is a separate host like Railway),
+// requests to `/api/v1/*` get rewritten to that origin.
+//
+// When unset (default on Vercel deploys), the rewrite is skipped and
+// the catch-all serverless function at
+// `apps/web/src/pages/api/v1/[...path].ts` handles `/api/v1/*` in-
+// process by forwarding to the Express app via the
+// `@espace-devhub/api/serverless` barrel. This lets the entire backend
+// ship inside the Next.js deploy on Vercel.
+const API_ORIGIN = process.env.API_ORIGIN;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -18,32 +26,38 @@ const nextConfig = {
     root: path.join(__dirname, "..", ".."),
   },
 
-  // Same-origin proxy so the browser sees /api/v1/* on :3000 alongside
-  // its own pages. Keeps cookies SameSite-clean in dev and avoids any
-  // CORS preflight on the happy path.
-  //
-  // The only Next.js route handler left is /api/oauth/github/exchange
-  // (still server-side because it consumes GITHUB_CLIENT_SECRET). All
-  // other legacy /api/* proxies (chat, classify-goals, grade-pr,
-  // github/gitlab/jira) were retired in M7.9c — those flows now hit
-  // the API service via /api/v1/* under this rewrite.
+  // Transpile the API workspace package — its dist/*.js is ESM with
+  // `.js` import suffixes (NodeNext output). Next's default bundler
+  // assumes node_modules deps are already-transpiled CommonJS or modern
+  // ESM without the explicit `.js` extensions; listing it here makes
+  // Turbopack/webpack run it through the standard transpile pipeline
+  // so the serverless catch-all can import from it.
+  transpilePackages: ["@espace-devhub/api", "@espace-devhub/shared"],
+
   async rewrites() {
-    return [
-      {
-        source: "/api/v1/:path*",
-        destination: `${API_ORIGIN}/api/v1/:path*`,
-      },
-      // Health endpoints are unversioned — useful for hitting from the
-      // dashboard during development.
-      {
-        source: "/api/healthz",
-        destination: `${API_ORIGIN}/healthz`,
-      },
-      {
-        source: "/api/readyz",
-        destination: `${API_ORIGIN}/readyz`,
-      },
-    ];
+    // Local dev / external-API mode: forward /api/v1/* to the
+    // configured origin so the file-based catch-all is bypassed.
+    // `beforeFiles` ensures the rewrite runs BEFORE Next's
+    // file-based route matching — without that, the catch-all
+    // serverless function would always win and we'd never hit the
+    // standalone Express server.
+    if (!API_ORIGIN) return [];
+    return {
+      beforeFiles: [
+        {
+          source: "/api/v1/:path*",
+          destination: `${API_ORIGIN}/api/v1/:path*`,
+        },
+        {
+          source: "/api/healthz",
+          destination: `${API_ORIGIN}/healthz`,
+        },
+        {
+          source: "/api/readyz",
+          destination: `${API_ORIGIN}/readyz`,
+        },
+      ],
+    };
   },
 };
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,12 +5,13 @@
   "description": "eSpace Dev Hub — Next.js frontend.",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "npm run build --workspace=@espace-devhub/api && next build --turbopack",
     "start": "next start",
     "lint": "next lint"
   },
   "dependencies": {
     "@api/nim": "file:.api/apis/nim",
+    "@espace-devhub/api": "*",
     "@espace-devhub/shared": "*",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -42,8 +43,12 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/express": "^4.17.23",
+    "@types/node": "^22.18.10",
+    "@types/react": "^19.0.0",
     "baseline-browser-mapping": "^2.10.23",
     "tailwindcss": "^4",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "typescript": "^5.7.3"
   }
 }

--- a/apps/web/src/pages/api/v1/[...path].ts
+++ b/apps/web/src/pages/api/v1/[...path].ts
@@ -1,0 +1,119 @@
+/**
+ * /api/v1/* catch-all — forwards every request to the Express app
+ * built by `@espace-devhub/api/serverless`.
+ *
+ * Why Pages Router (not App Router)
+ * ─────────────────────────────────
+ * Express's middleware chain expects Node's `IncomingMessage` /
+ * `ServerResponse` types — it reads from `req.url`, `req.headers`,
+ * pushes to `res.write()` / `res.end()`, etc. Next's Pages Router
+ * hands the handler those exact Node types directly
+ * (`NextApiRequest extends IncomingMessage`, `NextApiResponse extends
+ * ServerResponse`). The App Router's Web-fetch-style `Request` and
+ * `Response` are NOT compatible with Express without a manual
+ * adapter layer.
+ *
+ * App Router + Pages Router can coexist in the same Next.js project.
+ * Our only App-Router API route today is
+ * `/api/oauth/github/exchange`; this catch-all owns `/api/v1/*` and
+ * nothing else.
+ *
+ * Cold-start vs. warm-invocation
+ * ──────────────────────────────
+ * Vercel may keep a function container warm for a few minutes
+ * between requests. We cache the Express app on a module-level
+ * Promise so warm calls reuse it (and its Mongo connection pool).
+ * Cold starts pay the full price: one `buildApp()` (sync), then a
+ * background `connect()` → `bootstrap()` → `seedDefaultOrg()`
+ * pipeline that primes Mongo. Routes that touch Mongo via `getDb()`
+ * await the same in-flight `connect()` promise — see
+ * `apps/api/src/db/client.ts`.
+ *
+ * Body parsing + response handling
+ * ────────────────────────────────
+ *   - `bodyParser: false` — Express's own parsers consume the raw
+ *     body. Without this Next would parse first and Express would
+ *     get an empty stream.
+ *   - `responseLimit: false` — disables Next's 4MB default response
+ *     cap. The classify-goals NDJSON stream + audit-log responses
+ *     can exceed that on long sessions. Vercel still enforces its
+ *     own function-execution + payload limits at the platform
+ *     layer.
+ *   - `externalResolver: true` — silences Next's
+ *     "API resolved without sending a response" warning. We DO send
+ *     a response, but asynchronously via Express; Next's heuristic
+ *     can't tell.
+ *
+ * Streaming caveat on Vercel
+ * ──────────────────────────
+ * Vercel function-execution caps depend on plan:
+ *   - Hobby: 10 s per invocation (NDJSON streams cut off)
+ *   - Pro:   60 s for streaming responses
+ *   - Enterprise: configurable up to 900 s
+ * `/api/v1/ai/classify-goals` and `/api/v1/ai/grade-pr` are the
+ * streamiest endpoints. If you're on Hobby and seeing classifier
+ * timeouts, the fix is to refactor that route to a client-driven
+ * fan-out (one short request per goal) — see the migration notes
+ * in the README for instructions.
+ */
+
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { Application } from "express";
+
+let appPromise: Promise<Application> | null = null;
+
+async function getApp(): Promise<Application> {
+  if (!appPromise) {
+    appPromise = (async () => {
+      // Dynamic import so the module graph stays small for any
+      // request that doesn't touch this route (Next still bundles
+      // it into the function, but the import isn't evaluated until
+      // the first /api/v1/* hit on a fresh container).
+      const mod = await import("@espace-devhub/api");
+      const app = mod.buildApp();
+      // Kick off the Mongo + bootstrap pipeline in the background.
+      // We don't `await` it here so the first request can start
+      // processing immediately — any handler that needs the DB
+      // awaits the same in-flight `connect()` singleton via
+      // `getDb()` (see apps/api/src/db/client.ts).
+      void mod
+        .connect()
+        .then(() => mod.bootstrap())
+        .then(() => mod.seedDefaultOrg())
+        .catch((err: unknown) => {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "[boot] serverless mongo bootstrap failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+        });
+      return app;
+    })();
+  }
+  return appPromise;
+}
+
+export const config = {
+  api: {
+    bodyParser: false,
+    responseLimit: false,
+    externalResolver: true,
+  },
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  const app = await getApp();
+  // Express writes to res asynchronously; wrap the call in a promise
+  // that settles when the response is fully sent (either normal
+  // `finish` or premature `close`). Without this, Next would resolve
+  // the function before Express finishes streaming, leaving the
+  // client with a truncated body on Vercel.
+  return new Promise<void>((resolve) => {
+    res.on("close", () => resolve());
+    res.on("finish", () => resolve());
+    app(req, res);
+  });
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,42 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@api/nim": "file:.api/apis/nim",
+        "@espace-devhub/api": "*",
         "@espace-devhub/shared": "*",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -81,9 +82,13 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/express": "^4.17.23",
+        "@types/node": "^22.18.10",
+        "@types/react": "^19.0.0",
         "baseline-browser-mapping": "^2.10.23",
         "tailwindcss": "^4",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "typescript": "^5.7.3"
       }
     },
     "apps/web/.api/apis/nim": {
@@ -4046,6 +4051,16 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/@types/send": {
       "version": "1.2.1",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build --workspace=@espace-devhub/web",
+  "installCommand": "npm install",
+  "outputDirectory": "apps/web/.next",
+  "framework": "nextjs",
+  "functions": {
+    "apps/web/src/pages/api/v1/[...path].ts": {
+      "maxDuration": 60
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Wraps the existing Express API as a Vercel serverless function so the entire backend ships alongside the Next.js web app — no Railway / Render / separate host needed. **Zero changes to controllers, validators, middleware, sessions, NDJSON streaming, or any application code.**

## How it works
- `apps/api/src/serverless.ts` (new) — barrel exporting `buildApp` + `connect` / `bootstrap` / `seedDefaultOrg`.
- `apps/web/src/pages/api/v1/[...path].ts` (new) — Pages Router catch-all. Caches the Express app on a module-level promise; cold starts kick off Mongo bootstrap in the background, warm calls reuse the pool.
- `apps/web/next.config.mjs` — `/api/v1/*` rewrite only fires when `API_ORIGIN` env is set (local dev mode); without it, the catch-all takes the request.
- `vercel.json` at the repo root configures the monorepo build + sets the function maxDuration to 60s.

Local dev is unchanged: `apps/api` still runs standalone via `pnpm dev` on :4000, web rewrites `/api/v1/*` to it when `API_ORIGIN=http://localhost:4000` is set.

## Vercel project setup needed
1. **Root Directory**: leave at repo root (so `vercel.json` is picked up).
2. **Framework**: Next.js (auto-detected).
3. **Env vars** to copy from `apps/api/.env.local`:
   - `MONGO_URI`, `MONGO_DB_NAME`
   - `SESSION_SECRET`, `INTEGRATION_TOKEN_KEY`
   - `MISTRAL_API_KEY` / `GLM_API_KEY` / `OPENROUTER_API_KEY`
   - `RESEND_API_KEY`, `RESEND_DOMAIN_MODE`, `RESEND_FROM_EMAIL`, `RESEND_FROM_NAME`
   - `NEXT_PUBLIC_APP_URL` (your Vercel domain)
   - `ESPACE_*` and `CREALOGIX_*` engagement vars
   - **Do NOT set `API_ORIGIN`** in production — leaving it unset is what activates the catch-all.

## Streaming caveat
Vercel function-execution caps depend on plan:
- **Hobby**: 10s. `/api/v1/ai/classify-goals` NDJSON will cut off — refactor needed (client-side fan-out).
- **Pro**: 60s. Should cover 8–14 goals at concurrency 3.
- **Enterprise**: configurable up to 900s.

## Test plan
- [ ] Deploy → load the dashboard → `/api/v1/auth/me` returns the session.
- [ ] Login flow works end-to-end.
- [ ] A goal-spec save (PATCH `/api/v1/goal-specs/:goalId`) lands in Atlas.
- [ ] If on Pro: re-classify a goal → NDJSON stream completes within 60s.
- [ ] Local dev still works with `API_ORIGIN=http://localhost:4000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)