### PR TITLE
fix(serverless): unblock cookie-parser in Next catch-all

### DIFF
--- a/apps/web/src/pages/api/v1/[...path].ts
+++ b/apps/web/src/pages/api/v1/[...path].ts
@@ -106,6 +106,22 @@ export default async function handler(
   res: NextApiResponse,
 ): Promise<void> {
   const app = await getApp();
+
+  // Next pre-parses cookies onto `req.cookies` before handing the
+  // request to us. Express's `cookie-parser` short-circuits when it
+  // sees an existing `req.cookies`:
+  //
+  //     if (req.cookies) return next();
+  //
+  // …which means it never sets `req.secret` or `req.signedCookies`.
+  // That breaks signed-cookie writes (`res.cookie(..., { signed: true })`
+  // throws `cookieParser("secret") required for signed cookies`) and
+  // signed-cookie reads (the session middleware sees an empty
+  // `req.signedCookies`). Clear Next's pre-parse so cookie-parser
+  // re-parses from the raw `Cookie` header and wires everything up.
+  delete (req as unknown as { cookies?: unknown }).cookies;
+  delete (req as unknown as { signedCookies?: unknown }).signedCookies;
+
   // Express writes to res asynchronously; wrap the call in a promise
   // that settles when the response is fully sent (either normal
   // `finish` or premature `close`). Without this, Next would resolve

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm run build --workspace=@espace-devhub/web",
-  "installCommand": "npm install",
+  "installCommand": "npm install --include=dev",
   "framework": "nextjs",
   "functions": {
     "src/pages/api/v1/[...path].ts": {


### PR DESCRIPTION
## Summary
- Next's Pages Router pre-parses cookies onto `req.cookies` before our `/api/v1/[...path].ts` catch-all forwards the request to Express
- `cookie-parser`'s `if (req.cookies) return next()` short-circuit then skips setting `req.secret` and `req.signedCookies`
- That breaks signed-cookie writes (login throws on `res.cookie(..., { signed: true })`) AND signed-cookie reads (session middleware sees empty `req.signedCookies`)
- Fix: delete both Next-set keys before invoking the Express app so `cookie-parser` re-parses from the raw `Cookie` header

## Symptom from production logs
```
Error: cookieParser("secret") required for signed cookies
    at res.cookie (/var/task/node_modules/express/lib/response.js:868:11)
    at /var/task/.../auth/login
```
…on every `POST /api/v1/auth/login` after Mongo connected successfully.

## Why it didn't bite in dev
Local dev hits Express directly on port 4000 via the Next rewrite proxy — `req` is a plain Node `IncomingMessage` there, not a `NextApiRequest`, so `req.cookies` is unset and `cookie-parser` runs normally. Only the Vercel serverless catch-all triggers the short-circuit.

## Test plan
- [ ] `POST /api/v1/auth/login` with valid credentials returns 200 and a `Set-Cookie: devhub_sid=...` header
- [ ] Follow-up `GET /api/v1/auth/me` with that cookie returns the logged-in user (proves signed-cookie read also works)
- [ ] `POST /api/v1/auth/logout` clears the cookie

🤖 Generated with [Claude Code](https://claude.com/claude-code)