### PR TITLE
fix(api-client): redirect to /login on 401 from anywhere in the app

### DIFF
--- a/apps/web/src/lib/api-client.js
+++ b/apps/web/src/lib/api-client.js
@@ -23,6 +23,62 @@
 const API_BASE = "/api/v1";
 
 /**
+ * Pages where a 401 is normal and shouldn't bounce the user back to
+ * /login (we're either already on /login, completing an auth flow,
+ * or in a known-public surface). Matched as prefix-or-exact paths.
+ */
+const PUBLIC_AUTH_PATHS = Object.freeze([
+  "/login",
+  "/forgot-password",
+  "/password-reset",
+  "/accept-invite",
+  "/totp-setup",
+  "/oauth/github",
+  "/onboarding", // gated on /me itself; let the page handle its own redirect
+]);
+
+/**
+ * Some 401s mean "you have a partial session, finish step 2" rather
+ * than "your session is gone." Don't redirect on these — the UI is
+ * about to ask for a TOTP code or similar continuation.
+ */
+const NON_REDIRECT_401_CODES = Object.freeze(new Set([
+  "totp_required",
+  // Add more here if future endpoints use 401 to signal "you need to
+  // do X first" rather than "you're not logged in."
+]));
+
+/**
+ * Module-level flag — without this we'd queue N redirects when the
+ * page mounted and N components all fire a 401-able GET in parallel
+ * (dashboard tiles, useSession, useEngagementConfig). The first one
+ * wins; subsequent 401s during the same tick are no-ops.
+ */
+let redirectingToLogin = false;
+
+function maybeRedirectToLogin(errorCode) {
+  if (typeof window === "undefined") return;
+  if (redirectingToLogin) return;
+  if (errorCode && NON_REDIRECT_401_CODES.has(errorCode)) return;
+
+  const path = window.location.pathname || "/";
+  for (const pub of PUBLIC_AUTH_PATHS) {
+    if (path === pub || path.startsWith(`${pub}/`)) return;
+  }
+
+  redirectingToLogin = true;
+  const returnTo = path + (window.location.search || "");
+  // Existing /login page reads `?next=...` (see app/login/page.jsx).
+  const target =
+    returnTo === "/" || returnTo === ""
+      ? "/login"
+      : `/login?next=${encodeURIComponent(returnTo)}`;
+  // Use location.assign (not history.replace) so the back button
+  // doesn't bounce the user between the expired page and login.
+  window.location.replace(target);
+}
+
+/**
  * @typedef {Object} ApiSuccess
  * @property {true} ok
  * @property {number} status
@@ -90,6 +146,12 @@ async function request(method, path, body, init = {}) {
       payload && typeof payload === "object" && payload.error
         ? payload.error
         : { code: `http_${res.status}`, message: `HTTP ${res.status}` };
+    // Global 401 → login redirect (fire-and-forget). Excludes
+    // continuation codes like totp_required and skips when we're
+    // already on a public auth page. See PUBLIC_AUTH_PATHS above.
+    if (res.status === 401) {
+      maybeRedirectToLogin(apiError.code);
+    }
     return { ok: false, status: res.status, error: apiError };
   }
 


### PR DESCRIPTION
## Summary
Until now no central code path watched for 401 responses — every page handled "session expired" itself, and most didn't. A user with an expired cookie would see error toasts / empty states / broken tiles forever instead of being bounced to the login form.

Adds a global guard inside the central `request()` wrapper in `api-client.js`. Any 401 from any API call now triggers a redirect to `/login?next=<currentPath>` once.

## How it decides
| Check | Behavior |
|---|---|
| `window` missing (SSR) | skip |
| Already redirecting (module flag) | skip — prevents N parallel 401s queueing N redirects when a dashboard mounts |
| Error code in `NON_REDIRECT_401_CODES` (today: `totp_required`) | skip — that's "give us the 2nd factor", not "logged out" |
| Already on a public auth page (`/login`, `/forgot-password`, `/password-reset`, `/accept-invite`, `/totp-setup`, `/oauth/github`, `/onboarding`) | skip — `/me` legitimately 401s here pre-login |
| Otherwise | `location.replace("/login?next=<encodedPath>")` |

Uses `location.replace` (not `history.push`) so the back button doesn't bounce between the expired page and login.

## Test plan
- [ ] Log in → open any page that fetches API data (dashboard / checkin / evidence)
- [ ] In DevTools → Application → Cookies → delete `devhub_sid`
- [ ] Navigate or click anything that triggers an API call → page replaces with `/login?next=/dev/checkin` (or wherever you were)
- [ ] Log back in → land on the original page
- [ ] On `/login` while logged out, /me 401s — does NOT loop-redirect
- [ ] During TOTP step (login returned `needsTotp:true`), the page doesn't bounce to /login when /me 401s with `totp_required`

🤖 Generated with [Claude Code](https://claude.com/claude-code)