### PR TITLE
fix(vercel): paths relative to Root Directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,10 +2,9 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm run build --workspace=@espace-devhub/web",
   "installCommand": "npm install",
-  "outputDirectory": "apps/web/.next",
   "framework": "nextjs",
   "functions": {
-    "apps/web/src/pages/api/v1/[...path].ts": {
+    "src/pages/api/v1/[...path].ts": {
       "maxDuration": 60
     }
   }


### PR DESCRIPTION
## What
- `outputDirectory: "apps/web/.next"` → removed (Vercel auto-detects `.next`).
- `functions: { "apps/web/src/pages/api/v1/[...path].ts" }` → `{ "src/pages/api/v1/[...path].ts" }`.

## Why
Your Vercel project has Root Directory = `apps/web`. Paths in `vercel.json` are resolved relative to that, so prefixing them with `apps/web/` again produced the doubled `/vercel/path0/apps/web/apps/web/.next` lookup that the previous build failed on.

The build itself was already succeeding (Next compiled clean, all routes listed including the new `/api/v1/[...path]` catch-all). Just the post-build "where's the output?" check was looking in the wrong place.