### PR TITLE
feat(checkin): per-week CODE_RUBRIC "Analyze week" editor

### DIFF
--- a/apps/web/src/features/checkin/code-rubric-row.jsx
+++ b/apps/web/src/features/checkin/code-rubric-row.jsx
@@ -1,0 +1,462 @@
+"use client";
+
+/**
+ * Per-week CODE_RUBRIC editors for the weekly check-in.
+ *
+ * Two surfaces:
+ *
+ *   <CodeRubricEditor>          single-week inline editor (used by
+ *                               /dev/checkin's GoalRow). Shows the PRs
+ *                               merged in the active week + a "Grade
+ *                               week" action that runs the AI grader
+ *                               against just those PRs.
+ *
+ *   <CodeRubricGridRow>         full grid row (used by /dev/checkin/grid).
+ *                               Calls useGradedPrs ONCE per row, then
+ *                               partitions its PR list into the displayed
+ *                               weeks. Each cell shows N/M pass count
+ *                               + a per-week Analyze button. Last
+ *                               column is a "Grade all weeks" CTA.
+ *
+ * Design notes
+ * ────────────
+ * - useGradedPrs fetches the user's PRs from Jan 1 of the current
+ *   year ONCE per hook instance. Calling it inside each grid cell
+ *   would fire 12+ parallel GitHub search-API requests per row, which
+ *   the API would rate-limit (30 req/min). So the grid uses ONE hook
+ *   call at the row level and filters in JS by `mergedAt`.
+ *
+ * - The new `grade(subset)` action on useGradedPrs (introduced
+ *   alongside this file) lets us run the AI grader against any list
+ *   of PRs, not just "all ungraded". The dashboard widget still uses
+ *   `gradeAll()` for the year-wide flow.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import * as Popover from "@radix-ui/react-popover";
+import { Sparkles, ChevronDown } from "lucide-react";
+import { useGradedPrs } from "@/features/grading";
+import { cn } from "@/lib/cn";
+
+const CELL_FONT = { fontFamily: "var(--font-mono)" };
+
+/* ─────────────────────── single-week editor ─────────────────────── */
+
+export function CodeRubricEditor({ spec, weekStart, weekEnd }) {
+  const {
+    prs,
+    verdictsByPr,
+    rubric,
+    progress,
+    isListLoading,
+    listError,
+    grade,
+    hasGithub,
+    firstReviewOnly,
+  } = useGradedPrs(spec);
+
+  const weekPrs = useMemo(
+    () => filterPrsByMerged(prs, weekStart, weekEnd),
+    [prs, weekStart, weekEnd],
+  );
+  const stats = useMemo(
+    () => summariseVerdicts(weekPrs, verdictsByPr),
+    [weekPrs, verdictsByPr],
+  );
+
+  const onAnalyze = useCallback(() => grade(weekPrs), [grade, weekPrs]);
+  const disabled = !hasGithub || rubric.length === 0 || weekPrs.length === 0 || progress.running;
+
+  if (!hasGithub) {
+    return <Stub message="Connect GitHub to grade PRs." />;
+  }
+  if (rubric.length === 0) {
+    return <Stub message="Define rubric criteria via the dashboard widget first." />;
+  }
+  if (isListLoading && prs.length === 0) {
+    return <Stub message="Loading your PRs…" />;
+  }
+  if (listError && prs.length === 0) {
+    return <Stub message={`Couldn't load PRs: ${listError.message || "unknown"}`} />;
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-1.5">
+      <div
+        className="flex items-baseline justify-between text-[11px] text-muted-fg"
+        style={CELL_FONT}
+      >
+        <span>
+          {weekPrs.length} PR{weekPrs.length === 1 ? "" : "s"} merged this week
+          {firstReviewOnly && (
+            <span className="ml-1 opacity-70">· first-review only</span>
+          )}
+        </span>
+        {weekPrs.length > 0 && (
+          <span>
+            {stats.pass} / {stats.graded} pass
+            {stats.ungraded > 0 && ` · ${stats.ungraded} ungraded`}
+          </span>
+        )}
+      </div>
+
+      {weekPrs.length > 0 && (
+        <ul className="flex max-h-[160px] flex-col gap-0.5 overflow-y-auto rounded-md border border-border bg-bg/40 p-1.5">
+          {weekPrs.map((pr) => (
+            <li
+              key={pr.id}
+              className="flex items-center gap-1.5 text-[11px]"
+              style={CELL_FONT}
+            >
+              <VerdictPill verdict={verdictsByPr.get(pr.id)} />
+              <span className="truncate text-fg" title={pr.title}>
+                #{pr.number} {pr.title}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button
+        type="button"
+        onClick={onAnalyze}
+        disabled={disabled}
+        className={cn(
+          "flex items-center justify-center gap-1.5 rounded-md bg-accent px-2 py-1 text-[10px] uppercase tracking-[0.5px] text-accent-on transition-opacity",
+          disabled && "opacity-40",
+        )}
+        style={CELL_FONT}
+      >
+        <Sparkles size={11} />
+        {progress.running
+          ? `Grading ${progress.done}/${progress.total}…`
+          : weekPrs.length === 0
+          ? "No PRs this week"
+          : stats.ungraded === 0
+          ? "All graded"
+          : `Analyze week (${stats.ungraded})`}
+      </button>
+    </div>
+  );
+}
+
+/* ─────────────────────── grid row ─────────────────────── */
+
+const LABEL_COL = 240;
+
+export function CodeRubricGridRow({ goal, spec, weeks }) {
+  const {
+    prs,
+    verdictsByPr,
+    rubric,
+    progress,
+    isListLoading,
+    grade,
+    hasGithub,
+  } = useGradedPrs(spec);
+
+  // Bucket the year's PRs into the displayed weeks once. Each cell
+  // reads its own slice from this map.
+  const prsByWeek = useMemo(() => {
+    const out = new Map(weeks.map((w) => [w.weekLabel, []]));
+    for (const pr of prs) {
+      const dt = pr.mergedAt;
+      if (!dt) continue;
+      const t = new Date(dt).getTime();
+      for (const w of weeks) {
+        if (t >= w.start.getTime() && t < w.end.getTime()) {
+          out.get(w.weekLabel).push(pr);
+          break;
+        }
+      }
+    }
+    return out;
+  }, [prs, weeks]);
+
+  const rowTotals = useMemo(() => {
+    // Sum across the displayed weeks only — the dashboard widget's
+    // YTD summary differs, this one is "in this frame".
+    let pass = 0;
+    let graded = 0;
+    let ungraded = 0;
+    for (const [, weekPrs] of prsByWeek) {
+      const s = summariseVerdicts(weekPrs, verdictsByPr);
+      pass += s.pass;
+      graded += s.graded;
+      ungraded += s.ungraded;
+    }
+    return { pass, graded, ungraded };
+  }, [prsByWeek, verdictsByPr]);
+
+  const gradeAllWeeks = useCallback(() => {
+    const flat = [];
+    for (const list of prsByWeek.values()) flat.push(...list);
+    grade(flat);
+  }, [grade, prsByWeek]);
+
+  const disabledAll = !hasGithub || rubric.length === 0 || rowTotals.ungraded === 0 || progress.running;
+
+  return (
+    <>
+      <div
+        className="sticky left-0 z-10 flex items-center gap-2 border-b border-r border-border bg-bg px-3 py-2"
+        style={{ minWidth: LABEL_COL }}
+      >
+        <span
+          className="rounded-[3px] border border-border px-1 py-px text-[9px] uppercase tracking-[0.6px] text-muted-fg"
+          style={CELL_FONT}
+        >
+          rubric
+        </span>
+        <span className="truncate text-[12px] font-medium text-fg" title={goal?.title}>
+          {goal?.title || spec.title || "Untitled"}
+        </span>
+        <span className="ml-auto text-[10px] text-muted-fg/70" style={CELL_FONT}>
+          {rowTotals.pass}/{rowTotals.graded} ✓
+        </span>
+      </div>
+
+      {weeks.map((wk) => (
+        <CodeRubricCell
+          key={wk.weekLabel}
+          week={wk}
+          weekPrs={prsByWeek.get(wk.weekLabel) || []}
+          verdictsByPr={verdictsByPr}
+          hasGithub={hasGithub}
+          rubricReady={rubric.length > 0}
+          grade={grade}
+          isListLoading={isListLoading}
+          progress={progress}
+        />
+      ))}
+
+      {/* Trailing "Bulk" column — Grade-all-weeks for this row */}
+      <div className="flex items-center justify-end border-b border-border px-2">
+        <button
+          type="button"
+          onClick={gradeAllWeeks}
+          disabled={disabledAll}
+          title={
+            rubric.length === 0
+              ? "Define rubric in the dashboard widget first"
+              : rowTotals.ungraded === 0
+              ? "All graded"
+              : `Analyze ${rowTotals.ungraded} ungraded across these weeks`
+          }
+          className={cn(
+            "flex items-center gap-1 rounded-md border border-border bg-bg px-1.5 py-0.5 text-[10px] uppercase tracking-[0.4px] text-muted-fg hover:bg-accent-dim/60 hover:text-fg",
+            disabledAll && "opacity-40",
+          )}
+          style={CELL_FONT}
+        >
+          <Sparkles size={10} />
+          Grade all
+        </button>
+      </div>
+    </>
+  );
+}
+
+/* ─────────────────────── per-week cell ─────────────────────── */
+
+function CodeRubricCell({
+  week,
+  weekPrs,
+  verdictsByPr,
+  hasGithub,
+  rubricReady,
+  grade,
+  isListLoading,
+  progress,
+}) {
+  const stats = useMemo(
+    () => summariseVerdicts(weekPrs, verdictsByPr),
+    [weekPrs, verdictsByPr],
+  );
+  const onAnalyze = useCallback(() => grade(weekPrs), [grade, weekPrs]);
+  const disabled =
+    !hasGithub ||
+    !rubricReady ||
+    weekPrs.length === 0 ||
+    stats.ungraded === 0 ||
+    progress.running;
+
+  // Preview chip — what the cell shows when collapsed.
+  const preview =
+    !hasGithub || !rubricReady
+      ? "—"
+      : weekPrs.length === 0
+      ? "0"
+      : stats.graded === 0
+      ? `${weekPrs.length} ⃝`
+      : `${stats.pass}/${stats.graded}${
+          stats.ungraded > 0 ? ` · ${stats.ungraded}⃝` : ""
+        }`;
+
+  const tone =
+    stats.graded > 0 && stats.pass === stats.graded
+      ? "border-success/40 bg-success/5"
+      : stats.graded > 0 && stats.pass < stats.graded
+      ? "border-amber/40 bg-amber/5"
+      : "bg-bg";
+
+  return (
+    <div
+      className="flex items-center justify-center border-b border-r border-border bg-bg/40 px-2 py-1.5"
+      style={{ minHeight: 52 }}
+    >
+      <Popover.Root>
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px]",
+              "hover:bg-accent-dim/40",
+              tone,
+            )}
+            style={CELL_FONT}
+            disabled={!hasGithub || weekPrs.length === 0}
+          >
+            <span className="font-semibold text-fg">{preview}</span>
+            {weekPrs.length > 0 && <ChevronDown size={10} className="text-muted-fg" />}
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            align="start"
+            sideOffset={4}
+            className="z-50 flex w-[280px] flex-col gap-1.5 rounded-md border border-border bg-bg p-2 shadow-lg"
+          >
+            <div
+              className="flex items-baseline justify-between text-[11px] text-muted-fg"
+              style={CELL_FONT}
+            >
+              <span>
+                {week.weekLabel} · {weekPrs.length} PR
+                {weekPrs.length === 1 ? "" : "s"}
+              </span>
+              <span>
+                {stats.pass} / {stats.graded} pass
+              </span>
+            </div>
+            {weekPrs.length > 0 && (
+              <ul className="flex max-h-[140px] flex-col gap-0.5 overflow-y-auto rounded-md bg-bg/40 p-1.5">
+                {weekPrs.map((pr) => (
+                  <li
+                    key={pr.id}
+                    className="flex items-center gap-1.5 text-[11px]"
+                    style={CELL_FONT}
+                  >
+                    <VerdictPill verdict={verdictsByPr.get(pr.id)} />
+                    <span className="truncate text-fg" title={pr.title}>
+                      #{pr.number} {pr.title}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <button
+              type="button"
+              onClick={onAnalyze}
+              disabled={disabled}
+              className={cn(
+                "flex items-center justify-center gap-1 rounded-md bg-accent px-2 py-1 text-[10px] uppercase tracking-[0.4px] text-accent-on transition-opacity",
+                disabled && "opacity-40",
+              )}
+              style={CELL_FONT}
+            >
+              <Sparkles size={11} />
+              {progress.running
+                ? `Grading ${progress.done}/${progress.total}…`
+                : stats.ungraded === 0
+                ? "All graded"
+                : `Analyze (${stats.ungraded})`}
+            </button>
+            {isListLoading && (
+              <span
+                className="text-[10px] text-muted-fg/70"
+                style={CELL_FONT}
+              >
+                still loading PR list…
+              </span>
+            )}
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+    </div>
+  );
+}
+
+/* ─────────────────────── helpers ─────────────────────── */
+
+function filterPrsByMerged(prs, start, end) {
+  if (!Array.isArray(prs)) return [];
+  const s = start.getTime();
+  const e = end.getTime();
+  return prs.filter((pr) => {
+    if (!pr.mergedAt) return false;
+    const t = new Date(pr.mergedAt).getTime();
+    return t >= s && t < e;
+  });
+}
+
+function summariseVerdicts(prList, verdictsByPr) {
+  let pass = 0;
+  let graded = 0;
+  let errored = 0;
+  for (const pr of prList) {
+    const v = verdictsByPr.get(pr.id);
+    if (!v) continue;
+    if (v.errored) {
+      errored += 1;
+      continue;
+    }
+    graded += 1;
+    if (v.pass) pass += 1;
+  }
+  return {
+    pass,
+    graded,
+    errored,
+    ungraded: prList.length - graded - errored,
+  };
+}
+
+function VerdictPill({ verdict }) {
+  if (!verdict) {
+    return (
+      <span
+        className="inline-block h-2 w-2 rounded-full border border-border bg-bg"
+        title="Ungraded"
+      />
+    );
+  }
+  if (verdict.errored) {
+    return (
+      <span
+        className="inline-block h-2 w-2 rounded-full bg-amber/70"
+        title={verdict.reasoning || "Grading errored"}
+      />
+    );
+  }
+  return (
+    <span
+      className={cn(
+        "inline-block h-2 w-2 rounded-full",
+        verdict.pass ? "bg-success" : "bg-amber",
+      )}
+      title={verdict.pass ? "Pass" : "Fail"}
+    />
+  );
+}
+
+function Stub({ message }) {
+  return (
+    <div
+      className="rounded-md border border-dashed border-border px-2.5 py-1 text-[11px] text-muted-fg/80"
+      style={CELL_FONT}
+    >
+      {message}
+    </div>
+  );
+}

--- a/apps/web/src/features/checkin/goal-row.jsx
+++ b/apps/web/src/features/checkin/goal-row.jsx
@@ -35,6 +35,7 @@ import {
   ScaleEditor,
   UnsupportedStub,
 } from "./editors";
+import { CodeRubricEditor } from "./code-rubric-row";
 
 export function GoalRow({
   goal,
@@ -252,10 +253,17 @@ function EditorFor({
         />
       );
 
+    case SPEC_KINDS.CODE_RUBRIC:
+      return (
+        <CodeRubricEditor
+          spec={spec}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+        />
+      );
+
     // Phase D/E widgets with richer state — full inline editors land in
     // a later PR. For now, point the user at the dashboard widget.
-    case SPEC_KINDS.CODE_RUBRIC:
-      return <UnsupportedStub message="Grade PRs from the dashboard widget" />;
     case SPEC_KINDS.SCORECARD:
       return <UnsupportedStub message="Edit components from the dashboard widget" />;
     case SPEC_KINDS.DEPLOY_FREQUENCY:

--- a/apps/web/src/features/checkin/grid-page.jsx
+++ b/apps/web/src/features/checkin/grid-page.jsx
@@ -31,6 +31,7 @@ import {
 import { readInputs } from "@/features/goal-inputs";
 import { synthesiseWeek } from "@/features/snapshots";
 import { isoDaysAgo } from "@/lib/date";
+import { SPEC_KINDS } from "@/features/goal-specs";
 import { useCheckinGridRange } from "./use-checkin-grid-range";
 import { GridRow, RowCopyButton } from "./grid-row";
 
@@ -201,6 +202,11 @@ function GroupBlock({ group, weekCount, weeks, mrsByWeek, eventsByWeek, ticketsC
 }
 
 function RowGroup({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCount }) {
+  // CODE_RUBRIC rows render their own trailing "Bulk · Grade all"
+  // column inside GridRow → CodeRubricGridRow, so we skip appending
+  // RowCopyButton here (which would otherwise overflow the grid
+  // template's column count).
+  const skipBulk = spec.widget === SPEC_KINDS.CODE_RUBRIC;
   return (
     <>
       <GridRow
@@ -211,7 +217,7 @@ function RowGroup({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCount }) 
         eventsByWeek={eventsByWeek}
         ticketsCount={ticketsCount}
       />
-      <RowCopyButton goal={goal} spec={spec} weeks={weeks} />
+      {!skipBulk && <RowCopyButton goal={goal} spec={spec} weeks={weeks} />}
     </>
   );
 }

--- a/apps/web/src/features/checkin/grid-row.jsx
+++ b/apps/web/src/features/checkin/grid-row.jsx
@@ -35,8 +35,17 @@ import {
   ScaleCell,
   StubCell,
 } from "./grid-cells";
+import { CodeRubricGridRow } from "./code-rubric-row";
 
 export function GridRow({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCount }) {
+  // CODE_RUBRIC needs row-level state: one useGradedPrs hook call per
+  // row (a fetch per cell would hammer the GitHub search API). Delegate
+  // the whole row to the dedicated component which owns its label, its
+  // per-week cells, and its trailing bulk-action column.
+  if (spec.widget === SPEC_KINDS.CODE_RUBRIC) {
+    return <CodeRubricGridRow goal={goal} spec={spec} weeks={weeks} />;
+  }
+
   return (
     <>
       <RowLabel goal={goal} spec={spec} />

--- a/apps/web/src/features/grading/use-graded-prs.js
+++ b/apps/web/src/features/grading/use-graded-prs.js
@@ -221,9 +221,17 @@ export function useGradedPrs(spec, options = {}) {
   }, [prs, hash, gradingStoreSnap]);
 
   // Step 2 — grade any ungraded PRs when rubric is present.
-  const gradeAll = useCallback(async () => {
-    if (!rubric.length || !prs.length) return;
-    const pending = prs.filter((pr) => !readVerdict(pr.id, hash));
+  //
+  // `grade(subset)` runs the AI grader on the PRs you pass it. Filters
+  // out PRs that already have a verdict for the current rubric hash so
+  // repeat calls are idempotent. Used by:
+  //   - `gradeAll`     — grades every PR in the year window
+  //   - check-in cells — grade ONLY the PRs merged inside the active
+  //                      week so each week's pass-rate is captured on
+  //                      its own schedule
+  const grade = useCallback(async (subset) => {
+    if (!rubric.length || !Array.isArray(subset) || subset.length === 0) return;
+    const pending = subset.filter((pr) => !readVerdict(pr.id, hash));
     if (pending.length === 0) return;
 
     cancelRef.current = { aborted: false };
@@ -315,7 +323,11 @@ export function useGradedPrs(spec, options = {}) {
     if (!token.aborted) {
       setProgress({ done: pending.length, total: pending.length, running: false });
     }
-  }, [prs, rubric, hash]);
+  }, [rubric, hash, firstReviewOnly]);
+
+  // Back-compat alias for the dashboard CodeRubricWidget — grades every
+  // PR in the year window. New callers prefer `grade(subset)`.
+  const gradeAll = useCallback(() => grade(prs), [grade, prs]);
 
   // Cancel any in-flight grading when the hook owner unmounts or the
   // rubric changes — we don't want verdicts for the old hash landing in the
@@ -356,9 +368,12 @@ export function useGradedPrs(spec, options = {}) {
     progress,
     isListLoading,
     listError,
+    grade,
     gradeAll,
     refreshList,
     hasGithub: githubConnected,
+    hash,
+    firstReviewOnly,
   };
 }
 


### PR DESCRIPTION
## Summary
Closes the third item from the catch-up grid screenshot: "for the rubric metric, it should be analyze week, then it analyzes the data PRs from that week."

Each CODE_RUBRIC goal now has a per-week grading flow in both `/dev/checkin` and `/dev/checkin/grid`, so reviewers can see week-over-week pass rates instead of one rolling YTD number.

## What changed

### 1. `useGradedPrs` exposes `grade(subset)`
The existing `gradeAll()` runs against the full year's PR list. The new `grade(prList)` runs the same loop against any subset you pass. `gradeAll` is now `() => grade(prs)` so the dashboard widget keeps working unchanged.

### 2. `CodeRubricEditor` — single-week inline editor
On `/dev/checkin`:
- Count of PRs merged this week (+ first-review-only flag if set)
- `pass / graded` summary + `ungraded` count
- Scrollable list of PR titles with verdict dots (✓ pass, ⚠ fail, ○ ungraded)
- "Analyze week (N)" button → grades just this week's ungraded PRs

### 3. `CodeRubricGridRow` — multi-week grid row
On `/dev/checkin/grid`:
- **Row-level** `useGradedPrs` (not per cell — would hit 30/min GitHub search rate-limit with 12 parallel fetches)
- PRs bucketed in JS by `mergedAt` into the displayed week columns
- Each week cell: compact `pass/total` chip → Radix popover with PRs + Analyze button
- Trailing "Bulk · Grade all" column to grade every ungraded PR across the frame in one click
- Row label shows the across-frame summary `(Σ pass / Σ graded ✓)`

### 4. Grid layout fix
`RowGroup` skips appending `RowCopyButton` for CODE_RUBRIC because the rubric row owns its own trailing column. Without this the grid template would overflow by one column on every rubric row.

## Test plan
- [ ] `/dev/checkin/grid` on a goal with `widget: "CODE_RUBRIC"` — each week shows PRs merged that week
- [ ] Click a cell → popover lists PR titles + verdicts + Analyze button
- [ ] Click "Analyze (N)" — grader runs for just that week's ungraded PRs; cell updates to show the new verdicts
- [ ] Trailing "Grade all" — grades every ungraded PR across the displayed weeks
- [ ] Row label shows correct cross-frame pass / graded counts
- [ ] `/dev/checkin?week=W##` single-week view — same flow inline
- [ ] Dashboard `CodeRubricWidget` still works (gradeAll path)
- [ ] No regression on other widget kinds in grid or single-week views
- [ ] No grid layout overflow on CODE_RUBRIC rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)