### PR TITLE
fix(vercel): install devDependencies so tsc is available

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm run build --workspace=@espace-devhub/web",
-  "installCommand": "npm install",
+  "installCommand": "npm install --include=dev",
   "framework": "nextjs",
   "functions": {
     "src/pages/api/v1/[...path].ts": {


### PR DESCRIPTION
## Summary
- Vercel's default `npm install` runs with `NODE_ENV=production`, which skips devDependencies
- `tsc` (TypeScript compiler) lives in `apps/api`'s devDependencies and is needed during the API build step
- Switch the install command to `npm install --include=dev` so the build toolchain is available without polluting runtime deps

## Background
Last deploy failed at:
```
> @espace-devhub/api@0.0.0 build
> tsc -p tsconfig.build.json
sh: line 1: tsc: command not found
npm error code 127
```

The build chain is `vercel.json buildCommand` → `npm run build --workspace=@espace-devhub/web` → (web's build script) `npm run build --workspace=@espace-devhub/api && next build` → `tsc -p tsconfig.build.json`. That last step needs the TypeScript binary, which was being filtered out by production-mode install.

## Test plan
- [ ] Vercel build progresses past the `tsc` step
- [ ] `dist/` artifacts for `@espace-devhub/api` are produced (so the Pages Router catch-all can `import { buildApp } from "@espace-devhub/api"`)
- [ ] `next build` completes
- [ ] Deployed `/api/v1/health` (or equivalent) responds OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)