### PR TITLE
fix(snapshots): restore EVENTS_HORIZON_DAYS const in use-backfill

### DIFF
--- a/apps/web/src/features/snapshots/use-backfill.js
+++ b/apps/web/src/features/snapshots/use-backfill.js
@@ -52,6 +52,10 @@ import { readInputs } from "@/features/goal-inputs";
 import { isoDaysAgo, weekLabel } from "@/lib/date";
 
 const DAY = 24 * 60 * 60 * 1000;
+// GitHub's events feed caps at ~90d — that's the furthest back we
+// can fetch event data for backfill. `synthesiseWeek` uses the same
+// constant to mark older weeks as `partial: true` / `gaps: ["events"]`.
+const EVENTS_HORIZON_DAYS = 90;
 
 /**
  * @returns {{


### PR DESCRIPTION
## Summary
Hotfix for a regression introduced in #93. Production was throwing:

```
Uncaught ReferenceError: EVENTS_HORIZON_DAYS is not defined
  at useBackfill (.../snapshots/use-backfill.js)
```

## Root cause
When #93 extracted `synthesiseWeek` into its own module, I deleted the constants block from `use-backfill.js` too aggressively. The hook still references `EVENTS_HORIZON_DAYS` at line 68:

```js
const { data: events } = useCombinedEventsSince(isoDaysAgo(EVENTS_HORIZON_DAYS));
```

Build didn't catch this because the reference lives inside a hook body — JS resolves it against module scope at call time, not at parse time. Local builds passed because the build step doesn't execute hook bodies.

## Fix
Restore the constant (same `90` value the extracted `synthesise-week.js` uses).

## Test plan
- [ ] Page loads without ReferenceError in console
- [ ] BackfillBanner / `useBackfill` still works (90d events horizon honored)
- [ ] No regression on `/dev/checkin` or `/dev/checkin/grid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)