### PR TITLE
feat(checkin): inline editors for INCIDENT_LOG + RECURRING_MILESTONE + [object Object] fix

### DIFF
--- a/apps/web/src/features/checkin/editors.jsx
+++ b/apps/web/src/features/checkin/editors.jsx
@@ -319,6 +319,264 @@ export function BeforeAfterEditor({ goal, weekStart, weekEnd, activeLabel }) {
   );
 }
 
+/* ─────────────────────── Incident log ─────────────────────── */
+
+/**
+ * INCIDENT_LOG editor — one entry per incident, stored as
+ *   { severity, downtime, link? }
+ *
+ * The check-in single-week view shows ONLY the incidents logged in
+ * the active week. A "Log incident" inline form below the list lets
+ * the user add a new one with ts = mid-week of the active week.
+ *
+ * Severity scale matches the dashboard widget: P1 (critical) → P4
+ * (minor). The classifier doesn't enforce a specific severity scale
+ * so we adopt the most common one.
+ */
+const SEVERITIES = [
+  { id: "P1", label: "P1 · critical" },
+  { id: "P2", label: "P2 · major" },
+  { id: "P3", label: "P3 · minor" },
+  { id: "P4", label: "P4 · low" },
+];
+
+export function IncidentLogEditor({ goal, weekStart, weekEnd, activeLabel }) {
+  const { entries, append, remove } = useGoalInputs(goal?.id);
+  const inWindow = useMemo(
+    () =>
+      (entries || []).filter(
+        (e) =>
+          e.ts >= weekStart.getTime() &&
+          e.ts < weekEnd.getTime() &&
+          e.value &&
+          typeof e.value === "object",
+      ),
+    [entries, weekStart, weekEnd],
+  );
+
+  const totalDowntime = inWindow.reduce(
+    (sum, e) => sum + (Number(e.value?.downtime) || 0),
+    0,
+  );
+
+  const [severity, setSeverity] = useState("P2");
+  const [downtime, setDowntime] = useState("");
+  const [link, setLink] = useState("");
+
+  const canLog = downtime !== "" && Number.isFinite(Number(downtime));
+
+  const log = () => {
+    if (!canLog) return;
+    const ts = midWeekTs(activeLabel);
+    if (ts == null) return;
+    const minutes = Number(downtime);
+    if (!Number.isFinite(minutes) || minutes < 0) return;
+    append(
+      {
+        severity,
+        downtime: minutes,
+        ...(link.trim() ? { link: link.trim() } : {}),
+      },
+      undefined,
+      ts,
+    );
+    setDowntime("");
+    setLink("");
+  };
+
+  return (
+    <div className="flex w-[320px] flex-col gap-2">
+      <div
+        className="flex items-baseline justify-between text-[11px] text-muted-fg"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        <span>
+          {inWindow.length} incident{inWindow.length === 1 ? "" : "s"} this week
+        </span>
+        {inWindow.length > 0 && (
+          <span>Σ {totalDowntime} min downtime</span>
+        )}
+      </div>
+
+      {inWindow.length > 0 && (
+        <ul className="flex flex-col gap-1 rounded-md border border-border bg-bg/40 p-1.5">
+          {inWindow.map((e) => (
+            <li
+              key={e.ts}
+              className="flex items-center justify-between gap-2 text-[11px]"
+              style={{ fontFamily: "var(--font-mono)" }}
+            >
+              <span className="flex items-center gap-1.5">
+                <span className="rounded-[3px] border border-border px-1 py-px text-[9px] uppercase text-muted-fg">
+                  {e.value.severity || "P?"}
+                </span>
+                <span className="text-fg">{e.value.downtime ?? 0}m</span>
+                {e.value.link && (
+                  <a
+                    href={e.value.link}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="truncate text-muted-fg underline"
+                  >
+                    link
+                  </a>
+                )}
+              </span>
+              <button
+                type="button"
+                onClick={() => remove(e.ts)}
+                className="text-[10px] text-muted-fg/60 hover:text-fg"
+                title="Remove incident"
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div
+        className="flex flex-wrap items-center gap-1.5"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        <select
+          value={severity}
+          onChange={(ev) => setSeverity(ev.target.value)}
+          className="h-7 rounded-md border border-border bg-bg px-1.5 text-[11px]"
+        >
+          {SEVERITIES.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.id}
+            </option>
+          ))}
+        </select>
+        <input
+          type="number"
+          min={0}
+          value={downtime}
+          onChange={(ev) => setDowntime(ev.target.value)}
+          placeholder="min"
+          className="h-7 w-16 rounded-md border border-border bg-bg px-1.5 text-[11px]"
+        />
+        <input
+          type="url"
+          value={link}
+          onChange={(ev) => setLink(ev.target.value)}
+          placeholder="link (optional)"
+          className="h-7 min-w-0 flex-1 rounded-md border border-border bg-bg px-1.5 text-[11px]"
+        />
+        <button
+          type="button"
+          onClick={log}
+          disabled={!canLog}
+          className={cn(
+            "rounded-md bg-accent px-2.5 py-1 text-[10px] uppercase tracking-[0.4px] text-accent-on transition-opacity",
+            !canLog && "opacity-40",
+          )}
+        >
+          Log
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────── Recurring milestone ─────────────────────── */
+
+/**
+ * RECURRING_MILESTONE editor — a checklist that RESETS each period
+ * (e.g. quarterly DR drills). Storage shape: one entry per period,
+ *   { periodKey, items: [{id, label, done}] }
+ *
+ * Important: the editor scopes to the PERIOD the active week falls
+ * in, NOT the active week itself. A quarterly milestone toggled in
+ * W17 reflects in W18, W19, ... up to the quarter boundary — they
+ * all share the same period entry. The write uses `ts = midWeekTs`
+ * of the active week so the entry lives on a known weekday.
+ */
+export function RecurringMilestoneEditor({ goal, spec, activeLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const cadence = spec.manual?.cadence || "quarterly";
+
+  // Resolve the active week's period key (e.g. "2026-Q2"). All weeks
+  // inside the same quarter share this key.
+  const activePeriodKey = useMemo(() => {
+    const ts = midWeekTs(activeLabel);
+    return ts == null ? "all" : periodKeyFor(ts, cadence);
+  }, [activeLabel, cadence]);
+
+  // Latest entry whose periodKey matches the active period.
+  const items = useMemo(() => {
+    const matching = (entries || []).filter(
+      (e) => e?.value?.periodKey === activePeriodKey,
+    );
+    const latest = matching[matching.length - 1];
+    const stored = Array.isArray(latest?.value?.items) ? latest.value.items : null;
+    if (stored) return stored;
+    // First time we see this period — seed from spec.manual.items.
+    const seed = Array.isArray(spec.manual?.items) ? spec.manual.items : [];
+    return seed.map((it) => ({
+      id: it.id || slugify(it.label || it),
+      label: it.label || it,
+      done: false,
+    }));
+  }, [entries, activePeriodKey, spec.manual?.items]);
+
+  const done = items.filter((i) => i.done).length;
+  const total = items.length;
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+
+  const toggle = (id) => {
+    const ts = midWeekTs(activeLabel);
+    if (ts == null) return;
+    const next = items.map((it) =>
+      it.id === id ? { ...it, done: !it.done } : it,
+    );
+    append({ periodKey: activePeriodKey, items: next }, undefined, ts);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-1.5">
+      <div
+        className="flex items-baseline justify-between text-[11px] text-muted-fg"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        <span>
+          {done} / {total} this {cadenceWord(cadence)} · {pct}%
+        </span>
+        <span className="opacity-70">{activePeriodKey}</span>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {items.length === 0 ? (
+          <span
+            className="text-[10px] text-muted-fg/70"
+            style={{ fontFamily: "var(--font-mono)" }}
+          >
+            No checklist items — define them via the dashboard widget first.
+          </span>
+        ) : (
+          items.map((it) => (
+            <button
+              key={it.id}
+              type="button"
+              onClick={() => toggle(it.id)}
+              className={cn(
+                "flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] transition-colors",
+                it.done
+                  ? "bg-accent-dim text-fg"
+                  : "text-muted-fg hover:bg-accent-dim/40",
+              )}
+            >
+              {it.done && <Check size={11} />}
+              {it.label}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
 /* ─────────────────────── Read-only: auto widgets ─────────────────────── */
 
 export function AutoReadout({ value, unit, target, hint }) {
@@ -457,4 +715,61 @@ function slugify(s) {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");
+}
+
+/**
+ * Period key for RECURRING_MILESTONE. Matches the dashboard widget's
+ * shape so entries written from the dashboard and from check-in
+ * collide on the same key for the same period.
+ *
+ *   daily      → "YYYY-MM-DD"
+ *   weekly     → "YYYY-W##"   (ISO week, simplified — sun-anchored)
+ *   biweekly   → "YYYY-B##"
+ *   monthly    → "YYYY-MM"
+ *   quarterly  → "YYYY-Q#"
+ */
+function periodKeyFor(ts, cadence) {
+  const d = new Date(ts);
+  if (!Number.isFinite(d.getTime())) return "all";
+  const y = d.getUTCFullYear();
+  switch (cadence) {
+    case "daily":
+      return `${y}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+    case "weekly": {
+      const w = sunWeekOf(d);
+      return `${y}-W${pad2(w)}`;
+    }
+    case "biweekly": {
+      const w = sunWeekOf(d);
+      return `${y}-B${pad2(Math.floor((w - 1) / 2))}`;
+    }
+    case "monthly":
+      return `${y}-${pad2(d.getUTCMonth() + 1)}`;
+    case "quarterly":
+      return `${y}-Q${Math.floor(d.getUTCMonth() / 3) + 1}`;
+    default:
+      return "all";
+  }
+}
+
+function pad2(n) {
+  return String(n).padStart(2, "0");
+}
+
+function sunWeekOf(d) {
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const daysSinceJan1 = Math.floor((d.getTime() - yearStart.getTime()) / (24 * 60 * 60 * 1000));
+  return Math.floor(daysSinceJan1 / 7) + 1;
+}
+
+function cadenceWord(cadence) {
+  switch (cadence) {
+    case "daily":     return "day";
+    case "weekly":    return "week";
+    case "biweekly":  return "fortnight";
+    case "monthly":   return "month";
+    case "quarterly": return "quarter";
+    case "yearly":    return "year";
+    default:          return "period";
+  }
 }

--- a/apps/web/src/features/checkin/goal-row.jsx
+++ b/apps/web/src/features/checkin/goal-row.jsx
@@ -29,7 +29,9 @@ import {
   CounterEditor,
   DateLogEditor,
   FreeTextEditor,
+  IncidentLogEditor,
   MilestoneEditor,
+  RecurringMilestoneEditor,
   ScaleEditor,
   UnsupportedStub,
 } from "./editors";
@@ -208,7 +210,10 @@ function EditorFor({
       );
     }
     case SPEC_KINDS.FIRST_PASS_RATE: {
-      const pct = firstPassRatePct(weekMrs);
+      // firstPassRatePct returns `{ pct, clean, pingPong }` (or null).
+      // The read-out displays a scalar — unwrap to .pct.
+      const result = firstPassRatePct(weekMrs);
+      const pct = result?.pct ?? null;
       return (
         <AutoReadout
           value={pct == null ? "—" : pct}
@@ -228,12 +233,27 @@ function EditorFor({
         />
       );
 
+    case SPEC_KINDS.INCIDENT_LOG:
+      return (
+        <IncidentLogEditor
+          goal={goal}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          activeLabel={activeLabel}
+        />
+      );
+
+    case SPEC_KINDS.RECURRING_MILESTONE:
+      return (
+        <RecurringMilestoneEditor
+          goal={goal}
+          spec={spec}
+          activeLabel={activeLabel}
+        />
+      );
+
     // Phase D/E widgets with richer state — full inline editors land in
     // a later PR. For now, point the user at the dashboard widget.
-    case SPEC_KINDS.INCIDENT_LOG:
-      return <UnsupportedStub message="Log incidents from the dashboard widget" />;
-    case SPEC_KINDS.RECURRING_MILESTONE:
-      return <UnsupportedStub message="Toggle items from the dashboard widget" />;
     case SPEC_KINDS.CODE_RUBRIC:
       return <UnsupportedStub message="Grade PRs from the dashboard widget" />;
     case SPEC_KINDS.SCORECARD:

--- a/apps/web/src/features/checkin/grid-cells.jsx
+++ b/apps/web/src/features/checkin/grid-cells.jsx
@@ -391,6 +391,256 @@ export function BeforeAfterCell({ goal, weekStart, weekEnd, weekLabel }) {
   );
 }
 
+/* ─────────────────────── Incident log (cell, popover) ─────────────────────── */
+
+export function IncidentLogCell({ goal, weekStart, weekEnd, weekLabel }) {
+  const { entries, append, remove } = useGoalInputs(goal?.id);
+  const inWindow = useMemo(
+    () =>
+      (entries || []).filter(
+        (e) =>
+          e.ts >= weekStart.getTime() &&
+          e.ts < weekEnd.getTime() &&
+          e.value &&
+          typeof e.value === "object",
+      ),
+    [entries, weekStart, weekEnd],
+  );
+  const totalDowntime = inWindow.reduce(
+    (sum, e) => sum + (Number(e.value?.downtime) || 0),
+    0,
+  );
+
+  const [severity, setSeverity] = useState("P2");
+  const [downtime, setDowntime] = useState("");
+  const [link, setLink] = useState("");
+
+  const canLog = downtime !== "" && Number.isFinite(Number(downtime));
+
+  const log = () => {
+    if (!canLog) return;
+    const ts = midWeekTs(weekLabel);
+    if (ts == null) return;
+    const minutes = Number(downtime);
+    if (!Number.isFinite(minutes) || minutes < 0) return;
+    append(
+      {
+        severity,
+        downtime: minutes,
+        ...(link.trim() ? { link: link.trim() } : {}),
+      },
+      undefined,
+      ts,
+    );
+    setDowntime("");
+    setLink("");
+  };
+
+  const preview =
+    inWindow.length === 0
+      ? "0"
+      : `${inWindow.length} · ${totalDowntime}m`;
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "rounded-md border border-border bg-bg px-2 py-1 text-[11px]",
+            "hover:bg-accent-dim/40",
+            inWindow.length === 0 ? "text-muted-fg" : "text-fg",
+          )}
+          style={CELL_FONT}
+        >
+          {preview}
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 w-[280px] rounded-md border border-border bg-bg p-2 shadow-lg"
+        >
+          {inWindow.length > 0 && (
+            <ul className="mb-1.5 flex flex-col gap-0.5">
+              {inWindow.map((e) => (
+                <li
+                  key={e.ts}
+                  className="flex items-center justify-between gap-2 rounded-md bg-bg/40 px-1.5 py-0.5 text-[11px]"
+                  style={CELL_FONT}
+                >
+                  <span className="flex items-center gap-1.5">
+                    <span className="rounded-[3px] border border-border px-1 py-px text-[9px] uppercase text-muted-fg">
+                      {e.value.severity || "P?"}
+                    </span>
+                    <span className="text-fg">{e.value.downtime ?? 0}m</span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => remove(e.ts)}
+                    className="text-[10px] text-muted-fg/60 hover:text-fg"
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="flex flex-wrap items-center gap-1" style={CELL_FONT}>
+            <select
+              value={severity}
+              onChange={(ev) => setSeverity(ev.target.value)}
+              className="h-7 rounded-md border border-border bg-bg px-1 text-[11px]"
+            >
+              <option value="P1">P1</option>
+              <option value="P2">P2</option>
+              <option value="P3">P3</option>
+              <option value="P4">P4</option>
+            </select>
+            <input
+              type="number"
+              min={0}
+              value={downtime}
+              onChange={(ev) => setDowntime(ev.target.value)}
+              placeholder="min"
+              className="h-7 w-14 rounded-md border border-border bg-bg px-1.5 text-[11px]"
+            />
+            <input
+              type="url"
+              value={link}
+              onChange={(ev) => setLink(ev.target.value)}
+              placeholder="link"
+              className="h-7 min-w-0 flex-1 rounded-md border border-border bg-bg px-1.5 text-[11px]"
+            />
+            <button
+              type="button"
+              onClick={log}
+              disabled={!canLog}
+              className={cn(
+                "rounded-md bg-accent px-1.5 py-1 text-[10px] uppercase text-accent-on",
+                !canLog && "opacity-40",
+              )}
+            >
+              Log
+            </button>
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+/* ─────────────────────── Recurring milestone (cell, popover) ─────────────────────── */
+
+/**
+ * RECURRING_MILESTONE — the checklist resets per cadence period. The
+ * cell scopes its display to the period the active WEEK falls in
+ * (e.g. all weeks of "2026-Q2" share the same checklist state). The
+ * write uses `ts = midWeekTs(weekLabel)` so each toggle lives on a
+ * known weekday inside the cell's week, but the periodKey it carries
+ * is the cadence-level bucket — that's what lets cross-week toggles
+ * collapse to one entry.
+ */
+export function RecurringMilestoneCell({ goal, spec, weekLabel }) {
+  const { entries, append } = useGoalInputs(goal?.id);
+  const cadence = spec.manual?.cadence || "quarterly";
+
+  const periodKey = useMemo(() => {
+    const ts = midWeekTs(weekLabel);
+    return ts == null ? "all" : periodKeyFor(ts, cadence);
+  }, [weekLabel, cadence]);
+
+  const items = useMemo(() => {
+    const matching = (entries || []).filter(
+      (e) => e?.value?.periodKey === periodKey,
+    );
+    const latest = matching[matching.length - 1];
+    const stored = Array.isArray(latest?.value?.items) ? latest.value.items : null;
+    if (stored) return stored;
+    const seed = Array.isArray(spec.manual?.items) ? spec.manual.items : [];
+    return seed.map((it) => ({
+      id: it.id || slugify(it.label || it),
+      label: it.label || it,
+      done: false,
+    }));
+  }, [entries, periodKey, spec.manual?.items]);
+
+  const done = items.filter((i) => i.done).length;
+  const total = items.length;
+
+  const toggle = (id) => {
+    const ts = midWeekTs(weekLabel);
+    if (ts == null) return;
+    const next = items.map((it) =>
+      it.id === id ? { ...it, done: !it.done } : it,
+    );
+    append({ periodKey, items: next }, undefined, ts);
+  };
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded-md border border-border bg-bg px-2 py-1 text-[11px] hover:bg-accent-dim/40"
+          style={CELL_FONT}
+        >
+          <span className="font-semibold text-fg">
+            {done}/{total}
+          </span>
+          <span className="text-[9px] text-muted-fg/70">{periodKey}</span>
+          <ChevronDown size={10} className="text-muted-fg" />
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 max-h-[280px] w-[240px] overflow-y-auto rounded-md border border-border bg-bg p-2 shadow-lg"
+        >
+          <div className="flex flex-col gap-1">
+            {items.length === 0 ? (
+              <span
+                className="px-1 py-2 text-center text-[11px] text-muted-fg"
+                style={CELL_FONT}
+              >
+                Define items via the dashboard widget first
+              </span>
+            ) : (
+              items.map((it) => (
+                <button
+                  key={it.id}
+                  type="button"
+                  onClick={() => toggle(it.id)}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-md px-2 py-1 text-left text-[11px] transition-colors",
+                    it.done
+                      ? "bg-accent-dim text-fg"
+                      : "text-muted-fg hover:bg-accent-dim/40",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "flex h-3.5 w-3.5 items-center justify-center rounded-[3px] border",
+                      it.done
+                        ? "border-accent bg-accent text-accent-on"
+                        : "border-border bg-bg",
+                    )}
+                  >
+                    {it.done && <Check size={9} />}
+                  </span>
+                  <span className="truncate">{it.label}</span>
+                </button>
+              ))
+            )}
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
 /* ─────────────────────── Auto / Read-only (cell) ─────────────────────── */
 
 export function AutoCell({ value, unit, target }) {
@@ -519,4 +769,44 @@ function slugify(s) {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");
+}
+
+/* Period helpers — duplicated from editors.jsx to keep this module
+   self-contained for cell-only consumers. Shape matches the dashboard
+   RecurringMilestoneWidget's `periodKey`. */
+
+function periodKeyFor(ts, cadence) {
+  const d = new Date(ts);
+  if (!Number.isFinite(d.getTime())) return "all";
+  const y = d.getUTCFullYear();
+  switch (cadence) {
+    case "daily":
+      return `${y}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+    case "weekly": {
+      const w = sunWeekOf(d);
+      return `${y}-W${pad2(w)}`;
+    }
+    case "biweekly": {
+      const w = sunWeekOf(d);
+      return `${y}-B${pad2(Math.floor((w - 1) / 2))}`;
+    }
+    case "monthly":
+      return `${y}-${pad2(d.getUTCMonth() + 1)}`;
+    case "quarterly":
+      return `${y}-Q${Math.floor(d.getUTCMonth() / 3) + 1}`;
+    default:
+      return "all";
+  }
+}
+
+function pad2(n) {
+  return String(n).padStart(2, "0");
+}
+
+function sunWeekOf(d) {
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const daysSinceJan1 = Math.floor(
+    (d.getTime() - yearStart.getTime()) / (24 * 60 * 60 * 1000),
+  );
+  return Math.floor(daysSinceJan1 / 7) + 1;
 }

--- a/apps/web/src/features/checkin/grid-row.jsx
+++ b/apps/web/src/features/checkin/grid-row.jsx
@@ -29,7 +29,9 @@ import {
   CounterCell,
   DateLogCell,
   FreeTextCell,
+  IncidentLogCell,
   MilestoneCell,
+  RecurringMilestoneCell,
   ScaleCell,
   StubCell,
 } from "./grid-cells";
@@ -172,17 +174,43 @@ function CellFor({
       return <AutoCell value={pct} unit="%" target={spec.source?.target} />;
     }
     case SPEC_KINDS.FIRST_PASS_RATE: {
-      const pct = firstPassRatePct(mrsThisWeek);
-      return <AutoCell value={pct} unit="%" target={spec.source?.target} />;
+      // firstPassRatePct returns `{ pct, clean, pingPong }` (or null
+      // when there were no merges this week). Cells render scalars,
+      // so unwrap to the .pct field.
+      const result = firstPassRatePct(mrsThisWeek);
+      return (
+        <AutoCell
+          value={result?.pct ?? null}
+          unit="%"
+          target={spec.source?.target}
+        />
+      );
     }
     case SPEC_KINDS.TICKET_CYCLE:
       return (
         <AutoCell value={ticketsCount} unit="tk" target={spec.source?.target} />
       );
 
-    // Widgets without inline-cell editors yet — placeholder.
     case SPEC_KINDS.INCIDENT_LOG:
+      return (
+        <IncidentLogCell
+          goal={goal}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          weekLabel={weekLabel}
+        />
+      );
+
     case SPEC_KINDS.RECURRING_MILESTONE:
+      return (
+        <RecurringMilestoneCell
+          goal={goal}
+          spec={spec}
+          weekLabel={weekLabel}
+        />
+      );
+
+    // Widgets without inline-cell editors yet — placeholder.
     case SPEC_KINDS.CODE_RUBRIC:
     case SPEC_KINDS.SCORECARD:
     case SPEC_KINDS.DEPLOY_FREQUENCY:


### PR DESCRIPTION
## Summary
Three issues from the catch-up grid screenshot:

1. **`[object Object]`** showing in FIRST_PASS_RATE cells/rows
2. **Can't edit anything** — most goals were classified as INCIDENT_LOG or RECURRING_MILESTONE, both of which rendered stub placeholders
3. (Deferred) Per-week CODE_RUBRIC "Analyze week" button — tracked as follow-up

## Fixes

### 1. FIRST_PASS_RATE rendering
`firstPassRatePct(...)` returns `{ pct, clean, pingPong }` — not a bare number. The cell/row were passing the whole object to `<AutoCell value={...}>` which stringified to `[object Object]`. Unwrap to `.pct` at both call sites.

### 2. INCIDENT_LOG inline editors
- **Single-week row** (`/dev/checkin`): list of this week's incidents (severity chip + minutes + optional link + remove `×`), plus an inline form below: `[severity ▾] [min] [link] [Log]`. Total downtime shown in the header.
- **Grid cell** (`/dev/checkin/grid`): compact `"N · Σm"` chip → opens a Radix popover with the same form.

### 3. RECURRING_MILESTONE inline editors
- Cadence-aware. The checklist is **scoped to the PERIOD the active week falls in**, not the week itself. Toggles in W17 mirror in W18 / W19 etc. up to the quarter boundary because they share `periodKey="2026-Q2"`.
- **Single-week row**: full checklist with header showing `M/N · this quarter · pct%`.
- **Grid cell**: `"M/N · 2026-Q2 ▾"` chip → popover with the same checklist.
- Seeds from `spec.manual.items` first time we see a period. Writes `{ periodKey, items }` matching the dashboard widget's storage shape so entries collide on the same key.

## Still stub (follow-up PR)

| Widget | Why |
|---|---|
| `CODE_RUBRIC` | User asked for a per-week "Analyze week" button. Requires scoping `useGradedPrs` to a date window. Real feature, bigger lift — separate PR. |
| `SCORECARD` | Composite over its components. Inline editor lands once each component kind has one. |
| `DEPLOY_FREQUENCY` / `LEAD_TIME` / `BUILD_PASS_RATE` | CI/CD auto widgets. Could add read-only cell next; no manual edit by definition. |

## Test plan
- [ ] `/dev/checkin/grid` — INCIDENT_LOG cells show `0` when empty, `N · Σm` when populated; click opens form; logging an incident updates the cell
- [ ] Remove `×` on an incident inside the popover deletes only that entry
- [ ] RECURRING_MILESTONE cell shows `M/N · 2026-Q2`; toggling an item in W15 reflects in W16/17/18/19 (same quarter)
- [ ] Toggling in W14 (Q1) does NOT change W15+ (Q2) state
- [ ] FIRST_PASS_RATE cells show a number + `%`, not `[object Object]`
- [ ] Single-week `/dev/checkin`: same widgets editable inline, "Save week" works
- [ ] Save → `/dev/snapshots` shows the week with incident/recurring goal readings populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)