### PR TITLE
feat(checkin): multi-week catch-up grid for cold-start backfill

### DIFF
--- a/apps/web/src/app/[hub]/checkin/grid/page.jsx
+++ b/apps/web/src/app/[hub]/checkin/grid/page.jsx
@@ -1,0 +1,24 @@
+"use client";
+
+/**
+ * /[hub]/checkin/grid — multi-week catch-up grid view.
+ *
+ * Same slot guard as the single-week page (`checkin`), so any hub
+ * exposing the slot gets both pages.
+ */
+
+import { AppShell } from "@/components/shell/app-shell";
+import { useHubSlotGuard } from "@/features/hubs";
+import { CheckinGridPage } from "@/features/checkin";
+
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+  const exposed = useHubSlotGuard("checkin");
+  if (!exposed) return null;
+  return (
+    <AppShell>
+      <CheckinGridPage />
+    </AppShell>
+  );
+}

--- a/apps/web/src/app/[hub]/checkin/page.jsx
+++ b/apps/web/src/app/[hub]/checkin/page.jsx
@@ -1,0 +1,30 @@
+"use client";
+
+/**
+ * /[hub]/checkin — weekly check-in page.
+ *
+ * Slot id: "checkin". Currently enabled for the Dev hub only via
+ * packages/shared/src/hubs/registry.js. Other hubs' `pages` maps
+ * don't include it, so the slot guard redirects to the hub's
+ * dashboard for them.
+ *
+ * The route reads `?week=...` via useSearchParams in the child
+ * (CheckinPage → useCheckinWeek), so it must opt out of static
+ * prerender. force-dynamic mirrors the dashboard route's setup.
+ */
+
+import { AppShell } from "@/components/shell/app-shell";
+import { useHubSlotGuard } from "@/features/hubs";
+import { CheckinPage } from "@/features/checkin";
+
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+  const exposed = useHubSlotGuard("checkin");
+  if (!exposed) return null;
+  return (
+    <AppShell>
+      <CheckinPage />
+    </AppShell>
+  );
+}

