### PR TITLE
fix(api-client): only redirect on "unauthenticated" 401, not every 401

### DIFF
--- a/apps/web/src/lib/api-client.js
+++ b/apps/web/src/lib/api-client.js
@@ -29,6 +29,8 @@ const API_BASE = "/api/v1";
  */
 const PUBLIC_AUTH_PATHS = Object.freeze([
   "/login",
+  "/signup",
+  "/waiting-approval",
   "/forgot-password",
   "/password-reset",
   "/accept-invite",
@@ -38,14 +40,34 @@ const PUBLIC_AUTH_PATHS = Object.freeze([
 ]);
 
 /**
- * Some 401s mean "you have a partial session, finish step 2" rather
- * than "your session is gone." Don't redirect on these — the UI is
- * about to ask for a TOTP code or similar continuation.
+ * ALLOWLIST: the ONLY 401 error codes that mean "your session is gone,
+ * send the user back to /login." Everything else is a 401 from some
+ * OTHER source and should NOT trigger a redirect:
+ *
+ *   - integration_misconfigured  → user's GitHub/GitLab/Jira token is
+ *                                   bad. The widget should render a
+ *                                   reconnect prompt, not bounce auth.
+ *   - http_401 (upstream)        → the integration proxy passed
+ *                                   through a 401 from GitHub/GitLab
+ *                                   /Jira (their auth, not ours).
+ *                                   Same as above.
+ *   - totp_required              → partial session waiting for TOTP.
+ *                                   Login form swaps to step 2; not
+ *                                   a "you're logged out" signal.
+ *   - invalid_credentials,
+ *     invalid_totp_code          → only emitted on /login, which is
+ *                                   already in PUBLIC_AUTH_PATHS, but
+ *                                   defensively NOT in the allowlist.
+ *
+ * Switching from the previous blocklist to this allowlist fixes the
+ * infinite loop where landing in a hub fired off integration calls,
+ * those returned 401 (no tokens yet), api-client redirected to /login,
+ * useSession's /me succeeded (session was fine!), LoginForm saw the
+ * authenticated user and bounced back to the hub, which then fired
+ * the same integration calls and… loop.
  */
-const NON_REDIRECT_401_CODES = Object.freeze(new Set([
-  "totp_required",
-  // Add more here if future endpoints use 401 to signal "you need to
-  // do X first" rather than "you're not logged in."
+const REDIRECT_401_CODES = Object.freeze(new Set([
+  "unauthenticated", // the canonical "no session" signal from requireAuth
 ]));
 
 /**
@@ -59,7 +81,10 @@ let redirectingToLogin = false;
 function maybeRedirectToLogin(errorCode) {
   if (typeof window === "undefined") return;
   if (redirectingToLogin) return;
-  if (errorCode && NON_REDIRECT_401_CODES.has(errorCode)) return;
+  // Allowlist semantics — anything OTHER than the explicit "session is
+  // gone" codes stays on the current page so consumers can render
+  // their own "reconnect integration" / "wrong password" UI.
+  if (!errorCode || !REDIRECT_401_CODES.has(errorCode)) return;
 
   const path = window.location.pathname || "/";
   for (const pub of PUBLIC_AUTH_PATHS) {


### PR DESCRIPTION
## Summary
Fixes the post-signup / post-login infinite refresh loop.

## Root cause (your diagnosis was correct)
The PR #99 logic was "redirect on every 401 except for an explicit blocklist". That's the wrong default — the API and its upstream integrations both return 401 for completely different reasons:

| Code | Source | Should redirect? |
|---|---|---|
| `unauthenticated` | requireAuth middleware | ✅ yes — session is gone |
| `integration_misconfigured` | integrations proxy | ❌ no — UI should prompt to reconnect |
| `http_401` (upstream pass-through) | integrations proxy forwarding GitHub/GitLab/Jira auth | ❌ no — session is fine, integration is bad |
| `totp_required` | login two-step | ❌ no — login form swaps to step 2 |
| `invalid_credentials` / `invalid_totp_code` | login | ❌ no — login form handles itself |

The blocklist couldn't catch upstream pass-through 401s (they have the generic `http_401` code). Result of the loop:

```
1. Land in /dev/* → dashboard tiles fire integration calls
2. Integrations return 401 (no GitHub/GitLab/Jira tokens yet for a new user)
3. api-client redirects to /login
4. LoginForm mounts → useSession.refresh → /me succeeds (session WAS valid!)
5. LoginForm sees authenticated user → calls onSuccess → router.replace(next)
6. Lands back in /dev/* → step 1 again → infinite loop
```

## Fix
Switch from a blocklist to an **allowlist**: ONLY `unauthenticated` triggers the redirect. Verified by grepping every `HttpError(401, …)` in `apps/api/src` — that's the single canonical "session is missing" code.

Also added `/signup` and `/waiting-approval` to `PUBLIC_AUTH_PATHS` — those public surfaces' SessionProvider /me 401s shouldn't bounce away from the page itself (would have caused a similar but more subtle issue).

## Test plan
- [ ] Log in fresh → land in /dev/* without integration tokens → page stays put, no redirect loop
- [ ] Integration widgets show their own "reconnect" UI on the 401
- [ ] Sign up via /signup → walks through /totp-setup → /onboarding → /waiting-approval without bouncing
- [ ] Clear cookie + visit /dev/checkin → ONE clean redirect to /login?next=/dev/checkin
- [ ] /login when not logged in → page renders, no loop
- [ ] TOTP step-2 flow still works (no redirect on `totp_required`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)