### PR TITLE
feat(auth): self-serve signup with org signup codes + pending_admin status

### DIFF
--- a/apps/api/src/db/schemas/orgs.schema.ts
+++ b/apps/api/src/db/schemas/orgs.schema.ts
@@ -42,6 +42,21 @@ export const orgsValidator: Document = {
           },
         },
       },
+      signupCodes: {
+        bsonType: ["array", "null"],
+        items: {
+          bsonType: "object",
+          required: ["code", "createdAt", "createdBy", "usedCount"],
+          properties: {
+            code: { bsonType: "string", minLength: 4, maxLength: 64 },
+            createdAt: { bsonType: "date" },
+            createdBy: { bsonType: "objectId" },
+            expiresAt: { bsonType: ["date", "null"] },
+            disabledAt: { bsonType: ["date", "null"] },
+            usedCount: { bsonType: "int", minimum: 0 },
+          },
+        },
+      },
       createdAt: { bsonType: "date" },
       updatedAt: { bsonType: "date" },
     },

--- a/apps/api/src/db/types.ts
+++ b/apps/api/src/db/types.ts
@@ -36,11 +36,39 @@ export interface OrgSettings {
   };
 }
 
+/**
+ * One-shot signup code an admin distributes to people who should be
+ * able to self-sign-up against this org. Embedded as an array on the
+ * org doc so a single Mongo read during signup gets both org +
+ * matching code.
+ *
+ * Codes are globally unique (enforced at insert by the admin
+ * controller). Disabling a code keeps it on the document for
+ * audit-log readability — we never hard-delete used codes.
+ */
+export interface SignupCode {
+  /** The plain-text code users type. Indexed via the parent doc. */
+  code: string;
+  createdAt: Date;
+  createdBy: ObjectId;
+  /** ISO ms. null = never expires (admin's responsibility). */
+  expiresAt: Date | null;
+  /** Set to a Date when admin revokes the code. Null = still active. */
+  disabledAt: Date | null;
+  /** Convenience counter — bumped every successful signup. */
+  usedCount: number;
+}
+
 export interface Org {
   _id: ObjectId;
   slug: string; // url-safe id, e.g. "default"
   name: string;
   settings: OrgSettings;
+  /**
+   * Active + retired signup codes. Optional/nullable for migration
+   * compatibility with pre-signup orgs; readers default to [].
+   */
+  signupCodes?: SignupCode[] | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -72,10 +100,23 @@ export const ALL_USER_ROLES: readonly UserRole[] = [
   "member",
 ] as const;
 
-export type UserStatus = "invited" | "active" | "disabled";
+/**
+ * `pending_admin` is the self-signup status — the user proved email
+ * ownership by knowing the org's signup code, set a password, and (per
+ * policy) completed TOTP enrolment + the onboarding form, but admin
+ * still hasn't assigned them a role / hub. Login works for these
+ * users; they just land on /waiting-approval until admin promotes
+ * them to `active`.
+ */
+export type UserStatus =
+  | "invited"
+  | "pending_admin"
+  | "active"
+  | "disabled";
 
 export const ALL_USER_STATUSES: readonly UserStatus[] = [
   "invited",
+  "pending_admin",
   "active",
   "disabled",
 ] as const;

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -132,3 +132,16 @@ export const inviteAcceptLimiter = buildLimiter({
   max: 20,
   label: "invite-accept",
 });
+
+/**
+ * /signup — 10 per hour per IP. Self-service account creation. The
+ * primary anti-abuse mechanism is the org signup CODE — random
+ * sign-ups without a valid code 400 out. The rate-limit is the
+ * secondary layer: it slows a stuffing attack trying to GUESS codes
+ * from a single host, and also caps total account-creation noise.
+ */
+export const signupLimiter = buildLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+  label: "signup",
+});