--- a/apps/web/src/components/shell/header.jsx
+++ b/apps/web/src/components/shell/header.jsx
@@ -24,6 +24,7 @@ import { cn } from "@/lib/cn";
  */
 const NAV_ITEMS = [
   { slot: "dashboard", subpath: "" },
+  { slot: "checkin", subpath: "/checkin" },
   { slot: "goals", subpath: "/goals" },
   { slot: "evidence", subpath: "/evidence" },
   { slot: "hub-config", subpath: "/hub-config" },
@@ -41,6 +42,7 @@ const NAV_ITEMS = [
 const DEFAULT_LABELS = {
   dashboard: "Dashboard",
   goals: "Goals",
+  checkin: "Check-in",
   evidence: "Evidence",
   "hub-config": "Hubs",
   users: "Users",

--- a/apps/web/src/features/checkin/checkin-page.jsx
+++ b/apps/web/src/features/checkin/checkin-page.jsx
@@ -20,8 +20,10 @@
  */
 
 import { useCallback, useMemo } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
 import { toast } from "sonner";
-import { Save, AlertTriangle, ArrowRight } from "lucide-react";
+import { Save, AlertTriangle, ArrowRight, LayoutGrid } from "lucide-react";
 import { useGoals } from "@/features/goals";
 import { useGoalSpecs } from "@/features/goal-specs";
 import { useGoalWidgetItems } from "@/features/goal-widgets";
@@ -68,16 +70,12 @@ export function CheckinPage() {
   // Drives the gap banner. Cheap — both inputs change rarely.
   const gapCount = useUnfilledWeeksBefore(activeLabel);
 
+  const params = useParams();
+  const hubId = params?.hub || "dev";
+
   const onPrev = useCallback(() => setWeekLabel(prevLabel), [setWeekLabel, prevLabel]);
   const onNext = useCallback(() => setWeekLabel(nextLabel), [setWeekLabel, nextLabel]);
   const onToday = useCallback(() => setWeekLabel(todayLabel), [setWeekLabel, todayLabel]);
-  const onCatchUp = useCallback(() => {
-    // Jumps to the immediately-prior week so the dev can fill it,
-    // save, and either keep stepping back or use the navigator to
-    // pick the oldest gap directly. The grid view (PR #2) will
-    // collapse this into a single multi-week page.
-    setWeekLabel(prevLabel);
-  }, [setWeekLabel, prevLabel]);
 
   const onSave = useCallback(() => {
     if (!hasSpecs) {
@@ -161,6 +159,15 @@ export function CheckinPage() {
             onNext={onNext}
             onToday={onToday}
           />
+          <Link
+            href={`/${hubId}/checkin/grid`}
+            className="flex items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 py-1.5 text-[11px] uppercase tracking-[0.5px] text-muted-fg hover:bg-accent-dim/60 hover:text-fg"
+            style={{ fontFamily: "var(--font-mono)" }}
+            title="Multi-week catch-up grid"
+          >
+            <LayoutGrid size={13} />
+            Grid
+          </Link>
           <button
             type="button"
             onClick={onSave}
@@ -174,7 +181,7 @@ export function CheckinPage() {
       </div>
 
       {gapCount > 0 && (
-        <GapBanner count={gapCount} onCatchUp={onCatchUp} prevLabel={prevLabel} />
+        <GapBanner count={gapCount} hubId={hubId} />
       )}
 
       <div className="flex flex-col gap-5">
@@ -238,7 +245,7 @@ function L1Group({ group, children }) {
   );
 }
 
-function GapBanner({ count, onCatchUp, prevLabel }) {
+function GapBanner({ count, hubId }) {
   return (
     <div
       className={cn(
@@ -252,15 +259,14 @@ function GapBanner({ count, onCatchUp, prevLabel }) {
           <strong>{count}</strong> unfilled week{count === 1 ? "" : "s"} before this one
         </span>
       </div>
-      <button
-        type="button"
-        onClick={onCatchUp}
+      <Link
+        href={`/${hubId}/checkin/grid`}
         className="flex items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 py-1 text-[11px] uppercase tracking-[0.5px] text-fg hover:bg-accent-dim/60"
         style={{ fontFamily: "var(--font-mono)" }}
       >
-        Step to {prevLabel}
+        Catch up {count} week{count === 1 ? "" : "s"}
         <ArrowRight size={12} />
-      </button>
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/features/checkin/checkin-page.jsx
+++ b/apps/web/src/features/checkin/checkin-page.jsx
@@ -1,0 +1,320 @@
+"use client";
+
+/**
+ * Weekly check-in page.
+ *
+ * One page, one verb: "fill in this week's data, then save". The view
+ * is addressable per-week via `?week=W19` (or `?week=W19-2026`) so
+ * deep links and back-button navigation work, and devs catching up
+ * after a vacation can step through each missing week from one tab.
+ *
+ * Layout:
+ *   - Sticky header  → page title, week navigator, save button
+ *   - Gap banner     → "you have N unfilled weeks before this one"
+ *   - Grouped rows   → one section per L1, rows per classified L2
+ *
+ * The save button doesn't write anything itself — every editor writes
+ * to `goal-inputs` on input. Save just re-runs the snapshot synthesise
+ * for the active week so the snapshot stream reflects what was just
+ * filled, and emits a toast confirming the capture.
+ */
+
+import { useCallback, useMemo } from "react";
+import { toast } from "sonner";
+import { Save, AlertTriangle, ArrowRight } from "lucide-react";
+import { useGoals } from "@/features/goals";
+import { useGoalSpecs } from "@/features/goal-specs";
+import { useGoalWidgetItems } from "@/features/goal-widgets";
+import {
+  useCombinedEventsSince,
+  useCombinedMergedSince,
+  useJiraTickets,
+} from "@/features/integrations";
+import { readInputs } from "@/features/goal-inputs";
+import {
+  readSnapshots,
+  synthesiseWeek,
+} from "@/features/snapshots";
+import { isoDaysAgo } from "@/lib/date";
+import { cn } from "@/lib/cn";
+import { useCheckinWeek } from "./use-checkin-week";
+import { WeekNavigator } from "./week-navigator";
+import { GoalRow } from "./goal-row";
+
+export function CheckinPage() {
+  const {
+    activeLabel,
+    range,
+    prevLabel,
+    nextLabel,
+    todayLabel,
+    canGoNext,
+    setWeekLabel,
+  } = useCheckinWeek();
+
+  const { goals } = useGoals();
+  const { specs } = useGoalSpecs();
+  const { groupedItems, hasGoals, hasSpecs } = useGoalWidgetItems();
+
+  // Pull a full year's worth of merges + ~90d of events so backfilling
+  // older weeks still has data to work with. SWR keys are stable per
+  // day, so opening the page on the same day reuses the cache.
+  const { data: mrs } = useCombinedMergedSince(isoDaysAgo(365));
+  const { data: events } = useCombinedEventsSince(isoDaysAgo(90));
+  const { data: jira } = useJiraTickets();
+  const tickets = Array.isArray(jira?.issues) ? jira.issues : [];
+
+  // Count completed weeks BEFORE the active one that have no snapshot.
+  // Drives the gap banner. Cheap — both inputs change rarely.
+  const gapCount = useUnfilledWeeksBefore(activeLabel);
+
+  const onPrev = useCallback(() => setWeekLabel(prevLabel), [setWeekLabel, prevLabel]);
+  const onNext = useCallback(() => setWeekLabel(nextLabel), [setWeekLabel, nextLabel]);
+  const onToday = useCallback(() => setWeekLabel(todayLabel), [setWeekLabel, todayLabel]);
+  const onCatchUp = useCallback(() => {
+    // Jumps to the immediately-prior week so the dev can fill it,
+    // save, and either keep stepping back or use the navigator to
+    // pick the oldest gap directly. The grid view (PR #2) will
+    // collapse this into a single multi-week page.
+    setWeekLabel(prevLabel);
+  }, [setWeekLabel, prevLabel]);
+
+  const onSave = useCallback(() => {
+    if (!hasSpecs) {
+      toast.info("No classified goals yet — run the Analyst first.");
+      return;
+    }
+    try {
+      synthesiseWeek({
+        range,
+        goals,
+        specs,
+        mrs: mrs || [],
+        events: events || [],
+        tickets,
+        allInputs: readInputs(),
+        // The user is filling this in by hand; record the capture as
+        // manual so it wins over any subsequent auto-snapshot for the
+        // same week.
+        capturedBy: "manual",
+      });
+      toast.success(`Saved week ${activeLabel}`);
+    } catch (err) {
+      toast.error(
+        `Couldn't save week — ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }, [
+    activeLabel,
+    range,
+    goals,
+    specs,
+    mrs,
+    events,
+    tickets,
+    hasSpecs,
+  ]);
+
+  // Empty-state branches
+  if (!hasGoals) {
+    return (
+      <EmptyState
+        title="No goals to track yet"
+        body="Add goals on the Goals page, then come back to log this week's data."
+      />
+    );
+  }
+  if (!hasSpecs) {
+    return (
+      <EmptyState
+        title="Goals not classified yet"
+        body="Run the Analyst (chat panel) so each goal gets a widget. The check-in form needs widgets to know what to ask for."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 px-6 py-5">
+      {/* Sticky header */}
+      <div className="sticky top-[64px] z-10 -mx-6 flex items-center justify-between gap-3 border-b border-border bg-bg/85 px-6 py-3 backdrop-blur-md">
+        <div className="flex items-center gap-3">
+          <div>
+            <h1 className="text-[15px] font-semibold text-fg">Weekly check-in</h1>
+            <p
+              className="text-[10px] uppercase tracking-[0.6px] text-muted-fg"
+              style={{ fontFamily: "var(--font-mono)" }}
+            >
+              fill in what you did · save to lock the week
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <WeekNavigator
+            activeLabel={activeLabel}
+            rangeStart={range.start}
+            rangeEnd={range.end}
+            todayLabel={todayLabel}
+            canGoNext={canGoNext}
+            onPrev={onPrev}
+            onNext={onNext}
+            onToday={onToday}
+          />
+          <button
+            type="button"
+            onClick={onSave}
+            className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[11px] uppercase tracking-[0.5px] text-accent-on hover:opacity-90"
+            style={{ fontFamily: "var(--font-mono)" }}
+          >
+            <Save size={13} />
+            Save week
+          </button>
+        </div>
+      </div>
+
+      {gapCount > 0 && (
+        <GapBanner count={gapCount} onCatchUp={onCatchUp} prevLabel={prevLabel} />
+      )}
+
+      <div className="flex flex-col gap-5">
+        {groupedItems.map((group) => (
+          <L1Group key={group.l1.id} group={group}>
+            {group.items
+              // L1 entries already excluded by useGoalWidgetItems via
+              // unclassifiedGoals logic, BUT the grouped result still
+              // emits the L1 row first if classified. Drop kind:"L1"
+              // here — check-in is L2-only.
+              .filter((item) => item.goal.kind !== "L1")
+              .map((item) => (
+                <GoalRow
+                  key={item.goal.id}
+                  goal={item.goal}
+                  spec={item.spec}
+                  weekStart={range.start}
+                  weekEnd={range.end}
+                  activeLabel={activeLabel}
+                  mrs={mrs}
+                  events={events}
+                  tickets={tickets}
+                />
+              ))}
+          </L1Group>
+        ))}
+      </div>
+
+      <div className="flex justify-end pt-4">
+        <button
+          type="button"
+          onClick={onSave}
+          className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[11px] uppercase tracking-[0.5px] text-accent-on hover:opacity-90"
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          <Save size={13} />
+          Save week
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────── chrome ─────────────────────── */
+
+function L1Group({ group, children }) {
+  return (
+    <section className="flex flex-col gap-2">
+      <header className="flex items-baseline justify-between gap-2 border-b border-border/40 pb-1.5">
+        <h2 className="text-[12px] font-semibold uppercase tracking-[0.6px] text-fg" style={{ fontFamily: "var(--font-mono)" }}>
+          {group.l1.title}
+        </h2>
+        {group.l1.weightage != null && (
+          <span className="text-[10px] text-muted-fg/70" style={{ fontFamily: "var(--font-mono)" }}>
+            weight {group.l1.weightage}%
+          </span>
+        )}
+      </header>
+      <div className="flex flex-col gap-2">{children}</div>
+    </section>
+  );
+}
+
+function GapBanner({ count, onCatchUp, prevLabel }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-3 rounded-md border px-3 py-2",
+        "border-amber/40 bg-amber/5",
+      )}
+    >
+      <div className="flex items-center gap-2 text-[12px] text-fg">
+        <AlertTriangle size={14} className="text-amber" />
+        <span>
+          <strong>{count}</strong> unfilled week{count === 1 ? "" : "s"} before this one
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onCatchUp}
+        className="flex items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 py-1 text-[11px] uppercase tracking-[0.5px] text-fg hover:bg-accent-dim/60"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        Step to {prevLabel}
+        <ArrowRight size={12} />
+      </button>
+    </div>
+  );
+}
+
+function EmptyState({ title, body }) {
+  return (
+    <div className="flex h-[60vh] flex-col items-center justify-center gap-2 px-6 text-center">
+      <h2 className="text-[14px] font-semibold text-fg">{title}</h2>
+      <p className="max-w-md text-[12px] text-muted-fg">{body}</p>
+    </div>
+  );
+}
+
+/* ─────────────────────── helpers ─────────────────────── */
+
+/**
+ * How many completed Sun → Thu weeks before `activeLabel` (within the
+ * current calendar year) don't have a snapshot yet? Used to drive the
+ * gap banner.
+ */
+function useUnfilledWeeksBefore(activeLabel) {
+  return useMemo(() => {
+    if (typeof window === "undefined") return 0;
+    const existing = new Set(readSnapshots().map((s) => s.week));
+
+    // Enumerate completed weeks ending before activeLabel. We rely on
+    // the "Wnn" label sorting correctly within a year, so any snapshot
+    // week with label < activeLabel is BEFORE this week.
+    const now = new Date();
+    const year = now.getFullYear();
+    const yearStart = new Date(year, 0, 1);
+    const thisSunday = new Date(now);
+    thisSunday.setDate(now.getDate() - now.getDay());
+    thisSunday.setHours(0, 0, 0, 0);
+
+    const labels = [];
+    const cursor = new Date(thisSunday);
+    cursor.setDate(cursor.getDate() - 7); // start at most-recent completed
+    while (cursor >= yearStart) {
+      const midWeek = new Date(cursor);
+      midWeek.setDate(cursor.getDate() + 3);
+      const label = `W${String(weekNumberOf(midWeek)).padStart(2, "0")}`;
+      if (label < activeLabel) labels.push(label);
+      cursor.setDate(cursor.getDate() - 7);
+    }
+    return labels.filter((l) => !existing.has(l)).length;
+  }, [activeLabel]);
+}
+
+function weekNumberOf(date) {
+  const yearStart = new Date(date.getFullYear(), 0, 1);
+  const dayOfYear = Math.floor(
+    (date - yearStart) / (24 * 60 * 60 * 1000),
+  ) + 1;
+  const jan1Weekday = yearStart.getDay();
+  return Math.ceil((dayOfYear + jan1Weekday) / 7);
+}

--- a/apps/web/src/features/checkin/editors.jsx
+++ b/apps/web/src/features/checkin/editors.jsx
@@ -1,0 +1,460 @@
+"use client";
+
+/**
+ * Compact inline editors for the weekly check-in page.
+ *
+ * Each editor renders the "what did you do for this goal THIS week"
+ * input shape, scoped to the active week's [start, end) window. Writes
+ * go through `useGoalInputs().append(value, note, ts)` with `ts` set
+ * to the mid-week timestamp of the active week — so re-runs of the
+ * snapshot capture bucket the entry under the right `cadenceWindow`.
+ *
+ * One file, multiple editors. Each is small (~30 lines); a separate
+ * file per editor would be more ceremony than code. When any of them
+ * grows past ~60 lines we'll split.
+ *
+ * Editors covered in PR #1:
+ *   - CounterEditor          (number; sum of entries this week)
+ *   - ScaleEditor            (1–5 pills; latest entry this week)
+ *   - MilestoneEditor        (checklist; latest checklist snapshot)
+ *   - DateLogEditor          (count + add today; entries this week)
+ *   - FreeTextEditor         (textarea note for this week)
+ *   - BeforeAfterEditor      (baseline + current pair)
+ *
+ * Read-only displays:
+ *   - AutoReadout            (auto-widget metric from integration data)
+ *   - UnsupportedStub        (incident / recurring / rubric / scorecard
+ *                             for now — full editors in a later PR)
+ */
+
+import { useMemo, useState } from "react";
+import { Minus, Plus, Check } from "lucide-react";
+import { useGoalInputs } from "@/features/goal-inputs";
+import { midWeekTs } from "@/lib/date";
+import { cn } from "@/lib/cn";
+
+/* ─────────────────────── Counter ─────────────────────── */
+
+export function CounterEditor({ goal, spec, weekStart, weekEnd, activeLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const weekTotal = useMemo(
+    () => sumNumericInWindow(entries, weekStart, weekEnd),
+    [entries, weekStart, weekEnd],
+  );
+  const target = spec.manual?.target;
+  const unit = spec.manual?.unit || "";
+
+  const add = (delta) => {
+    const ts = midWeekTs(activeLabel);
+    if (ts == null) return;
+    append(delta, undefined, ts);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <ValueChip
+        value={weekTotal}
+        unit={unit}
+        target={target}
+        suffix={target ? `${target.op}${target.value}` : null}
+      />
+      <StepButton onClick={() => add(-1)} aria-label="Subtract 1">
+        <Minus size={12} />
+      </StepButton>
+      <StepButton onClick={() => add(+1)} aria-label="Add 1" primary>
+        <Plus size={12} />
+      </StepButton>
+      <StepButton onClick={() => add(+5)} aria-label="Add 5">
+        +5
+      </StepButton>
+    </div>
+  );
+}
+
+/* ─────────────────────── Scale (1–5) ─────────────────────── */
+
+export function ScaleEditor({ goal, weekStart, weekEnd, activeLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const currentValue = useMemo(() => {
+    const inWindow = entries.filter(
+      (e) =>
+        e.ts >= weekStart.getTime() &&
+        e.ts < weekEnd.getTime() &&
+        Number.isFinite(Number(e.value)),
+    );
+    const latest = inWindow[inWindow.length - 1];
+    return latest ? Number(latest.value) : null;
+  }, [entries, weekStart, weekEnd]);
+
+  const pick = (n) => {
+    const ts = midWeekTs(activeLabel);
+    if (ts == null) return;
+    append(n, undefined, ts);
+  };
+
+  return (
+    <div className="flex items-center gap-1">
+      {[1, 2, 3, 4, 5].map((n) => (
+        <button
+          key={n}
+          type="button"
+          onClick={() => pick(n)}
+          className={cn(
+            "h-7 w-7 rounded-md border border-border text-[12px] font-medium transition-colors",
+            currentValue === n
+              ? "bg-accent text-accent-on"
+              : "text-muted-fg hover:bg-accent-dim/60 hover:text-fg",
+          )}
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          {n}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ─────────────────────── Milestone (checklist) ─────────────────────── */
+
+export function MilestoneEditor({ goal, spec, weekStart, weekEnd, activeLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  // The widget stores the WHOLE checklist as one entry's value. We take
+  // the latest entry (up to and including this week) as the current
+  // state, then write a new entry on every toggle.
+  const items = useMemo(() => {
+    const upToWeek = entries.filter((e) => e.ts <= weekEnd.getTime());
+    const latest = upToWeek[upToWeek.length - 1];
+    const stored = Array.isArray(latest?.value?.items) ? latest.value.items : null;
+    if (stored) return stored;
+    // First-time-this-goal: seed from the spec's manual.items (the
+    // classifier's authoritative list).
+    const seed = Array.isArray(spec.manual?.items) ? spec.manual.items : [];
+    return seed.map((it) => ({
+      id: it.id || slugify(it.label || it),
+      label: it.label || it,
+      done: false,
+    }));
+  }, [entries, weekEnd, spec.manual?.items]);
+
+  const toggle = (id) => {
+    const ts = midWeekTs(activeLabel);
+    if (ts == null) return;
+    const next = items.map((it) =>
+      it.id === id ? { ...it, done: !it.done } : it,
+    );
+    append({ items: next }, undefined, ts);
+  };
+
+  const done = items.filter((i) => i.done).length;
+  const total = items.length;
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+
+  return (
+    <div className="flex w-full flex-col gap-1.5">
+      <div className="flex items-center justify-between text-[11px] text-muted-fg" style={{ fontFamily: "var(--font-mono)" }}>
+        <span>
+          {done} / {total} done · {pct}%
+        </span>
+        {weekStart && (
+          <span className="opacity-60">latest snapshot ≤ week-end</span>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {items.map((it) => (
+          <button
+            key={it.id}
+            type="button"
+            onClick={() => toggle(it.id)}
+            className={cn(
+              "flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] transition-colors",
+              it.done
+                ? "bg-accent-dim text-fg"
+                : "text-muted-fg hover:bg-accent-dim/40",
+            )}
+          >
+            {it.done && <Check size={11} />}
+            {it.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────── Free-text ─────────────────────── */
+
+export function FreeTextEditor({ goal, weekStart, weekEnd, activeLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const initial = useMemo(() => {
+    const inWindow = entries.filter(
+      (e) => e.ts >= weekStart.getTime() && e.ts < weekEnd.getTime(),
+    );
+    const latest = inWindow[inWindow.length - 1];
+    return typeof latest?.value === "string" ? latest.value : "";
+  }, [entries, weekStart, weekEnd]);
+
+  const [draft, setDraft] = useState(initial);
+  const dirty = draft !== initial;
+
+  const save = () => {
+    const ts = midWeekTs(activeLabel);
+    if (ts == null) return;
+    append(draft, undefined, ts);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-1.5">
+      <textarea
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        rows={2}
+        maxLength={500}
+        placeholder="Note for this week…"
+        className="w-full resize-none rounded-md border border-border bg-bg px-2 py-1.5 text-[12px]"
+        style={{ fontFamily: "var(--font-mono)" }}
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-muted-fg/70">{draft.length} / 500</span>
+        <button
+          type="button"
+          onClick={save}
+          disabled={!dirty || draft.length === 0}
+          className={cn(
+            "rounded-md px-2.5 py-1 text-[10px] uppercase tracking-[0.4px] transition-opacity disabled:opacity-40",
+            "bg-accent text-accent-on",
+          )}
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          {dirty ? "Save note" : "Saved"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────── Date-log ─────────────────────── */
+
+export function DateLogEditor({ goal, weekStart, weekEnd, activeLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const weekCount = useMemo(
+    () =>
+      entries.filter(
+        (e) => e.ts >= weekStart.getTime() && e.ts < weekEnd.getTime(),
+      ).length,
+    [entries, weekStart, weekEnd],
+  );
+
+  const add = () => {
+    const ts = midWeekTs(activeLabel);
+    if (ts == null) return;
+    append(true, undefined, ts);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <ValueChip value={weekCount} unit={weekCount === 1 ? "log" : "logs"} />
+      <button
+        type="button"
+        onClick={add}
+        className="flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-[11px] uppercase tracking-[0.4px] text-muted-fg transition-colors hover:bg-accent-dim/60 hover:text-fg"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        <Plus size={11} />
+        Log
+      </button>
+    </div>
+  );
+}
+
+/* ─────────────────────── Before-after ─────────────────────── */
+
+export function BeforeAfterEditor({ goal, weekStart, weekEnd, activeLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const initial = useMemo(() => {
+    const upToWeek = entries.filter((e) => e.ts <= weekEnd.getTime());
+    const latest = upToWeek[upToWeek.length - 1];
+    const b = Number(latest?.value?.baseline);
+    const c = Number(latest?.value?.current);
+    return {
+      baseline: Number.isFinite(b) ? String(b) : "",
+      current: Number.isFinite(c) ? String(c) : "",
+    };
+  }, [entries, weekEnd]);
+
+  const [draft, setDraft] = useState(initial);
+  const dirty = draft.baseline !== initial.baseline || draft.current !== initial.current;
+
+  const save = () => {
+    const ts = midWeekTs(activeLabel);
+    if (ts == null) return;
+    const baseline = Number(draft.baseline);
+    const current = Number(draft.current);
+    if (!Number.isFinite(baseline) || !Number.isFinite(current)) return;
+    append({ baseline, current }, undefined, ts);
+  };
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <NumberField
+        value={draft.baseline}
+        onChange={(v) => setDraft((d) => ({ ...d, baseline: v }))}
+        label="baseline"
+      />
+      <span className="text-[11px] text-muted-fg">→</span>
+      <NumberField
+        value={draft.current}
+        onChange={(v) => setDraft((d) => ({ ...d, current: v }))}
+        label="current"
+      />
+      <button
+        type="button"
+        onClick={save}
+        disabled={!dirty}
+        className="rounded-md px-2 py-1 text-[10px] uppercase tracking-[0.4px] bg-accent text-accent-on transition-opacity disabled:opacity-40"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        Save
+      </button>
+    </div>
+  );
+}
+
+/* ─────────────────────── Read-only: auto widgets ─────────────────────── */
+
+export function AutoReadout({ value, unit, target, hint }) {
+  return (
+    <div className="flex items-center gap-2">
+      <ValueChip value={value} unit={unit} target={target} suffix={target ? `${target.op}${target.value}` : null} />
+      {hint && (
+        <span
+          className="text-[10px] uppercase tracking-[0.4px] text-muted-fg/70"
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          {hint}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/* ─────────────────────── Stub for not-yet-supported kinds ─────────────────────── */
+
+export function UnsupportedStub({ message }) {
+  return (
+    <div
+      className="rounded-md border border-dashed border-border px-2.5 py-1 text-[11px] text-muted-fg/80"
+      style={{ fontFamily: "var(--font-mono)" }}
+    >
+      {message || "Edit from the goal widget for now — inline editor coming soon."}
+    </div>
+  );
+}
+
+/* ─────────────────────── primitives ─────────────────────── */
+
+function StepButton({ onClick, children, primary, ...rest }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex h-7 min-w-7 items-center justify-center rounded-md border border-border px-1.5 text-[11px] font-medium transition-colors",
+        primary
+          ? "bg-accent text-accent-on hover:opacity-90"
+          : "text-muted-fg hover:bg-accent-dim/60 hover:text-fg",
+      )}
+      style={{ fontFamily: "var(--font-mono)" }}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}
+
+function NumberField({ value, onChange, label }) {
+  return (
+    <label className="flex items-center gap-1">
+      <span
+        className="text-[10px] uppercase tracking-[0.4px] text-muted-fg/70"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        {label}
+      </span>
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-7 w-16 rounded-md border border-border bg-bg px-1.5 text-[12px]"
+        style={{ fontFamily: "var(--font-mono)" }}
+      />
+    </label>
+  );
+}
+
+function ValueChip({ value, unit, target, suffix }) {
+  const numeric = Number(value);
+  const display = Number.isFinite(numeric)
+    ? formatNumber(numeric)
+    : value == null
+    ? "—"
+    : String(value);
+  const meetsTarget = evalMet(numeric, target);
+  return (
+    <div
+      className={cn(
+        "flex items-baseline gap-1 rounded-md border border-border px-2 py-1",
+        meetsTarget === true
+          ? "border-success/40 bg-success/5"
+          : meetsTarget === false
+          ? "border-amber/40 bg-amber/5"
+          : "bg-bg",
+      )}
+      style={{ fontFamily: "var(--font-mono)" }}
+    >
+      <span className="text-[13px] font-semibold text-fg">{display}</span>
+      {unit && <span className="text-[10px] text-muted-fg">{unit}</span>}
+      {suffix && (
+        <span className="ml-1 text-[10px] text-muted-fg/70">/ {suffix}</span>
+      )}
+    </div>
+  );
+}
+
+/* ─────── helpers ─────── */
+
+function sumNumericInWindow(entries, start, end) {
+  if (!Array.isArray(entries)) return 0;
+  const s = start.getTime();
+  const e = end.getTime();
+  let sum = 0;
+  for (const entry of entries) {
+    if (entry.ts < s || entry.ts >= e) continue;
+    const n = Number(entry.value);
+    if (Number.isFinite(n)) sum += n;
+  }
+  return sum;
+}
+
+function evalMet(value, target) {
+  if (!target || target.value == null || !Number.isFinite(Number(value))) {
+    return null;
+  }
+  const v = Number(value);
+  if (target.op === ">=") return v >= target.value;
+  if (target.op === "<=") return v <= target.value;
+  if (target.op === "=") return Math.abs(v - target.value) < 0.01 * Math.abs(target.value || 1);
+  return null;
+}
+
+function formatNumber(n) {
+  if (Math.abs(n) >= 1000) return n.toLocaleString();
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(2).replace(/\.?0+$/, "");
+}
+
+function slugify(s) {
+  return String(s || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}

--- a/apps/web/src/features/checkin/goal-row.jsx
+++ b/apps/web/src/features/checkin/goal-row.jsx
@@ -1,0 +1,339 @@
+"use client";
+
+/**
+ * One row of the weekly check-in page — title + kind + an inline editor
+ * appropriate to the goal's spec.widget. Pure dispatcher: holds no
+ * input state of its own; each editor talks to the goal-inputs store
+ * directly via `useGoalInputs`.
+ *
+ * Auto widgets get a `<AutoReadout>` with the value computed for this
+ * week from the integration data the page already loaded (mrs, events,
+ * tickets). Manual widgets get their dedicated editor. Phase D/E
+ * widgets that need richer editors (incidents, recurring milestone,
+ * code rubric, scorecard) get an `<UnsupportedStub>` directing the
+ * user to the existing widget UI — until PR #2 of this work-stream
+ * builds inline editors for them too.
+ */
+
+import { useMemo } from "react";
+import { SPEC_KINDS } from "@/features/goal-specs";
+import {
+  avgReviewerComments,
+  firstPassRatePct,
+  linkagePct,
+  medianTurnaroundDays,
+} from "@/features/integrations";
+import {
+  AutoReadout,
+  BeforeAfterEditor,
+  CounterEditor,
+  DateLogEditor,
+  FreeTextEditor,
+  MilestoneEditor,
+  ScaleEditor,
+  UnsupportedStub,
+} from "./editors";
+
+export function GoalRow({
+  goal,
+  spec,
+  weekStart,
+  weekEnd,
+  activeLabel,
+  mrs,
+  events,
+  tickets,
+}) {
+  const widget = spec.widget;
+
+  // Filter integration data to this week's window once for any auto
+  // widget that wants it.
+  const weekMrs = useMemo(
+    () => filterMrs(mrs, weekStart, weekEnd),
+    [mrs, weekStart, weekEnd],
+  );
+  const weekEvents = useMemo(
+    () => filterEvents(events, weekStart, weekEnd),
+    [events, weekStart, weekEnd],
+  );
+
+  return (
+    <div className="flex items-start justify-between gap-4 rounded-md border border-border bg-bg/40 px-3 py-2.5">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <span
+            className="rounded-[3px] border border-border px-1 py-px text-[9px] uppercase tracking-[0.6px] text-muted-fg"
+            style={{ fontFamily: "var(--font-mono)" }}
+          >
+            {kindLabel(widget)}
+          </span>
+          <div className="truncate text-[13px] font-medium text-fg">
+            {goal?.title || spec.title || "Untitled"}
+          </div>
+        </div>
+        <SubLine spec={spec} />
+      </div>
+
+      <div className="flex-shrink-0">
+        <EditorFor
+          widget={widget}
+          goal={goal}
+          spec={spec}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          activeLabel={activeLabel}
+          weekMrs={weekMrs}
+          weekEvents={weekEvents}
+          tickets={tickets}
+        />
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────── dispatch ─────────────────────── */
+
+function EditorFor({
+  widget,
+  goal,
+  spec,
+  weekStart,
+  weekEnd,
+  activeLabel,
+  weekMrs,
+  weekEvents,
+  tickets,
+}) {
+  switch (widget) {
+    // Manual editors
+    case SPEC_KINDS.COUNTER:
+      return (
+        <CounterEditor
+          goal={goal}
+          spec={spec}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          activeLabel={activeLabel}
+        />
+      );
+    case SPEC_KINDS.SCALE:
+      return (
+        <ScaleEditor
+          goal={goal}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          activeLabel={activeLabel}
+        />
+      );
+    case SPEC_KINDS.MILESTONE:
+      return (
+        <MilestoneEditor
+          goal={goal}
+          spec={spec}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          activeLabel={activeLabel}
+        />
+      );
+    case SPEC_KINDS.FREE_TEXT:
+      return (
+        <FreeTextEditor
+          goal={goal}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          activeLabel={activeLabel}
+        />
+      );
+    case SPEC_KINDS.DATE_LOG:
+      return (
+        <DateLogEditor
+          goal={goal}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          activeLabel={activeLabel}
+        />
+      );
+    case SPEC_KINDS.BEFORE_AFTER:
+      return (
+        <BeforeAfterEditor
+          goal={goal}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          activeLabel={activeLabel}
+        />
+      );
+
+    // Auto read-outs computed from this week's integration data
+    case SPEC_KINDS.MERGED_COUNT:
+      return (
+        <AutoReadout
+          value={weekMrs.length}
+          unit={weekMrs.length === 1 ? "merge" : "merges"}
+          target={spec.source?.target}
+          hint="auto · github/gitlab"
+        />
+      );
+    case SPEC_KINDS.REVIEW_ROUNDS: {
+      const v = avgReviewerComments(weekMrs);
+      return (
+        <AutoReadout
+          value={v == null ? "—" : v.toFixed(2)}
+          unit="rounds"
+          target={spec.source?.target}
+          hint="auto · this week's MRs"
+        />
+      );
+    }
+    case SPEC_KINDS.TURNAROUND: {
+      const days = medianTurnaroundDays(weekMrs);
+      const hours = days == null ? null : Math.round(days * 24);
+      return (
+        <AutoReadout
+          value={hours == null ? "—" : hours}
+          unit="h median"
+          target={spec.source?.target}
+          hint="auto · open → merge"
+        />
+      );
+    }
+    case SPEC_KINDS.LINKAGE: {
+      const pct = linkagePct(weekMrs)?.pct ?? null;
+      return (
+        <AutoReadout
+          value={pct == null ? "—" : pct}
+          unit="%"
+          target={spec.source?.target}
+          hint="auto · % MRs linked"
+        />
+      );
+    }
+    case SPEC_KINDS.FIRST_PASS_RATE: {
+      const pct = firstPassRatePct(weekMrs);
+      return (
+        <AutoReadout
+          value={pct == null ? "—" : pct}
+          unit="%"
+          target={spec.source?.target}
+          hint="auto · first-pass"
+        />
+      );
+    }
+    case SPEC_KINDS.TICKET_CYCLE:
+      return (
+        <AutoReadout
+          value={Array.isArray(tickets) ? tickets.length : 0}
+          unit="tickets"
+          target={spec.source?.target}
+          hint="auto · jira"
+        />
+      );
+
+    // Phase D/E widgets with richer state — full inline editors land in
+    // a later PR. For now, point the user at the dashboard widget.
+    case SPEC_KINDS.INCIDENT_LOG:
+      return <UnsupportedStub message="Log incidents from the dashboard widget" />;
+    case SPEC_KINDS.RECURRING_MILESTONE:
+      return <UnsupportedStub message="Toggle items from the dashboard widget" />;
+    case SPEC_KINDS.CODE_RUBRIC:
+      return <UnsupportedStub message="Grade PRs from the dashboard widget" />;
+    case SPEC_KINDS.SCORECARD:
+      return <UnsupportedStub message="Edit components from the dashboard widget" />;
+    case SPEC_KINDS.DEPLOY_FREQUENCY:
+    case SPEC_KINDS.LEAD_TIME:
+    case SPEC_KINDS.BUILD_PASS_RATE:
+      return <UnsupportedStub message="Tracked via CI/CD — visible on the dashboard" />;
+
+    default:
+      return <UnsupportedStub message={`No editor for "${widget}" yet`} />;
+  }
+}
+
+/* ─────────────────────── chrome ─────────────────────── */
+
+function SubLine({ spec }) {
+  const target = spec.manual?.target || spec.source?.target;
+  const cadence = spec.manual?.cadence;
+  const bits = [];
+  if (cadence) bits.push(cadence);
+  if (target) bits.push(`target ${target.op}${target.value}${spec.manual?.unit ? " " + spec.manual.unit : ""}`);
+  if (bits.length === 0) return null;
+  return (
+    <div
+      className="text-[10px] uppercase tracking-[0.4px] text-muted-fg/70"
+      style={{ fontFamily: "var(--font-mono)" }}
+    >
+      {bits.join(" · ")}
+    </div>
+  );
+}
+
+function kindLabel(widget) {
+  // Compact friendly label for the chip — falls back to a sliced
+  // version of the SPEC_KINDS constant. We avoid pulling in the whole
+  // SPEC_KIND_META table from shared since this is purely cosmetic.
+  switch (widget) {
+    case SPEC_KINDS.COUNTER:
+      return "counter";
+    case SPEC_KINDS.SCALE:
+      return "scale";
+    case SPEC_KINDS.MILESTONE:
+      return "milestone";
+    case SPEC_KINDS.FREE_TEXT:
+      return "note";
+    case SPEC_KINDS.DATE_LOG:
+      return "date-log";
+    case SPEC_KINDS.BEFORE_AFTER:
+      return "before/after";
+    case SPEC_KINDS.MERGED_COUNT:
+      return "merges";
+    case SPEC_KINDS.REVIEW_ROUNDS:
+      return "rounds";
+    case SPEC_KINDS.TURNAROUND:
+      return "turnaround";
+    case SPEC_KINDS.LINKAGE:
+      return "linkage";
+    case SPEC_KINDS.FIRST_PASS_RATE:
+      return "first-pass";
+    case SPEC_KINDS.TICKET_CYCLE:
+      return "tickets";
+    case SPEC_KINDS.INCIDENT_LOG:
+      return "incidents";
+    case SPEC_KINDS.RECURRING_MILESTONE:
+      return "recurring";
+    case SPEC_KINDS.CODE_RUBRIC:
+      return "rubric";
+    case SPEC_KINDS.SCORECARD:
+      return "scorecard";
+    case SPEC_KINDS.DEPLOY_FREQUENCY:
+      return "deploys";
+    case SPEC_KINDS.LEAD_TIME:
+      return "lead-time";
+    case SPEC_KINDS.BUILD_PASS_RATE:
+      return "build-pass";
+    default:
+      return String(widget || "").toLowerCase().slice(0, 14);
+  }
+}
+
+/* ─────────────────────── filtering ─────────────────────── */
+
+function filterMrs(mrs, start, end) {
+  if (!Array.isArray(mrs)) return [];
+  const s = start.getTime();
+  const e = end.getTime();
+  return mrs.filter((m) => {
+    if (!m.merged_at) return false;
+    const t = new Date(m.merged_at).getTime();
+    return t >= s && t < e;
+  });
+}
+
+function filterEvents(events, start, end) {
+  if (!Array.isArray(events)) return [];
+  const s = start.getTime();
+  const e = end.getTime();
+  return events.filter((ev) => {
+    const t = new Date(ev.created_at || 0).getTime();
+    return t >= s && t < e;
+  });
+}

--- a/apps/web/src/features/checkin/grid-cells.jsx
+++ b/apps/web/src/features/checkin/grid-cells.jsx
@@ -1,0 +1,522 @@
+"use client";
+
+/**
+ * Compact per-cell editors for the catch-up grid.
+ *
+ * Sized to fit a ~120 × 56px cell. Cells that need more room
+ * (milestone checklist, free-text, before-after pair) collapse to a
+ * compact preview chip and expand into a Radix popover when clicked.
+ *
+ * These are the GRID counterparts to the row editors in `editors.jsx`.
+ * Sharing one set of editors between the row view and the grid view
+ * would have meant ALL of them grow popover behaviour just for the
+ * grid case, OR all of them stay inline and the grid breaks visually
+ * for milestone/free-text. Keeping the two surfaces as separate
+ * components is the smaller diff.
+ *
+ * All cells write through `useGoalInputs().append(value, note, ts)`
+ * with `ts = midWeekTs(weekLabel)` — same path as the row editors and
+ * the existing per-widget input UIs.
+ */
+
+import { useMemo, useState } from "react";
+import * as Popover from "@radix-ui/react-popover";
+import { Minus, Plus, Check, ChevronDown } from "lucide-react";
+import { useGoalInputs } from "@/features/goal-inputs";
+import { midWeekTs } from "@/lib/date";
+import { cn } from "@/lib/cn";
+
+const CELL_FONT = { fontFamily: "var(--font-mono)" };
+
+/* ─────────────────────── Counter (cell) ─────────────────────── */
+
+export function CounterCell({ goal, weekStart, weekEnd, weekLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const value = useMemo(
+    () => sumNumericInWindow(entries, weekStart, weekEnd),
+    [entries, weekStart, weekEnd],
+  );
+
+  const step = (delta) => {
+    const ts = midWeekTs(weekLabel);
+    if (ts == null) return;
+    append(delta, undefined, ts);
+  };
+
+  return (
+    <div className="flex items-center gap-0.5">
+      <CellStep onClick={() => step(-1)}>
+        <Minus size={10} />
+      </CellStep>
+      <CellValue value={value} />
+      <CellStep onClick={() => step(+1)} primary>
+        <Plus size={10} />
+      </CellStep>
+    </div>
+  );
+}
+
+/* ─────────────────────── Scale (cell) ─────────────────────── */
+
+export function ScaleCell({ goal, weekStart, weekEnd, weekLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const currentValue = useMemo(() => {
+    const inWindow = entries.filter(
+      (e) =>
+        e.ts >= weekStart.getTime() &&
+        e.ts < weekEnd.getTime() &&
+        Number.isFinite(Number(e.value)),
+    );
+    const latest = inWindow[inWindow.length - 1];
+    return latest ? Number(latest.value) : null;
+  }, [entries, weekStart, weekEnd]);
+
+  const pick = (n) => {
+    const ts = midWeekTs(weekLabel);
+    if (ts == null) return;
+    append(n, undefined, ts);
+  };
+
+  return (
+    <div className="flex items-center gap-0.5">
+      {[1, 2, 3, 4, 5].map((n) => (
+        <button
+          key={n}
+          type="button"
+          onClick={() => pick(n)}
+          className={cn(
+            "h-5 w-5 rounded-[3px] border border-border text-[10px] font-medium",
+            currentValue === n
+              ? "bg-accent text-accent-on"
+              : "text-muted-fg hover:bg-accent-dim/50",
+          )}
+          style={CELL_FONT}
+          aria-label={`Rate ${n}`}
+        >
+          {n}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ─────────────────────── Milestone (cell, popover) ─────────────────────── */
+
+export function MilestoneCell({ goal, spec, weekStart, weekEnd, weekLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const items = useMemo(() => {
+    const upToWeek = entries.filter((e) => e.ts <= weekEnd.getTime());
+    const latest = upToWeek[upToWeek.length - 1];
+    const stored = Array.isArray(latest?.value?.items) ? latest.value.items : null;
+    if (stored) return stored;
+    const seed = Array.isArray(spec.manual?.items) ? spec.manual.items : [];
+    return seed.map((it) => ({
+      id: it.id || slugify(it.label || it),
+      label: it.label || it,
+      done: false,
+    }));
+  }, [entries, weekEnd, spec.manual?.items]);
+
+  const done = items.filter((i) => i.done).length;
+  const total = items.length;
+
+  const toggle = (id) => {
+    const ts = midWeekTs(weekLabel);
+    if (ts == null) return;
+    const next = items.map((it) =>
+      it.id === id ? { ...it, done: !it.done } : it,
+    );
+    append({ items: next }, undefined, ts);
+  };
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded-md border border-border bg-bg px-2 py-1 text-[11px] hover:bg-accent-dim/40"
+          style={CELL_FONT}
+        >
+          <span className="font-semibold text-fg">
+            {done}/{total}
+          </span>
+          <ChevronDown size={10} className="text-muted-fg" />
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 max-h-[280px] w-[220px] overflow-y-auto rounded-md border border-border bg-bg p-2 shadow-lg"
+        >
+          <div className="flex flex-col gap-1">
+            {items.length === 0 ? (
+              <span
+                className="px-1 py-2 text-center text-[11px] text-muted-fg"
+                style={CELL_FONT}
+              >
+                No items in this milestone
+              </span>
+            ) : (
+              items.map((it) => (
+                <button
+                  key={it.id}
+                  type="button"
+                  onClick={() => toggle(it.id)}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-md px-2 py-1 text-left text-[11px] transition-colors",
+                    it.done
+                      ? "bg-accent-dim text-fg"
+                      : "text-muted-fg hover:bg-accent-dim/40",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "flex h-3.5 w-3.5 items-center justify-center rounded-[3px] border",
+                      it.done
+                        ? "border-accent bg-accent text-accent-on"
+                        : "border-border bg-bg",
+                    )}
+                  >
+                    {it.done && <Check size={9} />}
+                  </span>
+                  <span className="truncate">{it.label}</span>
+                </button>
+              ))
+            )}
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+/* ─────────────────────── Free-text (cell, popover) ─────────────────────── */
+
+export function FreeTextCell({ goal, weekStart, weekEnd, weekLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const saved = useMemo(() => {
+    const inWindow = entries.filter(
+      (e) => e.ts >= weekStart.getTime() && e.ts < weekEnd.getTime(),
+    );
+    const latest = inWindow[inWindow.length - 1];
+    return typeof latest?.value === "string" ? latest.value : "";
+  }, [entries, weekStart, weekEnd]);
+
+  const [draft, setDraft] = useState(saved);
+  const [open, setOpen] = useState(false);
+
+  const onOpenChange = (next) => {
+    if (next) setDraft(saved); // reset draft when popover opens
+    setOpen(next);
+  };
+
+  const onSave = () => {
+    if (draft === saved) {
+      setOpen(false);
+      return;
+    }
+    const ts = midWeekTs(weekLabel);
+    if (ts == null) return;
+    append(draft, undefined, ts);
+    setOpen(false);
+  };
+
+  const preview = saved.trim() || "—";
+
+  return (
+    <Popover.Root open={open} onOpenChange={onOpenChange}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "max-w-[180px] truncate rounded-md border border-border bg-bg px-2 py-1 text-left text-[11px]",
+            saved ? "text-fg" : "text-muted-fg",
+            "hover:bg-accent-dim/40",
+          )}
+          style={CELL_FONT}
+          title={saved || "Add a note"}
+        >
+          {preview}
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 w-[280px] rounded-md border border-border bg-bg p-2 shadow-lg"
+        >
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={3}
+            maxLength={500}
+            placeholder="Note for this week…"
+            className="w-full resize-none rounded-md border border-border bg-bg px-2 py-1.5 text-[12px]"
+            style={CELL_FONT}
+          />
+          <div className="mt-1.5 flex items-center justify-between">
+            <span className="text-[10px] text-muted-fg/70">{draft.length} / 500</span>
+            <button
+              type="button"
+              onClick={onSave}
+              className="rounded-md bg-accent px-2 py-1 text-[10px] uppercase tracking-[0.4px] text-accent-on"
+              style={CELL_FONT}
+            >
+              Save
+            </button>
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+/* ─────────────────────── Date-log (cell) ─────────────────────── */
+
+export function DateLogCell({ goal, weekStart, weekEnd, weekLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const count = useMemo(
+    () =>
+      entries.filter(
+        (e) => e.ts >= weekStart.getTime() && e.ts < weekEnd.getTime(),
+      ).length,
+    [entries, weekStart, weekEnd],
+  );
+
+  const add = () => {
+    const ts = midWeekTs(weekLabel);
+    if (ts == null) return;
+    append(true, undefined, ts);
+  };
+
+  return (
+    <div className="flex items-center gap-0.5">
+      <CellValue value={count} />
+      <CellStep onClick={add} primary>
+        <Plus size={10} />
+      </CellStep>
+    </div>
+  );
+}
+
+/* ─────────────────────── Before-after (cell, popover) ─────────────────────── */
+
+export function BeforeAfterCell({ goal, weekStart, weekEnd, weekLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const saved = useMemo(() => {
+    const upToWeek = entries.filter((e) => e.ts <= weekEnd.getTime());
+    const latest = upToWeek[upToWeek.length - 1];
+    const b = Number(latest?.value?.baseline);
+    const c = Number(latest?.value?.current);
+    return {
+      baseline: Number.isFinite(b) ? b : null,
+      current: Number.isFinite(c) ? c : null,
+    };
+  }, [entries, weekEnd]);
+
+  const [draft, setDraft] = useState({
+    baseline: saved.baseline == null ? "" : String(saved.baseline),
+    current: saved.current == null ? "" : String(saved.current),
+  });
+  const [open, setOpen] = useState(false);
+
+  const onOpenChange = (next) => {
+    if (next) {
+      setDraft({
+        baseline: saved.baseline == null ? "" : String(saved.baseline),
+        current: saved.current == null ? "" : String(saved.current),
+      });
+    }
+    setOpen(next);
+  };
+
+  const onSave = () => {
+    const b = Number(draft.baseline);
+    const c = Number(draft.current);
+    if (!Number.isFinite(b) || !Number.isFinite(c)) return;
+    const ts = midWeekTs(weekLabel);
+    if (ts == null) return;
+    append({ baseline: b, current: c }, undefined, ts);
+    setOpen(false);
+  };
+
+  const preview =
+    saved.baseline == null && saved.current == null
+      ? "—"
+      : `${formatNumber(saved.baseline)} → ${formatNumber(saved.current)}`;
+
+  return (
+    <Popover.Root open={open} onOpenChange={onOpenChange}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "rounded-md border border-border bg-bg px-2 py-1 text-[11px]",
+            "hover:bg-accent-dim/40",
+            saved.baseline == null && saved.current == null ? "text-muted-fg" : "text-fg",
+          )}
+          style={CELL_FONT}
+        >
+          {preview}
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 flex w-[220px] flex-col gap-1.5 rounded-md border border-border bg-bg p-2 shadow-lg"
+        >
+          <NumberField
+            label="baseline"
+            value={draft.baseline}
+            onChange={(v) => setDraft((d) => ({ ...d, baseline: v }))}
+          />
+          <NumberField
+            label="current"
+            value={draft.current}
+            onChange={(v) => setDraft((d) => ({ ...d, current: v }))}
+          />
+          <button
+            type="button"
+            onClick={onSave}
+            className="mt-1 rounded-md bg-accent px-2 py-1 text-[10px] uppercase tracking-[0.4px] text-accent-on"
+            style={CELL_FONT}
+          >
+            Save
+          </button>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+/* ─────────────────────── Auto / Read-only (cell) ─────────────────────── */
+
+export function AutoCell({ value, unit, target }) {
+  const numeric = Number(value);
+  const display = Number.isFinite(numeric)
+    ? formatNumber(numeric)
+    : value == null
+    ? "—"
+    : String(value);
+  const meetsTarget = evalMet(numeric, target);
+  return (
+    <div
+      className={cn(
+        "inline-flex items-baseline gap-0.5 rounded-md border border-border px-1.5 py-0.5",
+        meetsTarget === true
+          ? "border-success/40 bg-success/5"
+          : meetsTarget === false
+          ? "border-amber/40 bg-amber/5"
+          : "bg-bg",
+      )}
+      style={CELL_FONT}
+    >
+      <span className="text-[11px] font-semibold text-fg">{display}</span>
+      {unit && <span className="text-[9px] text-muted-fg">{unit}</span>}
+    </div>
+  );
+}
+
+/* ─────────────────────── Stub (cell) ─────────────────────── */
+
+export function StubCell({ tooltip }) {
+  return (
+    <span
+      className="text-[11px] text-muted-fg/60"
+      style={CELL_FONT}
+      title={tooltip || "Edit from the dashboard widget"}
+    >
+      —
+    </span>
+  );
+}
+
+/* ─────────────────────── primitives ─────────────────────── */
+
+function CellStep({ onClick, primary, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex h-5 w-5 items-center justify-center rounded-[3px] border border-border transition-colors",
+        primary
+          ? "bg-accent text-accent-on hover:opacity-90"
+          : "text-muted-fg hover:bg-accent-dim/50 hover:text-fg",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function CellValue({ value }) {
+  return (
+    <span
+      className="min-w-[28px] rounded-[3px] border border-border bg-bg px-1 text-center text-[11px] font-semibold text-fg"
+      style={CELL_FONT}
+    >
+      {Number.isFinite(value) ? value : 0}
+    </span>
+  );
+}
+
+function NumberField({ label, value, onChange }) {
+  return (
+    <label className="flex items-center gap-1.5">
+      <span
+        className="w-16 text-[10px] uppercase tracking-[0.4px] text-muted-fg"
+        style={CELL_FONT}
+      >
+        {label}
+      </span>
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-7 flex-1 rounded-md border border-border bg-bg px-1.5 text-[12px]"
+        style={CELL_FONT}
+      />
+    </label>
+  );
+}
+
+/* ─────── helpers ─────── */
+
+function sumNumericInWindow(entries, start, end) {
+  if (!Array.isArray(entries)) return 0;
+  const s = start.getTime();
+  const e = end.getTime();
+  let sum = 0;
+  for (const entry of entries) {
+    if (entry.ts < s || entry.ts >= e) continue;
+    const n = Number(entry.value);
+    if (Number.isFinite(n)) sum += n;
+  }
+  return sum;
+}
+
+function evalMet(value, target) {
+  if (!target || target.value == null || !Number.isFinite(Number(value))) return null;
+  const v = Number(value);
+  if (target.op === ">=") return v >= target.value;
+  if (target.op === "<=") return v <= target.value;
+  if (target.op === "=") return Math.abs(v - target.value) < 0.01 * Math.abs(target.value || 1);
+  return null;
+}
+
+function formatNumber(n) {
+  if (n == null) return "—";
+  if (Math.abs(n) >= 1000) return n.toLocaleString();
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(2).replace(/\.?0+$/, "");
+}
+
+function slugify(s) {
+  return String(s || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}

--- a/apps/web/src/features/checkin/grid-page.jsx
+++ b/apps/web/src/features/checkin/grid-page.jsx
@@ -1,0 +1,355 @@
+"use client";
+
+/**
+ * Catch-up grid view.
+ *
+ * Rows = classified L2 goals (grouped under their L1 headers).
+ * Columns = a range of work-weeks.
+ * Cells = compact editor / read-only chip for that (goal, week) pair.
+ *
+ * Use case: cold-start backfill. The dev opens the page, sees every
+ * empty week behind them at once, fills a few rows quickly (with
+ * "Copy from" filling steady-state metrics in one click), and hits
+ * Save all. The grid hides the per-week navigator overhead of the
+ * single-week page when the dev needs to touch many weeks at once.
+ *
+ * Layout: CSS grid with sticky goal column (left) and sticky week
+ * header (top). Scrolls in both directions when content overflows.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { Save, ChevronLeft, ChevronRight } from "lucide-react";
+import { useGoals } from "@/features/goals";
+import { useGoalSpecs } from "@/features/goal-specs";
+import { useGoalWidgetItems } from "@/features/goal-widgets";
+import {
+  useCombinedEventsSince,
+  useCombinedMergedSince,
+  useJiraTickets,
+} from "@/features/integrations";
+import { readInputs } from "@/features/goal-inputs";
+import { synthesiseWeek } from "@/features/snapshots";
+import { isoDaysAgo } from "@/lib/date";
+import { useCheckinGridRange } from "./use-checkin-grid-range";
+import { GridRow, RowCopyButton } from "./grid-row";
+
+const LABEL_COL = 240;
+const CELL_COL = 130;
+const ACTION_COL = 120;
+
+export function CheckinGridPage() {
+  const { weeks, fromLabel, toLabel, setRange, presetLastN } = useCheckinGridRange();
+
+  const { goals } = useGoals();
+  const { specs } = useGoalSpecs();
+  const { groupedItems, hasGoals, hasSpecs } = useGoalWidgetItems();
+
+  const { data: mrs } = useCombinedMergedSince(isoDaysAgo(365));
+  const { data: events } = useCombinedEventsSince(isoDaysAgo(90));
+  const { data: jira } = useJiraTickets();
+  const tickets = Array.isArray(jira?.issues) ? jira.issues : [];
+
+  // Bucket MR / event data per week ONCE for the whole grid — way
+  // cheaper than each cell re-filtering its own slice.
+  const mrsByWeek = useMemo(() => bucketByWeek(mrs, weeks, (m) => m?.merged_at), [mrs, weeks]);
+  const eventsByWeek = useMemo(
+    () => bucketByWeek(events, weeks, (e) => e?.created_at),
+    [events, weeks],
+  );
+
+  const [saving, setSaving] = useState(false);
+  const onSaveAll = useCallback(async () => {
+    if (!hasSpecs) {
+      toast.info("No classified goals yet — run the Analyst first.");
+      return;
+    }
+    setSaving(true);
+    let success = 0;
+    let failures = 0;
+    const inputs = readInputs();
+    for (const range of weeks) {
+      try {
+        synthesiseWeek({
+          range,
+          goals,
+          specs,
+          mrs: mrs || [],
+          events: events || [],
+          tickets,
+          allInputs: inputs,
+          capturedBy: "manual",
+        });
+        success += 1;
+      } catch {
+        failures += 1;
+      }
+    }
+    setSaving(false);
+    if (failures === 0) {
+      toast.success(`Saved ${success} week${success === 1 ? "" : "s"}`);
+    } else {
+      toast.error(`Saved ${success}, ${failures} failed — check console`);
+    }
+  }, [weeks, goals, specs, mrs, events, tickets, hasSpecs]);
+
+  if (!hasGoals) {
+    return <EmptyState title="No goals to track yet" body="Add goals first." />;
+  }
+  if (!hasSpecs) {
+    return (
+      <EmptyState
+        title="Goals not classified yet"
+        body="Run the Analyst so each goal has a widget."
+      />
+    );
+  }
+
+  const gridTemplateColumns = `${LABEL_COL}px repeat(${weeks.length}, ${CELL_COL}px) ${ACTION_COL}px`;
+
+  return (
+    <div className="flex flex-col gap-3 px-6 py-4">
+      <Toolbar
+        fromLabel={fromLabel}
+        toLabel={toLabel}
+        weekCount={weeks.length}
+        onPresetLastN={presetLastN}
+        onShift={(dir) => shiftRange(weeks, dir, setRange)}
+        onSaveAll={onSaveAll}
+        saving={saving}
+      />
+
+      <div className="overflow-x-auto rounded-md border border-border">
+        <div className="grid" style={{ gridTemplateColumns }}>
+          {/* corner */}
+          <div
+            className="sticky left-0 top-0 z-20 border-b border-r border-border bg-bg px-3 py-2 text-[10px] uppercase tracking-[0.6px] text-muted-fg"
+            style={{ fontFamily: "var(--font-mono)" }}
+          >
+            Goal
+          </div>
+
+          {/* week headers */}
+          {weeks.map((wk) => (
+            <div
+              key={wk.weekLabel}
+              className="sticky top-0 z-10 flex flex-col items-center justify-center border-b border-r border-border bg-bg/95 py-1 text-[11px]"
+              style={{ fontFamily: "var(--font-mono)" }}
+            >
+              <span className="font-semibold text-fg">{wk.weekLabel}</span>
+              <span className="text-[10px] text-muted-fg">{shortRange(wk.start, wk.end)}</span>
+            </div>
+          ))}
+
+          {/* trailing action column header */}
+          <div
+            className="sticky top-0 z-10 border-b border-border bg-bg/95 px-2 py-1 text-[10px] uppercase tracking-[0.6px] text-muted-fg"
+            style={{ fontFamily: "var(--font-mono)" }}
+          >
+            Bulk
+          </div>
+
+          {/* rows, grouped by L1 */}
+          {groupedItems.map((group) => (
+            <GroupBlock
+              key={group.l1.id}
+              group={group}
+              weekCount={weeks.length}
+              weeks={weeks}
+              mrsByWeek={mrsByWeek}
+              eventsByWeek={eventsByWeek}
+              ticketsCount={tickets.length}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────── chrome ─────────────────────── */
+
+function GroupBlock({ group, weekCount, weeks, mrsByWeek, eventsByWeek, ticketsCount }) {
+  const totalCols = 1 + weekCount + 1;
+  return (
+    <>
+      {/* L1 header banner spans the whole row */}
+      <div
+        className="sticky left-0 z-10 col-span-full border-b border-border bg-accent-dim/40 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.6px] text-fg"
+        style={{ fontFamily: "var(--font-mono)", gridColumn: `1 / span ${totalCols}` }}
+      >
+        {group.l1.title}
+        {group.l1.weightage != null && (
+          <span className="ml-2 text-muted-fg/80">· weight {group.l1.weightage}%</span>
+        )}
+      </div>
+      {group.items
+        .filter((item) => item.goal.kind !== "L1")
+        .map((item) => (
+          <RowGroup
+            key={item.goal.id}
+            goal={item.goal}
+            spec={item.spec}
+            weeks={weeks}
+            mrsByWeek={mrsByWeek}
+            eventsByWeek={eventsByWeek}
+            ticketsCount={ticketsCount}
+          />
+        ))}
+    </>
+  );
+}
+
+function RowGroup({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCount }) {
+  return (
+    <>
+      <GridRow
+        goal={goal}
+        spec={spec}
+        weeks={weeks}
+        mrsByWeek={mrsByWeek}
+        eventsByWeek={eventsByWeek}
+        ticketsCount={ticketsCount}
+      />
+      <RowCopyButton goal={goal} spec={spec} weeks={weeks} />
+    </>
+  );
+}
+
+function Toolbar({
+  fromLabel,
+  toLabel,
+  weekCount,
+  onPresetLastN,
+  onShift,
+  onSaveAll,
+  saving,
+}) {
+  return (
+    <div className="sticky top-[64px] z-30 -mx-6 flex flex-wrap items-center justify-between gap-2 border-b border-border bg-bg/85 px-6 py-2 backdrop-blur-md">
+      <div className="flex items-center gap-2">
+        <div>
+          <h1 className="text-[14px] font-semibold text-fg">Catch-up grid</h1>
+          <p
+            className="text-[10px] uppercase tracking-[0.6px] text-muted-fg"
+            style={{ fontFamily: "var(--font-mono)" }}
+          >
+            {fromLabel} → {toLabel} · {weekCount} week{weekCount === 1 ? "" : "s"}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <NavBtn onClick={() => onShift(-1)} ariaLabel="Shift range earlier">
+          <ChevronLeft size={14} />
+        </NavBtn>
+        <NavBtn onClick={() => onShift(+1)} ariaLabel="Shift range later">
+          <ChevronRight size={14} />
+        </NavBtn>
+        <Preset onClick={() => onPresetLastN(4)}>4w</Preset>
+        <Preset onClick={() => onPresetLastN(8)}>8w</Preset>
+        <Preset onClick={() => onPresetLastN(12)}>12w</Preset>
+        <button
+          type="button"
+          onClick={onSaveAll}
+          disabled={saving}
+          className="ml-2 flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[11px] uppercase tracking-[0.5px] text-accent-on transition-opacity hover:opacity-90 disabled:opacity-40"
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          <Save size={13} />
+          {saving ? "Saving…" : "Save all"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function NavBtn({ onClick, ariaLabel, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className="flex h-7 w-7 items-center justify-center rounded-md border border-border text-muted-fg hover:bg-accent-dim/60 hover:text-fg"
+    >
+      {children}
+    </button>
+  );
+}
+
+function Preset({ onClick, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-md border border-border px-2 py-1 text-[10px] uppercase tracking-[0.5px] text-muted-fg hover:bg-accent-dim/60 hover:text-fg"
+      style={{ fontFamily: "var(--font-mono)" }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function EmptyState({ title, body }) {
+  return (
+    <div className="flex h-[60vh] flex-col items-center justify-center gap-2 px-6 text-center">
+      <h2 className="text-[14px] font-semibold text-fg">{title}</h2>
+      <p className="max-w-md text-[12px] text-muted-fg">{body}</p>
+    </div>
+  );
+}
+
+/* ─────────────────────── helpers ─────────────────────── */
+
+function bucketByWeek(items, weeks, dateAccessor) {
+  const out = new Map();
+  if (!Array.isArray(items)) return out;
+  // Index weeks for fast lookup
+  const byLabel = new Map(weeks.map((w) => [w.weekLabel, []]));
+  for (const item of items) {
+    const dt = dateAccessor(item);
+    if (!dt) continue;
+    const t = new Date(dt).getTime();
+    for (const w of weeks) {
+      if (t >= w.start.getTime() && t < w.end.getTime()) {
+        byLabel.get(w.weekLabel).push(item);
+        break;
+      }
+    }
+  }
+  return byLabel;
+}
+
+function shortRange(start, end) {
+  const opts = { month: "short", day: "numeric" };
+  const startFmt = start.toLocaleDateString("en-US", opts);
+  // end is exclusive Friday 00:00 — display inclusive Thursday
+  const inclusiveEnd = new Date(end.getTime() - 24 * 60 * 60 * 1000);
+  const endFmt = inclusiveEnd.toLocaleDateString("en-US", opts);
+  return `${startFmt}–${endFmt}`;
+}
+
+function shiftRange(weeks, dir, setRange) {
+  if (weeks.length === 0) return;
+  const span = weeks.length;
+  const fromMs = weeks[0].start.getTime();
+  const offsetDays = dir * span * 7;
+  // Compute new from / to by shifting both edges by `span` weeks.
+  const newFromSunday = new Date(fromMs + offsetDays * 24 * 60 * 60 * 1000);
+  const newToSunday = new Date(
+    newFromSunday.getTime() + (span - 1) * 7 * 24 * 60 * 60 * 1000,
+  );
+  setRange({
+    from: weekLabelOf(newFromSunday),
+    to: weekLabelOf(newToSunday),
+  });
+}
+
+function weekLabelOf(sunday) {
+  const midWeek = new Date(sunday.getTime() + 3 * 24 * 60 * 60 * 1000);
+  const yearStart = new Date(midWeek.getFullYear(), 0, 1);
+  const dayOfYear =
+    Math.floor((midWeek - yearStart) / (24 * 60 * 60 * 1000)) + 1;
+  const jan1Weekday = yearStart.getDay();
+  const week = Math.ceil((dayOfYear + jan1Weekday) / 7);
+  return `W${String(week).padStart(2, "0")}`;
+}

--- a/apps/web/src/features/checkin/grid-row.jsx
+++ b/apps/web/src/features/checkin/grid-row.jsx
@@ -1,0 +1,315 @@
+"use client";
+
+/**
+ * One row of the catch-up grid — sticky goal label + one cell per
+ * week. The dispatcher picks the cell editor matching `spec.widget`
+ * (manual editors write to goal-inputs; auto cells read from the
+ * pre-filtered integration data for that week).
+ *
+ * The row also exposes a small "copy from W##" dropdown that takes
+ * any one cell's current value and broadcasts it into every other
+ * empty cell in the same row. The single highest-leverage feature for
+ * steady-state metrics where the dev's contribution doesn't really
+ * change week-to-week (morale rating, weekly mentor count, etc.).
+ */
+
+import { useMemo } from "react";
+import { SPEC_KINDS } from "@/features/goal-specs";
+import {
+  avgReviewerComments,
+  firstPassRatePct,
+  linkagePct,
+  medianTurnaroundDays,
+} from "@/features/integrations";
+import { useGoalInputs } from "@/features/goal-inputs";
+import { midWeekTs } from "@/lib/date";
+import {
+  AutoCell,
+  BeforeAfterCell,
+  CounterCell,
+  DateLogCell,
+  FreeTextCell,
+  MilestoneCell,
+  ScaleCell,
+  StubCell,
+} from "./grid-cells";
+
+export function GridRow({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCount }) {
+  return (
+    <>
+      <RowLabel goal={goal} spec={spec} />
+      {weeks.map((wk) => (
+        <GridCell
+          key={wk.weekLabel}
+          goal={goal}
+          spec={spec}
+          week={wk}
+          mrsThisWeek={mrsByWeek.get(wk.weekLabel) || []}
+          eventsThisWeek={eventsByWeek.get(wk.weekLabel) || []}
+          ticketsCount={ticketsCount}
+        />
+      ))}
+    </>
+  );
+}
+
+/* ─────────────────────── label column ─────────────────────── */
+
+function RowLabel({ goal, spec }) {
+  const widget = spec.widget;
+  return (
+    <div
+      className="sticky left-0 z-10 flex items-center gap-2 border-b border-r border-border bg-bg px-3 py-2"
+      style={{ minWidth: 240 }}
+    >
+      <span
+        className="rounded-[3px] border border-border px-1 py-px text-[9px] uppercase tracking-[0.6px] text-muted-fg"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        {kindLabel(widget)}
+      </span>
+      <span className="truncate text-[12px] font-medium text-fg">
+        {goal?.title || spec.title || "Untitled"}
+      </span>
+    </div>
+  );
+}
+
+/* ─────────────────────── cell dispatcher ─────────────────────── */
+
+function GridCell({
+  goal,
+  spec,
+  week,
+  mrsThisWeek,
+  eventsThisWeek,
+  ticketsCount,
+}) {
+  return (
+    <div
+      className="flex items-center justify-center border-b border-r border-border bg-bg/40 px-2 py-1.5"
+      style={{ minHeight: 52 }}
+    >
+      <CellFor
+        widget={spec.widget}
+        goal={goal}
+        spec={spec}
+        weekStart={week.start}
+        weekEnd={week.end}
+        weekLabel={week.weekLabel}
+        mrsThisWeek={mrsThisWeek}
+        eventsThisWeek={eventsThisWeek}
+        ticketsCount={ticketsCount}
+      />
+    </div>
+  );
+}
+
+function CellFor({
+  widget,
+  goal,
+  spec,
+  weekStart,
+  weekEnd,
+  weekLabel,
+  mrsThisWeek,
+  ticketsCount,
+}) {
+  switch (widget) {
+    case SPEC_KINDS.COUNTER:
+      return <CounterCell goal={goal} weekStart={weekStart} weekEnd={weekEnd} weekLabel={weekLabel} />;
+    case SPEC_KINDS.SCALE:
+      return <ScaleCell goal={goal} weekStart={weekStart} weekEnd={weekEnd} weekLabel={weekLabel} />;
+    case SPEC_KINDS.MILESTONE:
+      return (
+        <MilestoneCell
+          goal={goal}
+          spec={spec}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          weekLabel={weekLabel}
+        />
+      );
+    case SPEC_KINDS.FREE_TEXT:
+      return (
+        <FreeTextCell goal={goal} weekStart={weekStart} weekEnd={weekEnd} weekLabel={weekLabel} />
+      );
+    case SPEC_KINDS.DATE_LOG:
+      return (
+        <DateLogCell goal={goal} weekStart={weekStart} weekEnd={weekEnd} weekLabel={weekLabel} />
+      );
+    case SPEC_KINDS.BEFORE_AFTER:
+      return (
+        <BeforeAfterCell
+          goal={goal}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          weekLabel={weekLabel}
+        />
+      );
+
+    case SPEC_KINDS.MERGED_COUNT:
+      return (
+        <AutoCell value={mrsThisWeek.length} unit="" target={spec.source?.target} />
+      );
+    case SPEC_KINDS.REVIEW_ROUNDS: {
+      const v = avgReviewerComments(mrsThisWeek);
+      return (
+        <AutoCell
+          value={v == null ? null : Number(v.toFixed(2))}
+          unit="rds"
+          target={spec.source?.target}
+        />
+      );
+    }
+    case SPEC_KINDS.TURNAROUND: {
+      const days = medianTurnaroundDays(mrsThisWeek);
+      const hours = days == null ? null : Math.round(days * 24);
+      return <AutoCell value={hours} unit="h" target={spec.source?.target} />;
+    }
+    case SPEC_KINDS.LINKAGE: {
+      const pct = linkagePct(mrsThisWeek)?.pct ?? null;
+      return <AutoCell value={pct} unit="%" target={spec.source?.target} />;
+    }
+    case SPEC_KINDS.FIRST_PASS_RATE: {
+      const pct = firstPassRatePct(mrsThisWeek);
+      return <AutoCell value={pct} unit="%" target={spec.source?.target} />;
+    }
+    case SPEC_KINDS.TICKET_CYCLE:
+      return (
+        <AutoCell value={ticketsCount} unit="tk" target={spec.source?.target} />
+      );
+
+    // Widgets without inline-cell editors yet — placeholder.
+    case SPEC_KINDS.INCIDENT_LOG:
+    case SPEC_KINDS.RECURRING_MILESTONE:
+    case SPEC_KINDS.CODE_RUBRIC:
+    case SPEC_KINDS.SCORECARD:
+    case SPEC_KINDS.DEPLOY_FREQUENCY:
+    case SPEC_KINDS.LEAD_TIME:
+    case SPEC_KINDS.BUILD_PASS_RATE:
+      return <StubCell tooltip="Edit from the dashboard widget for now" />;
+
+    default:
+      return <StubCell tooltip={`No grid editor for "${widget}" yet`} />;
+  }
+}
+
+/* ─────────────────────── chrome helpers ─────────────────────── */
+
+function kindLabel(widget) {
+  switch (widget) {
+    case SPEC_KINDS.COUNTER:           return "counter";
+    case SPEC_KINDS.SCALE:             return "scale";
+    case SPEC_KINDS.MILESTONE:         return "milestone";
+    case SPEC_KINDS.FREE_TEXT:         return "note";
+    case SPEC_KINDS.DATE_LOG:          return "date-log";
+    case SPEC_KINDS.BEFORE_AFTER:      return "before/after";
+    case SPEC_KINDS.MERGED_COUNT:      return "merges";
+    case SPEC_KINDS.REVIEW_ROUNDS:     return "rounds";
+    case SPEC_KINDS.TURNAROUND:        return "turnaround";
+    case SPEC_KINDS.LINKAGE:           return "linkage";
+    case SPEC_KINDS.FIRST_PASS_RATE:   return "first-pass";
+    case SPEC_KINDS.TICKET_CYCLE:      return "tickets";
+    case SPEC_KINDS.INCIDENT_LOG:      return "incidents";
+    case SPEC_KINDS.RECURRING_MILESTONE: return "recurring";
+    case SPEC_KINDS.CODE_RUBRIC:       return "rubric";
+    case SPEC_KINDS.SCORECARD:         return "scorecard";
+    case SPEC_KINDS.DEPLOY_FREQUENCY:  return "deploys";
+    case SPEC_KINDS.LEAD_TIME:         return "lead-time";
+    case SPEC_KINDS.BUILD_PASS_RATE:   return "build-pass";
+    default:                            return String(widget || "").toLowerCase().slice(0, 14);
+  }
+}
+
+/* ─────────────────────── per-row "Copy from" button ─────────────────────── */
+
+/**
+ * Renders a small "Copy from" button at the end of a row. Reads ONE
+ * source week's value and writes it into every other empty cell in
+ * the same row that supports a copyable value (manual widgets only).
+ *
+ * Not a Radix dropdown — we expose it as a separate component so the
+ * grid layout can place it in a dedicated trailing column.
+ */
+export function RowCopyButton({ goal, spec, weeks }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+
+  const canCopy =
+    spec.widget === SPEC_KINDS.COUNTER ||
+    spec.widget === SPEC_KINDS.SCALE ||
+    spec.widget === SPEC_KINDS.DATE_LOG;
+
+  // Find the most recent week in range with a non-zero value.
+  const sourceWeek = useMemo(() => {
+    if (!canCopy) return null;
+    for (let i = weeks.length - 1; i >= 0; i--) {
+      const w = weeks[i];
+      const v = readCellValue(entries, w.start, w.end, spec.widget);
+      if (v != null && v !== 0 && v !== "") return { week: w, value: v };
+    }
+    return null;
+  }, [entries, weeks, spec.widget, canCopy]);
+
+  if (!canCopy || !sourceWeek) {
+    return (
+      <div
+        className="flex items-center justify-end border-b border-border px-2 text-[10px] text-muted-fg/40"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        —
+      </div>
+    );
+  }
+
+  const onCopy = () => {
+    for (const w of weeks) {
+      if (w.weekLabel === sourceWeek.week.weekLabel) continue;
+      const existing = readCellValue(entries, w.start, w.end, spec.widget);
+      if (existing != null && existing !== 0 && existing !== "") continue;
+      const ts = midWeekTs(w.weekLabel);
+      if (ts == null) continue;
+      append(sourceWeek.value, undefined, ts);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-end border-b border-border px-2">
+      <button
+        type="button"
+        onClick={onCopy}
+        title={`Fill empty cells with ${sourceWeek.value} from ${sourceWeek.week.weekLabel}`}
+        className="rounded-md border border-border bg-bg px-1.5 py-0.5 text-[10px] uppercase tracking-[0.4px] text-muted-fg hover:bg-accent-dim/60 hover:text-fg"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        Copy ← {sourceWeek.week.weekLabel}
+      </button>
+    </div>
+  );
+}
+
+function readCellValue(entries, start, end, widget) {
+  const s = start.getTime();
+  const e = end.getTime();
+  const inWindow = entries.filter((entry) => entry.ts >= s && entry.ts < e);
+  if (inWindow.length === 0) return null;
+
+  if (widget === SPEC_KINDS.COUNTER) {
+    let sum = 0;
+    for (const entry of inWindow) {
+      const n = Number(entry.value);
+      if (Number.isFinite(n)) sum += n;
+    }
+    return sum;
+  }
+  if (widget === SPEC_KINDS.SCALE) {
+    const numbers = inWindow
+      .filter((e) => Number.isFinite(Number(e.value)))
+      .map((e) => Number(e.value));
+    return numbers.length > 0 ? numbers[numbers.length - 1] : null;
+  }
+  if (widget === SPEC_KINDS.DATE_LOG) {
+    return inWindow.length;
+  }
+  return null;
+}

--- a/apps/web/src/features/checkin/index.js
+++ b/apps/web/src/features/checkin/index.js
@@ -1,0 +1,2 @@
+export { CheckinPage } from "./checkin-page";
+export { useCheckinWeek } from "./use-checkin-week";

--- a/apps/web/src/features/checkin/index.js
+++ b/apps/web/src/features/checkin/index.js
@@ -1,2 +1,4 @@
 export { CheckinPage } from "./checkin-page";
+export { CheckinGridPage } from "./grid-page";
 export { useCheckinWeek } from "./use-checkin-week";
+export { useCheckinGridRange } from "./use-checkin-grid-range";

--- a/apps/web/src/features/checkin/use-checkin-grid-range.js
+++ b/apps/web/src/features/checkin/use-checkin-grid-range.js
@@ -1,0 +1,161 @@
+"use client";
+
+/**
+ * Week-range state for the catch-up grid view.
+ *
+ * URL params: `?from=W14&to=W19` (inclusive on both ends). When the
+ * params are missing, we default to "the empty weeks behind us, capped
+ * at the most-recent 12" — that's the cold-start case where the dev
+ * just opened the grid for the first time and wants to fill in months
+ * of backlog without manual range-picking.
+ *
+ * Returns:
+ *   - `weeks`:        array of `{ start, end, weekLabel }` (newest-last)
+ *   - `fromLabel`,
+ *     `toLabel`:      current range boundaries
+ *   - `setRange`:     write `from` + `to` back to the URL
+ *   - `presetLastN`:  shortcut that targets the most-recent N completed
+ *                     weeks (used by the toolbar's quick-presets)
+ */
+
+import { useCallback, useMemo } from "react";
+import {
+  useRouter,
+  useSearchParams,
+  usePathname,
+} from "next/navigation";
+import {
+  DAY_MS,
+  resolveCompletedWorkWeek,
+  weekRangeFromLabel,
+  weekLabel as weekLabelFn,
+} from "@/lib/date";
+import { readSnapshots } from "@/features/snapshots";
+
+const MAX_GRID_WEEKS = 12;
+
+export function useCheckinGridRange() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+
+  const fromParam = params?.get("from") || null;
+  const toParam = params?.get("to") || null;
+
+  // Default range = the empty weeks behind us, oldest first, capped
+  // at MAX_GRID_WEEKS. Falls back to "the most-recent 6 weeks" when
+  // no snapshots exist yet (first-time dev).
+  const defaults = useMemo(() => computeDefaultRange(), []);
+  const fromLabel = fromParam || defaults.fromLabel;
+  const toLabel = toParam || defaults.toLabel;
+
+  const weeks = useMemo(
+    () => enumerateRange(fromLabel, toLabel),
+    [fromLabel, toLabel],
+  );
+
+  const setRange = useCallback(
+    (next) => {
+      const sp = new URLSearchParams(window.location.search);
+      if (next?.from) sp.set("from", next.from);
+      if (next?.to) sp.set("to", next.to);
+      router.replace(`${pathname}?${sp.toString()}`);
+    },
+    [router, pathname],
+  );
+
+  const presetLastN = useCallback(
+    (n) => {
+      const today = resolveCompletedWorkWeek();
+      // Walk back N-1 weeks from today's Sunday to find the from-edge.
+      const fromRange = weekFromOffset(today.start, -(n - 1) * 7);
+      setRange({ from: fromRange.weekLabel, to: today.weekLabel });
+    },
+    [setRange],
+  );
+
+  return {
+    weeks,
+    fromLabel,
+    toLabel,
+    setRange,
+    presetLastN,
+    maxWeeks: MAX_GRID_WEEKS,
+  };
+}
+
+/* ─────────── default-range derivation ─────────── */
+
+function computeDefaultRange() {
+  if (typeof window === "undefined") {
+    // Server-render: pick something deterministic. The client will
+    // re-derive once mounted.
+    const today = resolveCompletedWorkWeek();
+    return { fromLabel: today.weekLabel, toLabel: today.weekLabel };
+  }
+
+  const today = resolveCompletedWorkWeek();
+  const filledWeeks = new Set(readSnapshots().map((s) => s.week));
+
+  // Walk back from today's most-recent completed week toward Jan 1,
+  // collecting EMPTY weeks until we hit MAX_GRID_WEEKS. If we exhaust
+  // the year, the from-edge is Jan 1's week.
+  const year = new Date().getFullYear();
+  const yearStart = new Date(year, 0, 1);
+
+  let cursor = new Date(today.start);
+  const empties = [];
+  while (cursor >= yearStart && empties.length < MAX_GRID_WEEKS) {
+    const midWeek = new Date(cursor.getTime() + 3 * DAY_MS);
+    const label = weekLabelFn(midWeek);
+    if (!filledWeeks.has(label)) empties.push(label);
+    cursor = new Date(cursor.getTime() - 7 * DAY_MS);
+  }
+
+  if (empties.length === 0) {
+    // No gaps! Show the last 6 weeks anyway so the page renders
+    // something useful for the "I'm caught up but want to review"
+    // scenario.
+    const fromRange = weekFromOffset(today.start, -35);
+    return { fromLabel: fromRange.weekLabel, toLabel: today.weekLabel };
+  }
+
+  // empties is newest-first; flip so fromLabel = oldest.
+  return {
+    fromLabel: empties[empties.length - 1],
+    toLabel: empties[0],
+  };
+}
+
+/* ─────────── range enumeration ─────────── */
+
+function enumerateRange(fromLabel, toLabel) {
+  const fromRange = weekRangeFromLabel(fromLabel);
+  const toRange = weekRangeFromLabel(toLabel);
+  if (!fromRange || !toRange) return [];
+
+  const out = [];
+  let cursor = new Date(fromRange.start);
+  const stop = toRange.start.getTime();
+  while (cursor.getTime() <= stop && out.length <= MAX_GRID_WEEKS) {
+    const midWeek = new Date(cursor.getTime() + 3 * DAY_MS);
+    const label = weekLabelFn(midWeek);
+    const end = new Date(cursor);
+    end.setDate(cursor.getDate() + 5); // Sun + 5 = Friday 00:00 (= Thu EOD)
+    out.push({ start: new Date(cursor), end, weekLabel: label });
+    cursor = new Date(cursor.getTime() + 7 * DAY_MS);
+  }
+  return out;
+}
+
+function weekFromOffset(anchorSunday, deltaDays) {
+  const sunday = new Date(anchorSunday.getTime() + deltaDays * DAY_MS);
+  sunday.setHours(0, 0, 0, 0);
+  const friday = new Date(sunday);
+  friday.setDate(sunday.getDate() + 5);
+  return {
+    start: sunday,
+    end: friday,
+    weekLabel: weekLabelFn(new Date(sunday.getTime() + 3 * DAY_MS)),
+  };
+}

--- a/apps/web/src/features/checkin/use-checkin-week.js
+++ b/apps/web/src/features/checkin/use-checkin-week.js
@@ -1,0 +1,94 @@
+"use client";
+
+/**
+ * Active-week state for the weekly check-in page.
+ *
+ * The active week lives in the URL (`?week=W19` or `?week=W19-2026`) so
+ * deep links work and reloads preserve context. When the param is
+ * missing we default to the most recent COMPLETED Sun → Thu work-week —
+ * the same one the auto-snapshotter would have captured. Devs land on
+ * "last week" by default because that's almost always the one with
+ * blanks to fill.
+ *
+ * The hook also exposes `setWeekLabel` (writes back to the URL) plus
+ * pre-resolved `range` / `prev` / `next` triples so navigators don't
+ * have to know about the date math.
+ */
+
+import { useCallback, useMemo } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import {
+  resolveCompletedWorkWeek,
+  weekRangeFromLabel,
+  DAY_MS,
+  weekLabel as weekLabelFn,
+} from "@/lib/date";
+
+export function useCheckinWeek() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+
+  // The default landing week — most recent completed Sun → Thu. Stable
+  // within a single render and across renders within the same calendar
+  // day, so URL navigations stay deterministic.
+  const defaultWeek = useMemo(() => resolveCompletedWorkWeek(), []);
+
+  const requestedLabel = params?.get("week") || null;
+  const activeLabel = (requestedLabel || defaultWeek.weekLabel).trim();
+
+  const range = useMemo(() => {
+    const r = weekRangeFromLabel(activeLabel);
+    return r || defaultWeek;
+  }, [activeLabel, defaultWeek]);
+
+  // prev / next week labels, derived by stepping ±7 days from the
+  // active range's start and re-computing the Wnn label. Cheap.
+  const prevLabel = useMemo(
+    () => labelFromOffset(range, -7),
+    [range],
+  );
+  const nextLabel = useMemo(
+    () => labelFromOffset(range, +7),
+    [range],
+  );
+
+  // Today's "most recent completed" week — used by the Today button.
+  const todayLabel = defaultWeek.weekLabel;
+
+  // Don't let users navigate past `todayLabel` — the in-progress week
+  // has no Thursday EOD yet, so its snapshot is meaningless. Clamp the
+  // next-button when we're already at todayLabel.
+  const canGoNext = activeLabel !== todayLabel;
+
+  const setWeekLabel = useCallback(
+    (label) => {
+      if (!label) return;
+      const params = new URLSearchParams(window.location.search);
+      params.set("week", label);
+      router.replace(`${pathname}?${params.toString()}`);
+    },
+    [router, pathname],
+  );
+
+  return {
+    activeLabel,
+    range,
+    prevLabel,
+    nextLabel,
+    todayLabel,
+    canGoNext,
+    setWeekLabel,
+  };
+}
+
+/* ───────── helpers ───────── */
+
+function labelFromOffset(range, deltaDays) {
+  const ms = range.start.getTime() + deltaDays * DAY_MS;
+  const sunday = new Date(ms);
+  // Mid-week date is what `weekLabel` keys on — Tuesday lands cleanly
+  // inside the Sun → Thu window for both prev and next moves.
+  const midWeek = new Date(sunday.getTime() + 3 * DAY_MS);
+  return weekLabelFn(midWeek);
+}

--- a/apps/web/src/features/checkin/week-navigator.jsx
+++ b/apps/web/src/features/checkin/week-navigator.jsx
@@ -1,0 +1,101 @@
+"use client";
+
+/**
+ * Top-of-page week selector. Renders prev / current / next + a Today
+ * button. Designed to be small enough to live in a sticky page header
+ * alongside the "Save week" CTA.
+ *
+ * The hard rule: you can navigate as far back as Jan 1 of the current
+ * year, but you can't step forward past `todayLabel` (the most recent
+ * completed week). The in-progress week has no Thu EOD yet — there's
+ * nothing for the user to fill that wouldn't be invalidated 4 days
+ * later.
+ */
+
+import { ChevronLeft, ChevronRight, CalendarDays } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+export function WeekNavigator({
+  activeLabel,
+  rangeStart,
+  rangeEnd,
+  todayLabel,
+  canGoNext,
+  onPrev,
+  onNext,
+  onToday,
+}) {
+  const display = formatRange(rangeStart, rangeEnd);
+  const atToday = activeLabel === todayLabel;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <NavButton onClick={onPrev} ariaLabel="Previous week">
+        <ChevronLeft size={16} />
+      </NavButton>
+
+      <div
+        className="flex flex-col items-center justify-center rounded-md border border-border bg-bg px-3 py-1.5"
+        style={{ minWidth: 168, fontFamily: "var(--font-mono)" }}
+      >
+        <div className="text-[11px] uppercase tracking-[0.6px] text-muted-fg">
+          {activeLabel}
+        </div>
+        <div className="text-[12px] font-medium text-fg">{display}</div>
+      </div>
+
+      <NavButton onClick={onNext} disabled={!canGoNext} ariaLabel="Next week">
+        <ChevronRight size={16} />
+      </NavButton>
+
+      <button
+        type="button"
+        onClick={onToday}
+        disabled={atToday}
+        className={cn(
+          "ml-1 flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] uppercase tracking-[0.4px] transition-colors",
+          atToday
+            ? "cursor-default text-muted-fg/50"
+            : "text-muted-fg hover:bg-accent-dim/60 hover:text-fg",
+        )}
+        style={{ fontFamily: "var(--font-mono)" }}
+        title="Jump to the most recent completed week"
+      >
+        <CalendarDays size={12} />
+        Today
+      </button>
+    </div>
+  );
+}
+
+function NavButton({ onClick, disabled, ariaLabel, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      className={cn(
+        "flex h-8 w-8 items-center justify-center rounded-md border border-border transition-colors",
+        disabled
+          ? "cursor-default text-muted-fg/40"
+          : "text-muted-fg hover:bg-accent-dim/60 hover:text-fg",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/* ─────── helpers ─────── */
+
+function formatRange(start, end) {
+  if (!(start instanceof Date) || !(end instanceof Date)) return "—";
+  const opts = { month: "short", day: "numeric" };
+  const startFmt = start.toLocaleDateString("en-US", opts);
+  // `end` is the EXCLUSIVE Friday 00:00. Display the inclusive
+  // Thursday so users see the actual work-week (Sun → Thu).
+  const inclusiveEnd = new Date(end.getTime() - 24 * 60 * 60 * 1000);
+  const endFmt = inclusiveEnd.toLocaleDateString("en-US", opts);
+  return `${startFmt} – ${endFmt}`;
+}

--- a/apps/web/src/features/goal-inputs/use-goal-inputs.js
+++ b/apps/web/src/features/goal-inputs/use-goal-inputs.js
@@ -37,11 +37,15 @@ function getServerSnapshot() {
  * Hook: subscribe to a single goal's time-series entries.
  *
  * Returns:
- *   - entries           : Array<GoalInput>  (ts-ascending)
- *   - latest            : GoalInput | null
- *   - append(value,note?): persist a new entry
- *   - remove(ts)        : delete an entry by timestamp
- *   - clear()           : wipe every entry for this goal
+ *   - entries                   : Array<GoalInput>  (ts-ascending)
+ *   - latest                    : GoalInput | null
+ *   - append(value, note?, ts?) : persist a new entry. `ts` (epoch ms)
+ *                                 is optional — pass it to record an
+ *                                 entry against a past week (used by
+ *                                 the weekly check-in / backfill flow).
+ *                                 Defaults to `Date.now()`.
+ *   - remove(ts)                : delete an entry by timestamp
+ *   - clear()                   : wipe every entry for this goal
  *
  * Demo-mode short-circuit: when demo mode is on AND the goalId looks
  * like a demo goal AND the user has no real entries on it, we return
@@ -81,7 +85,12 @@ export function useGoalInputs(goalId) {
   }, [raw, goalId, demo, demoEntriesByGoal]);
 
   const append = useCallback(
-    (value, note) => appendEntry({ goalId, value, note }),
+    (value, note, ts) =>
+      appendEntry(
+        ts != null
+          ? { goalId, value, note, ts }
+          : { goalId, value, note },
+      ),
     [goalId],
   );
   const remove = useCallback((ts) => removeEntry(goalId, ts), [goalId]);

--- a/apps/web/src/features/snapshots/index.js
+++ b/apps/web/src/features/snapshots/index.js
@@ -12,5 +12,6 @@ export { captureGoalReadings } from "./capture-readings";
 export { goalCompliance } from "./compliance";
 export { useSnapshotCompliance } from "./use-snapshot-compliance";
 export { useBackfill } from "./use-backfill";
+export { synthesiseWeek } from "./synthesise-week";
 export { BackfillBanner } from "./backfill-banner";
 export { SnapshotsSync } from "./snapshots-sync-mount";

--- a/apps/web/src/features/snapshots/synthesise-week.js
+++ b/apps/web/src/features/snapshots/synthesise-week.js
@@ -1,0 +1,143 @@
+"use client";
+
+/**
+ * `synthesiseWeek` — capture (or re-capture) the snapshot for ONE
+ * specific Sun → Thu work-week.
+ *
+ * Lifted out of `use-backfill.js` so it can be called from two places:
+ *
+ *   1. The backfill hook (`useBackfill`) walks every missing completed
+ *      week since Jan 1 and writes one snapshot per week.
+ *   2. The weekly check-in page (`/[hub]/checkin`) re-runs it for the
+ *      currently-active week whenever the user saves manual inputs —
+ *      so the snapshot stream stays in sync with what the form just
+ *      wrote into the goal-inputs store.
+ *
+ * The function is pure aside from the `saveSnapshot` side-effect. It
+ * reads the existing snapshot stream once to thread prior-week
+ * `cumulative` values through the monthly/quarterly cadence-windows,
+ * so the running totals chain correctly even when weeks are filled
+ * out of order.
+ *
+ * Inputs (one object):
+ *   range       — { start, end, weekLabel } — same triple used by the
+ *                 auto-snapshotter + backfill enumerator. `weekLabel`
+ *                 is the "Wnn" string the snapshot store keys on.
+ *   goals       — { l1s: [...] } from useGoals(); used to walk every
+ *                 classified L2 (the captureGoalReadings call below).
+ *   specs       — Map<goalId, spec> from useGoalSpecs().
+ *   mrs         — array of merged PRs visible to the caller. Will be
+ *                 filtered to this week's window inside.
+ *   events      — array of event-feed entries (90d horizon). Older
+ *                 weeks get partial:true + gaps:["events"].
+ *   tickets     — Jira issues array (or empty).
+ *   allInputs   — full {goalId → entries[]} map from readInputs(); the
+ *                 capture step slices it per goal.
+ *
+ * Returns the snapshot object that was written (post-normalisation by
+ * saveSnapshot). Callers that don't care can ignore it.
+ *
+ * The `saveSnapshot` helper enforces "manual wins over auto" — if a
+ * user manually edited the headline metrics for this week and we then
+ * re-run synthesise from check-in, the manual values stay. Goal
+ * readings get refreshed unconditionally since they're the whole point
+ * of the re-capture.
+ */
+
+import {
+  avgReviewerComments,
+  countMrComments,
+  linkagePct,
+  medianTurnaroundDays,
+} from "@/features/integrations";
+import { captureGoalReadings } from "./capture-readings";
+import { readSnapshots, saveSnapshot } from "./snapshots-store";
+
+const DAY = 24 * 60 * 60 * 1000;
+const EVENTS_HORIZON_DAYS = 90;
+
+/**
+ * @param {{
+ *   range:     { start: Date, end: Date, weekLabel: string },
+ *   goals:     { l1s: Array<any> },
+ *   specs:     Map<string, any> | Record<string, any>,
+ *   mrs:       Array<any>,
+ *   events:    Array<any>,
+ *   tickets:   Array<any>,
+ *   allInputs: Record<string, Array<any>>,
+ *   capturedBy?: "auto" | "manual", // defaults to "auto"
+ * }} args
+ */
+export function synthesiseWeek({
+  range,
+  goals,
+  specs,
+  mrs,
+  events,
+  tickets,
+  allInputs,
+  capturedBy = "auto",
+}) {
+  const startMs = range.start.getTime();
+  const endMs = range.end.getTime();
+
+  const mrsThisWeek = (mrs || []).filter((m) => {
+    if (!m.merged_at) return false;
+    const t = new Date(m.merged_at).getTime();
+    return t >= startMs && t < endMs;
+  });
+  const eventsThisWeek = (events || []).filter((e) => {
+    const t = new Date(e.created_at || 0).getTime();
+    return t >= startMs && t < endMs;
+  });
+
+  // Was the events feed available for this week? GitHub caps at ~90d.
+  // For weeks older than that, mark partial + gaps so the snapshot
+  // honestly says "events unavailable".
+  const ageDays = Math.floor((Date.now() - endMs) / DAY);
+  const eventsAvailable = ageDays <= EVENTS_HORIZON_DAYS;
+  const partial = !eventsAvailable;
+  const gaps = eventsAvailable ? [] : ["events"];
+
+  const merged = mrsThisWeek.length;
+  const reviews = eventsAvailable ? countMrComments(eventsThisWeek) : 0;
+  const median = medianTurnaroundDays(mrsThisWeek);
+  const linkage = linkagePct(mrsThisWeek)?.pct ?? 0;
+  const rounds = avgReviewerComments(mrsThisWeek) ?? 0;
+
+  // priorReadings: pick up the most recent snapshot already in the
+  // store whose week sits BEFORE this one so monthly/quarterly
+  // cumulatives chain through correctly. Sorting by weekLabel is fine
+  // within a year — "W17" < "W18" lexicographically.
+  const existing = readSnapshots();
+  const prior = existing
+    .filter((s) => s.week && s.week < range.weekLabel)
+    .sort((a, b) => b.week.localeCompare(a.week))[0] || null;
+
+  const goalReadings = captureGoalReadings({
+    weekStart: range.start,
+    weekEnd: range.end,
+    goals,
+    specs,
+    mrs: mrsThisWeek,
+    events: eventsThisWeek,
+    tickets: tickets || [],
+    allInputs: allInputs || {},
+    priorReadings: prior?.goalReadings || null,
+  });
+
+  return saveSnapshot({
+    week: range.weekLabel,
+    capturedAt: new Date(endMs).toISOString(),
+    capturedBy,
+    merged,
+    reviews,
+    turnaround: median == null ? 0 : Math.round(median * 24),
+    linkage,
+    rounds: Math.round(rounds * 10) / 10,
+    note: "",
+    goalReadings,
+    partial,
+    gaps,
+  });
+}

--- a/apps/web/src/features/snapshots/use-backfill.js
+++ b/apps/web/src/features/snapshots/use-backfill.js
@@ -39,18 +39,11 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import {
-  readSnapshots,
-  saveSnapshot,
-} from "./snapshots-store";
-import { captureGoalReadings } from "./capture-readings";
+import { readSnapshots } from "./snapshots-store";
+import { synthesiseWeek } from "./synthesise-week";
 import { useGoals } from "@/features/goals";
 import { useGoalSpecs } from "@/features/goal-specs";
 import {
-  avgReviewerComments,
-  countMrComments,
-  linkagePct,
-  medianTurnaroundDays,
   useCombinedEventsSince,
   useCombinedMergedSince,
   useJiraTickets,
@@ -59,8 +52,6 @@ import { readInputs } from "@/features/goal-inputs";
 import { isoDaysAgo, weekLabel } from "@/lib/date";
 
 const DAY = 24 * 60 * 60 * 1000;
-const WEEK = 7 * DAY;
-const EVENTS_HORIZON_DAYS = 90;
 
 /**
  * @returns {{
@@ -105,15 +96,15 @@ export function useBackfill() {
 
     for (let i = 0; i < missing.length; i++) {
       if (cancelledRef.current) break;
-      const range = missing[i];
       synthesiseWeek({
-        range,
+        range: missing[i],
         goals,
         specs,
         mrs: mrs || [],
         events: events || [],
         tickets: Array.isArray(jira?.issues) ? jira.issues : [],
         allInputs,
+        capturedBy: "auto",
       });
       setProgress({ done: i + 1, total: missing.length });
       // Yield to the browser so the banner re-renders.
@@ -178,76 +169,5 @@ function enumerateCompletedWeeks() {
   return out;
 }
 
-/**
- * Synthesise one week's snapshot from the loaded data. Filters merges
- * + events + inputs to the week's window, computes the headline
- * metrics, and runs `captureGoalReadings` for the per-goal map.
- */
-function synthesiseWeek({
-  range,
-  goals,
-  specs,
-  mrs,
-  events,
-  tickets,
-  allInputs,
-}) {
-  const startMs = range.start.getTime();
-  const endMs = range.end.getTime();
-
-  const mrsThisWeek = mrs.filter((m) => {
-    if (!m.merged_at) return false;
-    const t = new Date(m.merged_at).getTime();
-    return t >= startMs && t < endMs;
-  });
-  const eventsThisWeek = events.filter((e) => {
-    const t = new Date(e.created_at || 0).getTime();
-    return t >= startMs && t < endMs;
-  });
-
-  // Was the events feed available for this week? GitHub caps at ~90d.
-  // For weeks older than that, mark partial + gaps so the snapshot
-  // honestly says "events unavailable".
-  const ageDays = Math.floor((Date.now() - endMs) / DAY);
-  const eventsAvailable = ageDays <= EVENTS_HORIZON_DAYS;
-  const partial = !eventsAvailable;
-  const gaps = eventsAvailable ? [] : ["events"];
-
-  const merged = mrsThisWeek.length;
-  const reviews = eventsAvailable ? countMrComments(eventsThisWeek) : 0;
-  const median = medianTurnaroundDays(mrsThisWeek);
-  const linkage = linkagePct(mrsThisWeek)?.pct ?? 0;
-  const rounds = avgReviewerComments(mrsThisWeek) ?? 0;
-
-  // priorReadings: pick up the most recent snapshot already in the
-  // store so monthly/quarterly cumulatives chain through correctly.
-  const existing = readSnapshots();
-  const prior = existing.find((s) => s.week < range.weekLabel);
-
-  const goalReadings = captureGoalReadings({
-    weekStart: range.start,
-    weekEnd: range.end,
-    goals,
-    specs,
-    mrs: mrsThisWeek,
-    events: eventsThisWeek,
-    tickets,
-    allInputs,
-    priorReadings: prior?.goalReadings || null,
-  });
-
-  saveSnapshot({
-    week: range.weekLabel,
-    capturedAt: new Date(endMs).toISOString(),
-    capturedBy: "auto",
-    merged,
-    reviews,
-    turnaround: median == null ? 0 : Math.round(median * 24),
-    linkage,
-    rounds: Math.round(rounds * 10) / 10,
-    note: "",
-    goalReadings,
-    partial,
-    gaps,
-  });
-}
+// `synthesiseWeek` now lives in ./synthesise-week.js so the checkin
+// page can call it directly when saving the active week.

--- a/apps/web/src/lib/date.js
+++ b/apps/web/src/lib/date.js
@@ -74,4 +74,96 @@ export function fullDate(iso) {
   });
 }
 
+/**
+ * Resolve a Sun → Thu work-week from a Wnn label (current year).
+ *
+ * Inputs: "W17" or "W17-2026" — the year suffix is optional and
+ * defaults to the current calendar year (matches how the snapshot
+ * store keys its rows today).
+ *
+ * Returns `{ start, end, weekLabel }` — the same triple the
+ * auto-snapshotter and backfill enumerator produce. Suitable for
+ * direct hand-off to `synthesiseWeek`.
+ *
+ * Returns null when the label can't be parsed.
+ */
+export function weekRangeFromLabel(label) {
+  if (typeof label !== "string") return null;
+  const m = label.trim().match(/^W(\d{1,2})(?:-(\d{4}))?$/i);
+  if (!m) return null;
+  const weekNum = Number(m[1]);
+  const year = m[2] ? Number(m[2]) : new Date().getFullYear();
+  if (!Number.isFinite(weekNum) || weekNum < 1 || weekNum > 53) return null;
+
+  // Invert weekLabel(): find the Sunday of the requested week. weekLabel
+  // counts week 1 as the week containing Jan 1 (with the partial week
+  // before Jan 1 still grouped under week 1). Working backwards: the
+  // Sunday of week N is at dayOfYear `7*(N-1) - jan1Weekday + 1`.
+  const yearStart = new Date(year, 0, 1);
+  const jan1Weekday = yearStart.getDay(); // 0=Sun
+  const dayOfYearOfSunday = 7 * (weekNum - 1) - jan1Weekday + 1;
+  const sunday = new Date(year, 0, dayOfYearOfSunday);
+  sunday.setHours(0, 0, 0, 0);
+
+  const friday = new Date(sunday);
+  friday.setDate(sunday.getDate() + 5); // Sun + 5 = Friday 00:00 (= Thu EOD)
+
+  return {
+    start: sunday,
+    end: friday,
+    weekLabel: weekLabel(new Date(sunday.getTime() + 3 * DAY_MS)),
+  };
+}
+
+/**
+ * Resolve the most recent COMPLETED Sun → Thu work-week (no in-progress
+ * weeks). Shares logic with use-auto-snapshot's resolver but lives here
+ * so non-React callers (URL defaulting, link builders) can use it.
+ */
+export function resolveCompletedWorkWeek(now = new Date()) {
+  const d = new Date(now);
+  const day = d.getDay();
+  let daysSinceFriday;
+  if (day >= 5) {
+    daysSinceFriday = day - 5; // Fri=0, Sat=1
+  } else {
+    daysSinceFriday = day + 2; // Sun=2, Mon=3, ..., Thu=6
+  }
+  const friday = new Date(d);
+  friday.setDate(d.getDate() - daysSinceFriday);
+  friday.setHours(0, 0, 0, 0);
+  const sunday = new Date(friday);
+  sunday.setDate(friday.getDate() - 5);
+  return {
+    start: sunday,
+    end: friday,
+    weekLabel: weekLabel(new Date(sunday.getTime() + 3 * DAY_MS)),
+  };
+}
+
+/**
+ * Mid-week timestamp (Tuesday 12:00 local) for a given week label.
+ * Useful when writing a goal-input that should be attributed to the
+ * selected week — putting it at mid-week keeps the ts well inside the
+ * Sun → Fri window so cadence-window logic doesn't have to worry about
+ * edge cases.
+ */
+export function midWeekTs(label) {
+  const r = weekRangeFromLabel(label);
+  if (!r) return null;
+  const mid = new Date(r.start);
+  mid.setDate(r.start.getDate() + 2); // Tue
+  mid.setHours(12, 0, 0, 0);
+  return mid.getTime();
+}
+
+/**
+ * Compare two "Wnn" labels for sort order. Treats them as 1..53 within
+ * the same year. (Year-suffixed labels compare lexicographically and
+ * still order correctly across full years.)
+ */
+export function compareWeekLabels(a, b) {
+  return (a || "").localeCompare(b || "");
+}
+
 export { DAY_MS };

--- a/packages/shared/src/hubs/registry.d.ts
+++ b/packages/shared/src/hubs/registry.d.ts
@@ -16,6 +16,7 @@ export interface HubTheme {
 export type HubPageSlot =
   | "dashboard"
   | "goals"
+  | "checkin"
   | "evidence"
   | "snapshots"
   | "reviews"

--- a/packages/shared/src/hubs/registry.js
+++ b/packages/shared/src/hubs/registry.js
@@ -55,6 +55,7 @@ export const ALL_PROVIDERS = Object.freeze(["github", "gitlab", "jira", "jenkins
 export const PAGE_SLOTS = Object.freeze([
   "dashboard",
   "goals",
+  "checkin",
   "evidence",
   "snapshots",
   "reviews",
@@ -116,6 +117,7 @@ const DEV_HUB = Object.freeze({
   pages: Object.freeze({
     dashboard: "dev:dashboard",
     goals: "dev:goals",
+    checkin: "dev:checkin",
     evidence: "dev:evidence",
     snapshots: "dev:snapshots",
     reviews: "dev:reviews",


### PR DESCRIPTION
## Summary
PR #2 of the weekly-checkin workstream. **Stacks on `feat/weekly-checkin-foundation` (#93)** — review/merge that one first; this PR's diff will collapse to just the grid additions once #93 lands.

The single-week page handles "fill last week" well, but a dev with 18 empty weeks behind them walking week-by-week is miserable. The grid puts every empty week on screen at once so they can fill the whole backlog from one page.

## What ships
- **New route** `/[hub]/checkin/grid` (same `checkin` slot guard as the single-week page)
- **URL-driven range** `?from=W14&to=W19`. Default = empty weeks back to Jan 1, capped at 12 columns
- **Layout** CSS grid with sticky left column (goals) and sticky top row (weeks). Scrolls in both axes.
- **Compact cell editors** for every manual widget today:
  - Counter (`-1 / [val] / +1`)
  - Scale (5 micro-pills)
  - Milestone (`N/M` chip → Radix popover with full checklist)
  - Free-text (ellipsized line → popover with 500-char textarea)
  - Date-log (count + tap-to-+1)
  - Before-after (`B → C` chip → popover with both number fields)
- **Auto cells** (MERGED_COUNT, REVIEW_ROUNDS, TURNAROUND, LINKAGE, FIRST_PASS_RATE, TICKET_CYCLE) — read-only chips computed from this week's slice. Data is pre-bucketed per-week ONCE so cells don't re-filter the full feed.
- **"Copy ← W##" per-row bulk-fill**: scans the row for a non-empty source week and writes that value into every empty cell in the same row. The single highest-leverage feature for steady-state metrics (morale rating, mentor calls). Enabled for COUNTER / SCALE / DATE_LOG today.
- **Toolbar**: range preset chips (4w/8w/12w), prev/next page-shift arrows, Save All → runs `synthesiseWeek` for every displayed week with `capturedBy: "manual"`.

## Single-week page changes
- `GapBanner`'s "Step to W18" → **"Catch up N weeks"** linking to `/checkin/grid` (grid is genuinely the right tool for that flow now)
- New **"Grid"** toggle button next to "Save week" in the single-week toolbar for direct access

## Not in scope
| Deferred to | Item |
|---|---|
| later | Cell editors for `INCIDENT_LOG` / `RECURRING_MILESTONE` / `CODE_RUBRIC` / `SCORECARD` (currently render stub) |
| **PR #95** | Auto-backfill engine — one-click "fill all auto data since Jan 1" |
| **PR #96** | First-time setup wizard wrapping the grid + auto-backfill |
| later | Edit-history / audit-log visibility |
| follow-up | Per-week save (vs save-all) |

## Test plan
- [ ] `/dev/checkin/grid` opens with default range = empty weeks oldest-first
- [ ] `?from=W10&to=W18` deep-link renders that exact range
- [ ] 4w / 8w / 12w preset chips switch the range
- [ ] Prev / next arrows shift the range by `weeks.length` (whole page at a time)
- [ ] Counter cells `-1` / `+1` mutate just that (goal, week) entry
- [ ] Scale cells set the active pill for the (goal, week) pair
- [ ] Milestone popover toggles persist after closing/reopening
- [ ] Free-text popover saves draft on click, preview shows ellipsized line
- [ ] Before/after popover saves both numbers as one entry
- [ ] Date-log `+` button increments only the clicked week
- [ ] Auto cells show the right values per week (different across weeks)
- [ ] "Copy ← W##" fills only EMPTY cells in the row, leaves filled ones alone
- [ ] "Save all" → toast confirms; `/dev/snapshots` shows one row per displayed week with the manual-filled goal readings
- [ ] Single-week page's gap banner now goes to the grid
- [ ] Grid toggle on single-week page works
- [ ] Existing dashboard widgets and single-week page still work (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)