### PR TITLE
feat(api): dockerize so the backend can run on any networked host

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Build context tightening — anything below is excluded from `docker
+# build`, which avoids slow uploads + accidental secret leaks.
+
+# Dependency trees (Dockerfile reinstalls cleanly inside the container)
+node_modules
+**/node_modules
+
+# Build outputs (Dockerfile rebuilds from sources)
+**/dist
+**/.next
+**/.turbo
+
+# Local env (NEVER bake into the image — secrets are injected at run
+# time via `--env-file` / docker-compose `env_file`). The .example
+# files are safe to ship.
+.env
+.env.local
+**/.env
+**/.env.local
+!**/.env.example
+
+# Git + editor noise
+.git
+.github
+.vscode
+.idea
+.claude
+*.log
+bash.exe.stackdump
+
+# Frontend — the api image doesn't need apps/web/src at all. The
+# Dockerfile only copies apps/api/ + packages/shared/, but ignoring
+# apps/web reduces context-upload time on large repos.
+apps/web/src
+apps/web/public
+apps/web/.next
+
+# Test / docs noise
+**/*.test.ts
+docs
+.design-reference
+_presentation

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,88 @@
+# syntax=docker/dockerfile:1.7
+#
+# eSpace Dev Hub API container.
+#
+# Two stages: build the TypeScript → JS once, then ship a slim runtime
+# image that only carries what `node dist/server.js` actually needs.
+#
+# Why this exists
+# ───────────────
+# The deployed Vercel function bundles apps/api inside its serverless
+# catch-all (apps/web/src/pages/api/v1/[...path].ts). For users on
+# networks where Vercel can't reach the upstream (e.g. Crealogix's
+# internal GitLab at git.bcn.crealogix.net), we run the SAME Express
+# app as a standalone container — on a host that DOES have line of
+# sight to the upstream — and point Vercel's `API_ORIGIN` env at it
+# (next.config.mjs rewrites /api/v1/* to that origin).
+#
+# Build context is the REPO ROOT, not apps/api. The workspace dep
+# `@espace-devhub/shared` lives one level up, so we copy the whole
+# tree.
+
+# ─── build stage ───────────────────────────────────────────────────
+FROM node:20-alpine AS build
+
+WORKDIR /repo
+
+# Manifests first → keeps the install layer cached when only sources
+# change. We need the workspace topology to be visible to npm so
+# `npm ci` can hoist correctly.
+COPY package.json package-lock.json ./
+COPY apps/api/package.json apps/api/
+COPY apps/web/package.json apps/web/
+COPY packages/shared/package.json packages/shared/
+
+# Install everything (the api's `dependencies` include typescript +
+# @types/* from PR #95 so this is the same install Vercel uses).
+RUN npm ci
+
+# Copy only what the api build needs. We deliberately skip apps/web/src
+# so editing the frontend doesn't bust the api image's cache.
+COPY packages/shared packages/shared
+COPY apps/api apps/api
+
+# Compile TS → dist/. Same step the Vercel build runs.
+RUN npm run build --workspace=@espace-devhub/api
+
+# Trim devDeps to keep the runtime image small. apps/api currently
+# has only `pino-pretty` + `tsx` in devDependencies — neither is
+# needed in production.
+RUN npm prune --omit=dev --workspaces
+
+# ─── runtime stage ─────────────────────────────────────────────────
+FROM node:20-alpine
+
+# `tini` becomes PID 1 so SIGTERM from `docker stop` reaches Node
+# cleanly and Mongo connections drain instead of orphaning.
+RUN apk add --no-cache tini wget
+
+WORKDIR /repo
+
+# Carry over node_modules + the built api + the shared package. We
+# don't run `npm install` here — the build stage already produced a
+# tree-shaken, dev-dep-free install. Copying preserves the workspace
+# layout so the runtime resolves `@espace-devhub/shared` correctly.
+COPY --from=build /repo/node_modules ./node_modules
+COPY --from=build /repo/packages packages
+COPY --from=build /repo/apps/api apps/api
+COPY --from=build /repo/package.json /repo/package-lock.json ./
+
+WORKDIR /repo/apps/api
+
+# Non-root runtime is good hygiene — the `node` user comes with the
+# official image and owns the /repo tree by default when we COPY.
+USER node
+
+ENV NODE_ENV=production
+ENV PORT=4000
+
+EXPOSE 4000
+
+# Express exposes /healthz unconditionally (apps/api/src/modules/health
+# /routes.ts). Wget is from `apk add` above. 30s interval, 5 retries —
+# matches how Vercel's external health probe behaves.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=5 \
+  CMD wget --quiet --tries=1 --spider http://localhost:4000/healthz || exit 1
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "dist/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,20 @@
 # Local development services for the eSpace Dev Hub API.
 #
 # Usage:
-#   docker compose up -d                       # start the core service (mongo)
+#   docker compose up -d                       # core (mongo + api)
+#   docker compose --profile api up -d         # api only (uses external Mongo, e.g. Atlas)
+#   docker compose --profile tunnel up -d      # core + Cloudflare Tunnel (public hostname)
 #   docker compose --profile future up -d      # + redis (reserved for M4+)
 #   docker compose --profile qa up -d          # + jenkins (QA Hub dev)
 #   docker compose down                        # stop (data persists)
 #   docker compose down -v                     # stop + wipe ALL data
+#
+# The `api` service is what makes this useful from a public Vercel
+# frontend — when paired with the `tunnel` profile, Vercel's
+# `API_ORIGIN` env points at the public tunnel hostname and /api/v1/*
+# proxies through to this container. Lets you run the backend on any
+# host with the right network access (e.g. a laptop on Crealogix VPN
+# that can resolve `git.bcn.crealogix.net`).
 #
 # Mongo lives at mongodb://localhost:27017/devhub-dev (configured in
 # apps/api/.env.local). Redis + Jenkins ride on `profiles:` flags so
@@ -32,6 +41,86 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+
+  api:
+    # The eSpace Dev Hub Express API. Same code as the Vercel
+    # serverless catch-all (apps/web/src/pages/api/v1/[...path].ts),
+    # just running as a long-lived Node process inside this container.
+    #
+    # Why a separate "api" profile is NOT enabled here: most local
+    # dev wants the api running alongside Mongo, so it's always-on by
+    # default. If you only want the api against an EXTERNAL Mongo
+    # (e.g. Atlas), stop the mongo service: `docker compose stop mongo`.
+    container_name: espace-devhub-api
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    ports:
+      # Localhost-bound by default. Use the tunnel for external
+      # access; if you need LAN access without a tunnel, change to
+      # "0.0.0.0:4000:4000".
+      - "127.0.0.1:4000:4000"
+    env_file:
+      # Same env file `npm run dev` uses. Required keys:
+      #   MONGO_URI, SESSION_SECRET, INTEGRATION_TOKEN_KEY
+      # Plus integration secrets (RESEND_API_KEY, MISTRAL_API_KEY)
+      # and per-engagement keys (<ENGAGEMENT>_GITHUB_CLIENT_ID, …).
+      - apps/api/.env.local
+    environment:
+      NODE_ENV: production
+      # If MONGO_URI in .env.local points at "mongodb://localhost",
+      # rewrite it to the compose service name `mongo` so the api
+      # container can resolve it. The env_file load wins on conflict,
+      # so set MONGO_URI=mongodb://mongo:27017/devhub-dev in
+      # .env.local if you want the local-mongo path.
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-https://espace-hubs.vercel.app,http://localhost:3000}
+    depends_on:
+      mongo:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:4000/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    # Uncomment if your host's VPN client (e.g. corporate Cisco /
+    # GlobalProtect) doesn't share routes with Docker's bridge —
+    # network_mode: host bypasses Docker networking and uses the
+    # host's interfaces directly so VPN routes apply.
+    # network_mode: "host"
+
+  tunnel:
+    # Optional Cloudflare Tunnel sidecar. Activate with --profile tunnel.
+    # Use case: expose the api on a public hostname so the Vercel
+    # frontend can call it. No inbound firewall changes needed; the
+    # tunnel opens an OUTBOUND persistent connection to Cloudflare's
+    # edge, which then routes external requests through to the api.
+    #
+    # First-time bootstrap (one-off, on your machine):
+    #   cloudflared tunnel login                                   # opens browser, sign in to CF
+    #   cloudflared tunnel create dev-espace-hub                   # creates the tunnel
+    #   cloudflared tunnel token dev-espace-hub                    # copy the token
+    #
+    # Then in a sibling `.env` file (NOT apps/api/.env.local):
+    #   TUNNEL_TOKEN=eyJhIjoi…
+    #
+    # Then in CF dashboard → Zero Trust → Networks → Tunnels →
+    # your tunnel → Public Hostname, point it at http://api:4000
+    # (Docker's service-name DNS resolves `api` to this container).
+    #
+    # Finally, set `API_ORIGIN=https://<your-public-hostname>` on
+    # Vercel + redeploy.
+    container_name: espace-devhub-api-tunnel
+    profiles: ["tunnel"]
+    image: cloudflare/cloudflared:latest
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:?TUNNEL_TOKEN required when --profile tunnel is active. See docs/RUN_LOCALLY.md.}
+    depends_on:
+      api:
+        condition: service_healthy
+    restart: unless-stopped
 
   redis:
     # Reserved for cross-process rate limits + background queues (M4+).

--- a/docs/RUN_LOCALLY.md
+++ b/docs/RUN_LOCALLY.md
@@ -1,0 +1,184 @@
+# Run the backend locally (Docker)
+
+This is the runbook for running `apps/api` as a Docker container —
+either purely local (talking to a local Mongo + your laptop's network)
+or paired with a Cloudflare Tunnel so the Vercel frontend can reach
+it over the public internet.
+
+When you need this: the Vercel-bundled API can't reach private
+upstreams that only resolve on a corporate VPN (e.g. an internal
+GitLab like `git.bcn.crealogix.net`). Running the API on a host
+that's already on that VPN solves the network gap. The frontend
+stays on Vercel.
+
+---
+
+## TL;DR
+
+```bash
+# 1. Make sure apps/api/.env.local has MONGO_URI, SESSION_SECRET,
+#    INTEGRATION_TOKEN_KEY, and the <ENGAGEMENT>_* keys you need.
+cp apps/api/.env.example apps/api/.env.local   # if you don't have one yet, then fill it in
+
+# 2. Boot Mongo + API
+docker compose up -d
+
+# 3. (Optional) expose the API publicly so Vercel can reach it
+echo "TUNNEL_TOKEN=eyJhIjoi…" > .env
+docker compose --profile tunnel up -d
+
+# 4. Point Vercel at the tunnel
+#    Vercel → Settings → Environment Variables → API_ORIGIN=<public-tunnel-host>
+#    Vercel → Deployments → Redeploy
+```
+
+That's it. Visit `https://espace-hubs.vercel.app` (or whatever your
+deploy domain is). Every `/api/v1/*` call now traverses Vercel →
+Cloudflare Tunnel → your `api` container → upstreams visible from
+your host.
+
+---
+
+## What the two services do
+
+| Service | Always-on? | What it is |
+|---|---|---|
+| `mongo` | yes (default profile) | Local MongoDB 7. The api connects to it when `MONGO_URI` points at `mongodb://mongo:27017/devhub-dev`. Skip it (`docker compose stop mongo`) if you want the api to talk to Atlas instead. |
+| `api` | yes (default profile) | The Express server (`apps/api/dist/server.js`) inside a Node 20 Alpine container. Reads `apps/api/.env.local`. Exposes `:4000` to localhost only. |
+| `tunnel` | opt-in (`--profile tunnel`) | A `cloudflare/cloudflared` sidecar that opens an outbound tunnel to Cloudflare's edge. Provides a stable public hostname for the `api` without any inbound firewall changes. |
+
+---
+
+## Three setup shapes
+
+### Shape A — pure local dev, no Vercel involvement
+
+Use when: you just want to develop against `localhost:3000` (Next dev
+server) and talk to your own API on `localhost:4000`.
+
+```bash
+docker compose up -d        # mongo + api both running
+npm run dev:web             # Next.js dev server on :3000, proxies /api/v1/* to :4000
+```
+
+In `apps/web/.env.local`, omit `API_ORIGIN` — Next's rewrite falls
+through to the bundled catch-all, which won't run because the dev
+server's catch-all goes to `localhost:4000` via `next.config.mjs`.
+
+### Shape B — Vercel frontend + your laptop's API (via tunnel)
+
+Use when: you want to test against the public Vercel deploy but the
+API needs to run on a host with line-of-sight to private upstreams
+(your laptop on the corporate VPN).
+
+```bash
+# One-time CF setup (free personal account works)
+cloudflared tunnel login
+cloudflared tunnel create dev-espace-hub
+cloudflared tunnel token dev-espace-hub      # copy the eyJhIjoi… token
+
+# Write the token into .env (NOT apps/api/.env.local)
+echo "TUNNEL_TOKEN=eyJhIjoi…" > .env
+
+# Boot mongo + api + tunnel
+docker compose --profile tunnel up -d
+
+# CF dashboard → Zero Trust → Networks → Tunnels → dev-espace-hub →
+# Public Hostnames → Add public hostname
+#   Subdomain: dev-api
+#   Domain:    <your-cf-zone>
+#   Service:   http://api:4000     ← Docker's service-name DNS
+# Save. Now https://dev-api.<your-cf-zone>.com forwards to the api.
+
+# Vercel → Settings → Environment Variables
+#   API_ORIGIN = https://dev-api.<your-cf-zone>.com
+#   (Production scope)
+# Vercel → Deployments → Redeploy
+
+# Visit https://espace-hubs.vercel.app — all /api/v1/* now flows
+# through your laptop's api.
+```
+
+When you stop the host machine, the tunnel + api both drop. That's
+fine for dev / personal testing. For production, see Shape C.
+
+### Shape C — production: persistent host inside Crealogix's network
+
+Same compose file, different host:
+
+```bash
+# On a Linux VM inside Crealogix's network that can reach
+# git.bcn.crealogix.net (or whatever private upstream you need):
+git clone https://github.com/nova-sudo/eSpaceDev.git
+cd eSpaceDev
+# Copy production env values into apps/api/.env.local — same set of
+# keys, but values pointing at the production Mongo (Atlas), the
+# production engagement integrations, etc.
+echo "TUNNEL_TOKEN=eyJhIjoi…" > .env    # production CF tunnel token
+
+docker compose --profile tunnel up -d
+
+# That's it — the VM runs the API forever. systemd / Watchtower can
+# auto-restart the container on host reboot.
+```
+
+Operational extras you probably want on a real host:
+- A systemd unit that runs `docker compose --profile tunnel up`
+  on boot
+- Log shipping (the container logs to stdout, so `docker logs` or
+  any log driver works — `fluentd`, `journald`, etc.)
+- Image-update automation: `watchtower` polls a registry and
+  redeploys when you push a new build
+
+---
+
+## Common gotchas
+
+### "Can't connect to MongoDB" inside the container
+
+If your `MONGO_URI` is `mongodb://localhost:27017/...`, that resolves
+to the container's OWN localhost (which has no Mongo). Change it to
+`mongodb://mongo:27017/devhub-dev` so Docker's service-name DNS
+points at the `mongo` container.
+
+If you're using Atlas, paste the Atlas SRV URI as-is — it's public
+DNS, works the same inside the container as outside.
+
+### "Cannot reach git.bcn.crealogix.net from inside the container"
+
+The container shares the host's network via the default bridge
+driver — but some VPN clients (Cisco AnyConnect, GlobalProtect)
+don't push routes into the bridge. If the api inside Docker can't
+reach an upstream that the host CAN reach, edit
+`docker-compose.yml`:
+
+```yaml
+api:
+  network_mode: "host"    # uncomment this; remove `ports:` (no needed)
+```
+
+This makes the container share the host's loopback + interfaces
+directly, so VPN routes apply unchanged.
+
+### Tunnel won't start: "TUNNEL_TOKEN required"
+
+You activated `--profile tunnel` without setting the env. Either:
+- Add `TUNNEL_TOKEN=…` to a `.env` file in the repo root, or
+- Inline: `TUNNEL_TOKEN=… docker compose --profile tunnel up -d`
+
+### "Build is slow / fails after editing apps/web"
+
+The Dockerfile only copies `apps/api/` and `packages/shared/` so
+editing the frontend should NOT bust the api image cache. If you're
+seeing slow rebuilds, double-check that `.dockerignore` excludes
+`apps/web/.next` and `apps/web/node_modules`.
+
+---
+
+## When to stop using this
+
+If/when Crealogix IT exposes their internal GitLab via a public
+hostname (or whitelists Vercel's egress IP via Pro Secure Compute),
+you can revert to the Vercel-bundled API by un-setting `API_ORIGIN`
+on Vercel. The serverless catch-all takes over again; this whole
+runbook becomes optional.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "services:up": "docker compose up -d",
     "services:down": "docker compose down",
     "services:reset": "docker compose down -v",
+    "api:docker:build": "docker compose build api",
+    "api:docker:up": "docker compose up -d api",
+    "api:docker:logs": "docker compose logs -f api",
+    "api:docker:tunnel": "docker compose --profile tunnel up -d",
     "admin:create": "npm run admin:create --workspace=@espace-devhub/api --"
   }
 }


### PR DESCRIPTION
## The problem this solves
When the user's network has private upstreams (e.g. Crealogix's internal GitLab at `git.bcn.crealogix.net` → `192.168.104.31`), Vercel's serverless functions can't reach them — they're in AWS, the upstream is corporate-only and not on public DNS. We confirmed this earlier:

```
nslookup git.bcn.crealogix.net 1.1.1.1
  → *** can't find git.bcn.crealogix.net: Non-existent domain
```

Solution: move the backend to a host that IS on the right network, point Vercel at it. The Express app is already deploy-shape-agnostic — same code ran by Vercel's serverless catch-all runs unchanged in a container.

## What ships

| File | What it is |
|---|---|
| `apps/api/Dockerfile` | Multi-stage Node 20 Alpine build → slim runtime image. Runs as `node` user, `tini` as PID 1, `/healthz` healthcheck. |
| `.dockerignore` | Tight build context (no `node_modules`, no `.next`, no `.env*`, no `apps/web/src`) |
| `docker-compose.yml` | Adds `api` (always-on, reads `apps/api/.env.local`, binds `127.0.0.1:4000`) and `tunnel` (`--profile tunnel`, Cloudflare Tunnel sidecar) to the existing Mongo dev compose. |
| `package.json` scripts | `api:docker:build`, `api:docker:up`, `api:docker:logs`, `api:docker:tunnel` |
| `docs/RUN_LOCALLY.md` | Runbook for three shapes (local dev / Vercel+tunnel / production VM) |

## Three setup shapes documented in the runbook

- **Shape A — local-only dev:** `docker compose up -d` + `npm run dev:web`. No tunnel.
- **Shape B — Vercel frontend + your laptop's API + tunnel:** zero IT involvement. Works today for testing against Crealogix's internal GitLab from your VPN-connected laptop. Set `API_ORIGIN` on Vercel → redeploy.
- **Shape C — production VM inside the target network:** same compose file, runs always-on on a Crealogix-side VM. The "ask" for IT becomes just "give us a Linux VM that can reach `git.bcn.crealogix.net`."

## What it doesn't touch

- Code in `apps/api/src/**` — the Express server is already container-friendly; `dist/server.js` boots on any host.
- The Vercel-bundled serverless catch-all at `apps/web/src/pages/api/v1/[...path].ts` — stays as the default when `API_ORIGIN` is unset, so this PR is non-destructive.

## Test plan
- [ ] `docker compose up -d` boots both `mongo` and `api`, both pass healthcheck
- [ ] `curl http://localhost:4000/healthz` returns 200 from the container
- [ ] On a Crealogix-VPN'd host, the `api` container can reach `git.bcn.crealogix.net` (test by saving a PAT in the integration UI and seeing the /user verify call succeed)
- [ ] `docker compose --profile tunnel up -d` with `TUNNEL_TOKEN` set boots the tunnel; CF dashboard shows the connection
- [ ] After setting `API_ORIGIN=<tunnel-host>` on Vercel + redeploy, `/api/v1/*` calls from `espace-hubs.vercel.app` flow through the tunnel and into the container
- [ ] Un-setting `API_ORIGIN` + redeploy reverts to the bundled Vercel function (no regression on the existing path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)