--- a/apps/api/src/modules/auth/controller.ts
+++ b/apps/api/src/modules/auth/controller.ts
@@ -70,6 +70,7 @@ import {
   passwordResetRequestSchema,
   passwordResetSchema,
   profileUpdateSchema,
+  signupSchema,
   totpDisableSchema,
   totpVerifySchema,
   type PublicUser,
@@ -134,10 +135,14 @@ export async function loginHandler(
       ? await verifyPassword(password, user.passwordHash)
       : await verifyPassword(password, DUMMY_HASH); // burn time anyway
 
+    // Self-sign-up users land with status="pending_admin" — they need
+    // to be able to log in so they can complete TOTP + onboarding and
+    // then sit on the waiting-approval screen. AuthGuard handles the
+    // actual hub-access gating, so accepting them here is safe.
     const validCredentials =
       !!user &&
       !lockedOut &&
-      user.status === "active" &&
+      (user.status === "active" || user.status === "pending_admin") &&
       !!user.passwordHash &&
       passwordOk;
 
@@ -732,9 +737,13 @@ export async function passwordResetRequestHandler(
 
     // Only mint if the user exists AND can actually reset (not
     // disabled, has set up a password). Either way, return ok.
+    // pending_admin users count — they HAVE a password, they just
+    // don't have a role/hub yet; locking them out of reset would
+    // leave them stranded if they forget the password before admin
+    // approves them.
     if (
       user &&
-      user.status === "active" &&
+      (user.status === "active" || user.status === "pending_admin") &&
       user.passwordHash !== null
     ) {
       const meta = networkMeta(req);
@@ -1180,6 +1189,165 @@ export async function totpDisableHandler(
     });
 
     res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+
+// ─── POST /api/v1/auth/signup (public) ───────────────────────────────
+
+/**
+ * Self-serve signup. The user proves they belong to the org by
+ * supplying a signup code an admin distributed; we create a fresh
+ * user row with `status="pending_admin"`, mint a session, and let
+ * them proceed through TOTP setup + onboarding. They land on
+ * /waiting-approval until admin promotes them to "active".
+ *
+ * Security model:
+ *   - The code is the gate. No code, no signup.
+ *   - Codes can be disabled or expire; both branches are checked.
+ *   - One Mongo round-trip finds both the org AND the matching code
+ *     via $elemMatch on the embedded array.
+ *   - Email uniqueness is enforced at the unique index level — a
+ *     duplicate-key error from Mongo becomes the same generic
+ *     "email_taken" response to the client (no enumeration about
+ *     whether the user is invited / active / pending).
+ *   - role + roles + allowedHubs are intentionally left empty / null
+ *     on the new doc. Admin assigns them via the approval queue.
+ *     Until then the user has zero hub access.
+ */
+export async function signupHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { email, password, displayName, signupCode } =
+      signupSchema.parse(req.body);
+
+    const now = new Date();
+    const orgs = await getOrgsCollection();
+    const org = await orgs.findOne({
+      signupCodes: {
+        $elemMatch: {
+          code: signupCode,
+          disabledAt: null,
+          $or: [{ expiresAt: null }, { expiresAt: { $gt: now } }],
+        },
+      },
+    });
+    if (!org) {
+      throw new HttpError(
+        400,
+        "invalid_signup_code",
+        "Signup code is invalid or expired.",
+      );
+    }
+
+    const users = await getUsersCollection();
+    const existing = await users.findOne({ email });
+    if (existing) {
+      throw new HttpError(
+        400,
+        "email_taken",
+        "An account with this email already exists. Try logging in.",
+      );
+    }
+
+    const passwordHash = await hashPassword(password);
+    const userDoc: User = {
+      _id: undefined as unknown as ObjectId, // assigned by Mongo on insert
+      orgId: org._id,
+      email,
+      passwordHash,
+      // Legacy single-role field needs a value (until the migration
+      // drops it). "member" is the lowest-privilege known role and
+      // confers no hub access on its own — admin assigns real role(s)
+      // during approval.
+      role: "member",
+      roles: null,
+      status: "pending_admin",
+      totpSecret: null,
+      totpEnrolledAt: null,
+      zohoEmployeeId: null,
+      managerId: null,
+      level: null,
+      hireDate: null,
+      displayName,
+      createdAt: now,
+      updatedAt: now,
+      invitedBy: null,
+      invitedAt: null,
+      lastLoginAt: now,
+      failedLoginAttempts: 0,
+      lockedUntil: null,
+      // Hub access is empty — AuthGuard will trap them at the
+      // /waiting-approval screen after they finish TOTP + onboarding.
+      allowedHubs: [],
+      primaryHub: null,
+      // Onboarding NOT yet complete — guard routes them through
+      // /totp-setup → /onboarding → /waiting-approval.
+      onboardingCompletedAt: null,
+      employeeId: null,
+      department: null,
+      engagement: null,
+    };
+
+    let insertedId: ObjectId;
+    try {
+      const result = await users.insertOne(userDoc);
+      insertedId = result.insertedId;
+    } catch (err) {
+      // Race: another signup landed the same email a millisecond
+      // before us, or the email had a leading-zero unique-index
+      // conflict. Surface as "email_taken" to match the explicit
+      // pre-check above so we never reveal the timing.
+      if (err && typeof err === "object" && "code" in err && err.code === 11000) {
+        throw new HttpError(
+          400,
+          "email_taken",
+          "An account with this email already exists.",
+        );
+      }
+      throw err;
+    }
+
+    // Bump the code's usedCount so admins see traction on each code.
+    await orgs.updateOne(
+      { _id: org._id, "signupCodes.code": signupCode },
+      { $inc: { "signupCodes.$.usedCount": 1 }, $set: { updatedAt: now } },
+    );
+
+    // Mint a session. totpVerified=true because there's nothing to
+    // verify yet (no enrolment); totpEnrolled=false trips the
+    // /totp-setup gate downstream.
+    const meta = networkMeta(req);
+    const { sessionId } = await mintSession({
+      userId: insertedId,
+      orgId: org._id,
+      role: userDoc.role,
+      ip: meta.ip,
+      userAgent: meta.ua,
+      totpVerified: true,
+      totpEnrolled: false,
+    });
+    setSessionCookie(res, sessionId);
+
+    await writeAudit({
+      orgId: org._id,
+      actorUserId: insertedId,
+      actorRole: userDoc.role,
+      action: "user.signup",
+      targetType: "user",
+      targetId: insertedId.toHexString(),
+      after: { email, signupCodeUsed: signupCode },
+      ...meta,
+    });
+
+    res.json({
+      user: toPublicUser({ ...userDoc, _id: insertedId }),
+    });
   } catch (err) {
     next(err);
   }

--- a/apps/api/src/modules/auth/routes.ts
+++ b/apps/api/src/modules/auth/routes.ts
@@ -34,6 +34,7 @@ import {
   loginLimiter,
   passwordResetLimiter,
   passwordResetRequestLimiter,
+  signupLimiter,
   totpLimiter,
 } from "../../middleware/rate-limit.js";
 import {
@@ -45,6 +46,7 @@ import {
   meHandler,
   passwordResetHandler,
   passwordResetRequestHandler,
+  signupHandler,
   totpDisableHandler,
   totpEnrolHandler,
   totpVerifyEnrolmentHandler,
@@ -60,6 +62,7 @@ export const authRouter: Router = Router();
 // stuffing attack sweeping many accounts from one host.
 authRouter.post("/login", loginLimiter, loginHandler);
 authRouter.post("/logout", logoutHandler);
+authRouter.post("/signup", signupLimiter, signupHandler);
 authRouter.post("/accept-invite", inviteAcceptLimiter, acceptInviteHandler);
 authRouter.post(
   "/password/reset-request",

--- a/apps/api/src/modules/auth/schemas.ts
+++ b/apps/api/src/modules/auth/schemas.ts
@@ -75,6 +75,23 @@ export type PasswordResetRequestInput = z.infer<
   typeof passwordResetRequestSchema
 >;
 
+/**
+ * Self-serve signup payload. Different from invite-accept because the
+ * user proves "you should be allowed here" via the org's `signupCode`,
+ * not a one-time invite token they got from an admin.
+ *
+ * Display name is required (unlike invite-accept where it's optional)
+ * — the invite handler had a placeholder display name on the user
+ * doc the admin typed; signup has no such fallback.
+ */
+export const signupSchema = z.object({
+  email,
+  password,
+  displayName,
+  signupCode: z.string().min(4).max(64),
+});
+export type SignupInput = z.infer<typeof signupSchema>;
+
 export const passwordResetSchema = z.object({
   token: oneTimeToken,
   password,

--- a/apps/web/src/app/signup/page.jsx
+++ b/apps/web/src/app/signup/page.jsx
@@ -1,0 +1,37 @@
+"use client";
+
+/**
+ * /signup — self-serve account creation. Public; no AuthGuard.
+ *
+ * On success the SignupForm pushes the new user into the session
+ * store, so when we navigate away the AuthGuard sees an authenticated
+ * user and walks them through /totp-setup → /onboarding →
+ * /waiting-approval (status="pending_admin").
+ */
+
+import { useRouter } from "next/navigation";
+import { SignupForm } from "@/features/auth";
+
+export default function SignupPage() {
+  const router = useRouter();
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "var(--bg)",
+        color: "var(--fg)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <SignupForm
+        onSuccess={() => {
+          // AuthGuard on the destination will route them through
+          // /totp-setup → /onboarding → /waiting-approval. Land on
+          // the dashboard root so that chain has a starting point.
+          router.replace("/");
+        }}
+      />
+    </main>
+  );
+}

--- a/apps/web/src/app/waiting-approval/page.jsx
+++ b/apps/web/src/app/waiting-approval/page.jsx
@@ -1,0 +1,27 @@
+"use client";
+
+/**
+ * /waiting-approval — landing page for self-sign-up users while admin
+ * promotes them to "active". Wrapped in AuthGuard so unauthenticated
+ * users get bounced to /login; the guard's `pending_admin` branch
+ * skips its own redirect when pathname is already /waiting-approval
+ * (no loop).
+ */
+
+import { AuthGuard, WaitingApproval } from "@/features/auth";
+
+export default function WaitingApprovalPage() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "var(--bg)",
+        color: "var(--fg)",
+      }}
+    >
+      <AuthGuard>
+        <WaitingApproval />
+      </AuthGuard>
+    </main>
+  );
+}

--- a/apps/web/src/features/auth/auth-guard.jsx
+++ b/apps/web/src/features/auth/auth-guard.jsx
@@ -40,6 +40,7 @@ const AUTH_REQUIRED =
 
 const TOTP_SETUP_PATH = "/totp-setup";
 const ONBOARDING_PATH = "/onboarding";
+const WAITING_APPROVAL_PATH = "/waiting-approval";
 
 export function AuthGuard({ children, fallback = null }) {
   const router = useRouter();
@@ -76,6 +77,21 @@ export function AuthGuard({ children, fallback = null }) {
     !user.onboardingCompletedAt &&
     pathname !== ONBOARDING_PATH;
 
+  // Self-signup gate: TOTP done + onboarding done, but admin hasn't
+  // promoted the user to "active" yet. Trap them at /waiting-approval
+  // regardless of which URL they typed. AuthGuard order matters: this
+  // runs LAST so the user has fully set up their account before we
+  // tell them to wait. Active users skip this branch entirely.
+  const needsApprovalRedirect =
+    AUTH_REQUIRED &&
+    !loading &&
+    !!user &&
+    !needsTotp &&
+    !!user.totpEnrolled &&
+    !!user.onboardingCompletedAt &&
+    user.status === "pending_admin" &&
+    pathname !== WAITING_APPROVAL_PATH;
+
   useEffect(() => {
     if (needsLoginRedirect) {
       const target = `/login${
@@ -92,11 +108,16 @@ export function AuthGuard({ children, fallback = null }) {
     }
     if (needsOnboardingRedirect) {
       router.replace(ONBOARDING_PATH);
+      return;
+    }
+    if (needsApprovalRedirect) {
+      router.replace(WAITING_APPROVAL_PATH);
     }
   }, [
     needsLoginRedirect,
     needsTotpSetupRedirect,
     needsOnboardingRedirect,
+    needsApprovalRedirect,
     pathname,
     router,
   ]);
@@ -106,6 +127,7 @@ export function AuthGuard({ children, fallback = null }) {
   if (!user || needsTotp) return fallback ?? <AuthLoading />;
   if (needsTotpSetupRedirect) return fallback ?? <AuthLoading />;
   if (needsOnboardingRedirect) return fallback ?? <AuthLoading />;
+  if (needsApprovalRedirect) return fallback ?? <AuthLoading />;
   return children;
 }
 

--- a/apps/web/src/features/auth/index.js
+++ b/apps/web/src/features/auth/index.js
@@ -22,6 +22,8 @@ export { AcceptInviteForm } from "./accept-invite-form.jsx";
 export { PasswordResetRequestForm } from "./password-reset-request-form.jsx";
 export { PasswordResetForm } from "./password-reset-form.jsx";
 export { TotpSetupForm } from "./totp-setup-form.jsx";
+export { SignupForm } from "./signup-form.jsx";
+export { WaitingApproval } from "./waiting-approval.jsx";
 export { AuthGuard } from "./auth-guard.jsx";
 export { UserChip } from "./user-chip.jsx";
 export {

--- a/apps/web/src/features/auth/login-form.jsx
+++ b/apps/web/src/features/auth/login-form.jsx
@@ -252,7 +252,7 @@ export function LoginForm({ onSuccess }) {
               just stuck on the 6-digit code; the right recovery there
               is backup codes, not password reset). */}
           <div
-            className="mt-1"
+            className="mt-1 flex flex-col gap-2"
             style={{
               fontFamily: "var(--font-mono)",
               fontSize: 11,
@@ -267,6 +267,16 @@ export function LoginForm({ onSuccess }) {
             >
               Forgot password?
             </Link>
+            <div>
+              Don't have an account?{" "}
+              <Link
+                href="/signup"
+                className="text-accent hover:underline"
+                style={{ fontWeight: 600 }}
+              >
+                Create one
+              </Link>
+            </div>
           </div>
         </form>
       )}

--- a/apps/web/src/features/auth/signup-form.jsx
+++ b/apps/web/src/features/auth/signup-form.jsx
@@ -1,0 +1,239 @@
+"use client";
+
+/**
+ * Self-serve signup form.
+ *
+ *   email + password + display name + org signup code
+ *     → POST /api/v1/auth/signup
+ *     → server creates user with status="pending_admin", mints session
+ *     → useSession() refresh picks up the new user
+ *     → AuthGuard routes them through /totp-setup → /onboarding →
+ *       /waiting-approval
+ *
+ * The signup code is the abuse-control gate. Admins distribute it
+ * over secure channels — Slack/DM, not a public URL. The code lookup
+ * is a single Mongo round-trip on the org doc.
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+import { apiPost } from "@/lib/api-client";
+import { setSession } from "./session-store.js";
+
+const INPUT_STYLE = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 13,
+  padding: "10px 14px",
+  background: "var(--card)",
+  border: "1px solid var(--border-strong)",
+  borderRadius: "var(--radius-sub, 3px)",
+  outline: "none",
+};
+
+const LABEL_STYLE = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  letterSpacing: "0.5px",
+  color: "var(--muted-fg)",
+  textTransform: "uppercase",
+};
+
+export function SignupForm({ onSuccess }) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [signupCode, setSignupCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    const result = await apiPost("/auth/signup", {
+      email,
+      password,
+      displayName,
+      signupCode: signupCode.trim(),
+    });
+    setSubmitting(false);
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+    // Push the new user into the session store so AuthGuard /
+    // useSession reflect the auth state without a /me round-trip.
+    setSession({
+      user: result.data?.user ?? null,
+      loading: false,
+      needsTotp: false,
+      error: null,
+    });
+    onSuccess?.(result.data?.user);
+  }
+
+  const errorMessage = error ? humanizeError(error) : null;
+
+  return (
+    <div className="mx-auto flex max-w-sm flex-col gap-5 py-12">
+      <div>
+        <h1
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display, var(--font-inter-tight))",
+            fontSize: 28,
+            letterSpacing: "-0.8px",
+          }}
+        >
+          Create account
+        </h1>
+        <p
+          className="mt-1 text-muted-fg"
+          style={{ fontSize: 13.5, lineHeight: 1.5 }}
+        >
+          You'll need a signup code from your admin. After signing up, your
+          account waits for admin approval before you can pick a hub.
+        </p>
+      </div>
+
+      <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
+        <label className="flex flex-col gap-1.5">
+          <span style={LABEL_STYLE}>Display name</span>
+          <input
+            type="text"
+            autoComplete="name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            disabled={submitting}
+            autoFocus
+            required
+            minLength={1}
+            maxLength={200}
+            style={INPUT_STYLE}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span style={LABEL_STYLE}>Email</span>
+          <input
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={submitting}
+            required
+            style={INPUT_STYLE}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span style={LABEL_STYLE}>Password</span>
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={submitting}
+            required
+            minLength={8}
+            maxLength={256}
+            style={INPUT_STYLE}
+          />
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              color: "var(--muted-fg)",
+            }}
+          >
+            at least 8 characters
+          </span>
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span style={LABEL_STYLE}>Signup code</span>
+          <input
+            type="text"
+            value={signupCode}
+            onChange={(e) => setSignupCode(e.target.value)}
+            disabled={submitting}
+            required
+            minLength={4}
+            maxLength={64}
+            style={{
+              ...INPUT_STYLE,
+              letterSpacing: "1px",
+              textTransform: "uppercase",
+            }}
+          />
+        </label>
+
+        {errorMessage ? (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11.5,
+              color: "var(--bad)",
+            }}
+          >
+            {errorMessage}
+          </div>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={submitting || !email || !password || !displayName || !signupCode}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: "0.5px",
+            textTransform: "uppercase",
+            background: "var(--accent)",
+            color: "var(--accent-on, #fff)",
+            border: 0,
+            borderRadius: "var(--radius-sub, 3px)",
+            padding: "12px 16px",
+            cursor: submitting ? "wait" : "pointer",
+            opacity: submitting ? 0.6 : 1,
+          }}
+        >
+          {submitting ? "Creating account…" : "Create account"}
+        </button>
+      </form>
+
+      <div
+        className="text-center"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          color: "var(--muted-fg)",
+        }}
+      >
+        Already have an account?{" "}
+        <Link
+          href="/login"
+          style={{ color: "var(--accent)", textDecoration: "underline" }}
+        >
+          Sign in
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function humanizeError(error) {
+  if (!error) return null;
+  switch (error.code) {
+    case "invalid_signup_code":
+      return "Signup code is invalid or expired. Ask your admin for a current one.";
+    case "email_taken":
+      return "An account with this email already exists. Try signing in instead.";
+    case "rate_limited":
+      return "Too many attempts. Wait a few minutes and try again.";
+    case "network_error":
+      return "Network error. Check your connection and try again.";
+    default:
+      return error.message || "Something went wrong. Please try again.";
+  }
+}

--- a/apps/web/src/features/auth/waiting-approval.jsx
+++ b/apps/web/src/features/auth/waiting-approval.jsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * Landing surface for self-sign-up users whose account is still
+ * `status="pending_admin"`. AuthGuard routes them here after they've
+ * finished TOTP setup + onboarding. Stays here until admin promotes
+ * their status to `active` and grants them a role/hub.
+ */
+
+import { useSession } from "./use-session.js";
+
+export function WaitingApproval() {
+  const { user, logout } = useSession();
+
+  return (
+    <div
+      className="mx-auto flex max-w-lg flex-col items-center gap-5 py-16 text-center"
+    >
+      <div
+        aria-hidden
+        style={{
+          fontSize: 40,
+          lineHeight: 1,
+          color: "var(--accent)",
+        }}
+      >
+        ⌛
+      </div>
+      <h1
+        className="font-semibold"
+        style={{
+          fontFamily: "var(--font-display, var(--font-inter-tight))",
+          fontSize: 26,
+          letterSpacing: "-0.5px",
+        }}
+      >
+        Waiting for admin approval
+      </h1>
+      <p
+        className="text-muted-fg"
+        style={{ fontSize: 13.5, lineHeight: 1.55, maxWidth: 420 }}
+      >
+        Thanks{user?.displayName ? `, ${user.displayName}` : ""} — your
+        account is set up. An admin needs to assign you a role and
+        hub before you can start tracking. This usually happens within
+        a business day; reach out to your admin if it's urgent.
+      </p>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          color: "var(--muted-fg)",
+          textAlign: "left",
+          padding: "10px 14px",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius-sub, 3px)",
+          background: "var(--card)",
+        }}
+      >
+        <div>email · {user?.email || "—"}</div>
+        <div>
+          status · <span style={{ color: "var(--accent)" }}>pending_admin</span>
+        </div>
+        {user?.department && <div>department · {user.department}</div>}
+      </div>
+      <button
+        type="button"
+        onClick={() => logout()}
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          letterSpacing: "0.5px",
+          textTransform: "uppercase",
+          color: "var(--muted-fg)",
+          background: "transparent",
+          border: 0,
+          cursor: "pointer",
+          textDecoration: "underline",
+        }}
+      >
+        Sign out
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Lets employees create accounts themselves instead of waiting for an admin invite.

**Flow:**
```
/signup → email + password + display name + signup code
       → user created with status="pending_admin"
       → session minted, user logged in immediately
AuthGuard → /totp-setup → /onboarding → /waiting-approval
       → sits here until admin promotes to "active" and assigns role + hub
```

Admin approval UI lands in PR #101 — until then admins mint signup codes + approve users manually via a script.

## Backend
- New `pending_admin` user status (`active` and `pending_admin` both authenticate, but only `active` has hub access)
- New `SignupCode` embedded array on org docs: `{ code, createdAt, createdBy, expiresAt, disabledAt, usedCount }`
- New `POST /api/v1/auth/signup` — finds org by `$elemMatch` on the code, creates user, mints session, audits, bumps usedCount
- New `signupLimiter` (10/hr per IP) — code is the real gate, this caps noise
- Login + password-reset-request now also accept `pending_admin` (they have a password; locking reset would strand them)

## Frontend
- New `/signup` route + `<SignupForm>` (display name, email, password, signup code)
- New `/waiting-approval` route + `<WaitingApproval>` screen with sign-out
- `AuthGuard` gains a `needsApprovalRedirect` step (LAST in the chain) — TOTP done + onboarding done + status=`pending_admin` → `/waiting-approval`
- Login page gets a "Don't have an account? Create one" link

## How to mint a signup code (until PR #101's admin UI)
```js
db.orgs.updateOne(
  { _id: <orgId> },
  { $push: { signupCodes: {
      code: "ESPACE-2026",
      createdAt: new Date(),
      createdBy: <adminUserId>,
      expiresAt: null,         // or new Date("2026-12-31")
      disabledAt: null,
      usedCount: 0,
  } } }
);
```

## Test plan
- [ ] Mint a signup code via mongosh
- [ ] `/signup` with that code → user created (status=`pending_admin`)
- [ ] Auto-logged-in → bounced to `/totp-setup` → set up TOTP → bounced to `/onboarding` → fill department → bounced to `/waiting-approval`
- [ ] Cannot reach `/dev/*` or other protected hubs until admin promotes
- [ ] Try `/signup` with wrong/expired/disabled code → `400 invalid_signup_code`
- [ ] Try `/signup` with an existing email → `400 email_taken`
- [ ] Existing flows still work: invite + accept-invite, login, password reset
- [ ] Sign out from `/waiting-approval` → lands on `/login`
- [ ] Login as the pending user → routed straight back to `/waiting-approval`
- [ ] Manually promote in mongosh (`status: "active"`, `roles: ["dev"]`, `allowedHubs: ["dev"]`, `primaryHub: "dev"`) → reload → lands in dev hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)