### PR TITLE
feat(desktop): Phase 1 — Electron companion app (tray + Docker control)

### DIFF
--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+dist-electron/
+*.log
+.vite/

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,0 +1,71 @@
+# `@espace-devhub/desktop` — Companion app
+
+Desktop tray app that runs the eSpace Dev Hub **backend container** on
+a user's machine. The deployed Vercel frontend can then route API
+calls through to it (via a Cloudflare Tunnel), giving the user access
+to private resources their machine can reach but Vercel cannot — for
+example, Crealogix's internal GitLab at `git.bcn.crealogix.net`.
+
+## Phase 1 (this directory, today)
+
+What works:
+
+- ✅ Tray icon + window UI
+- ✅ Start / stop the `docker compose --profile tunnel` stack
+- ✅ Live API healthcheck against `localhost:4000/healthz`
+- ✅ Persisted settings (repo path, Cloudflare Tunnel token, auto-start)
+- ✅ Logs panel tailing the docker compose output
+
+What's deferred:
+
+- 🚧 FortiClient VPN automation (Phase 2)
+- 🚧 Per-user Cloudflare Tunnel auto-provisioning (Phase 3)
+- 🚧 Server-side per-user `API_ORIGIN` routing (Phase 3)
+- 🚧 Code signing + auto-update (Phase 4)
+- 🚧 First-run onboarding wizard (Phase 4)
+
+## Dev quick start
+
+This app is intentionally **NOT** part of the root npm workspaces —
+Electron's ~300MB install would slow every web/api iteration on
+Vercel. Install deps explicitly:
+
+```bash
+cd apps/desktop
+npm install                              # one-time, pulls electron + electron-builder
+npm run dev                              # Vite HMR + Electron, two-process dev
+```
+
+Vite serves the renderer on `:5173`; Electron loads that URL in dev
+mode and watches for main-process rebuilds.
+
+## Build an installer locally
+
+```bash
+cd apps/desktop
+npm run dist                             # Windows NSIS .exe in dist-electron/
+```
+
+The build is **unsigned** in Phase 1. Windows Defender SmartScreen
+will warn the user on first launch ("Unknown publisher" → More info
+→ Run anyway). Code signing comes in Phase 4.
+
+## How users will use it
+
+1. Install Docker Desktop (one-time)
+2. Install this companion app (one-time)
+3. Clone the espace-devhub repo somewhere on disk
+4. Open the companion, point it at the repo path, paste their CF
+   tunnel token
+5. Click **Start backend** — Docker boots `mongo` + `api` + a
+   Cloudflare Tunnel sidecar
+6. Open the Vercel-deployed app in their browser; the frontend routes
+   API calls through the user's tunnel
+
+Phase 2 collapses step 4's "paste tunnel token" into "click Sign in
+to Cloudflare" + auto-provisions a tunnel.
+
+Phase 3 collapses the "open the Vercel app and it just works" into
+literally that — currently the user must also set `API_ORIGIN` on
+Vercel manually; phase 3 makes the frontend look up the routing
+target per-user from the API.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,0 +1,62 @@
+# Electron-builder configuration for packaging the companion app.
+#
+# Phase 1 ships an UNSIGNED NSIS installer for Windows + a portable
+# DMG for macOS. Code signing + auto-update wiring lands in Phase 4
+# (needs Authenticode cert + Apple Developer ID + a release pipeline).
+#
+# Test a local build with:
+#   cd apps/desktop
+#   npm run dist             # → dist-electron/eSpace Dev Hub Companion-0.1.0.exe
+#
+# The installer drops the app under `%LocalAppData%\Programs\eSpace
+# Dev Hub Companion\`. Users can move it elsewhere; the companion
+# resolves the repo path from its settings store, not from its own
+# install path.
+
+appId: ai.trybytes.espace-devhub.companion
+productName: eSpace Dev Hub Companion
+copyright: Copyright © 2026 eSpace
+artifactName: ${productName}-${version}-${os}-${arch}.${ext}
+
+directories:
+  buildResources: build
+  output: dist-electron
+
+# We bundle the dist/ output of `tsc -p tsconfig.node.json` (main +
+# preload) and `vite build` (renderer). `files:` includes everything
+# the runtime needs; node_modules is pulled in automatically.
+files:
+  - dist/**/*
+  - package.json
+  - "!node_modules/**/{CHANGELOG.md,README.md,LICENSE,*.d.ts.map}"
+
+# Don't try to pack the local Docker engine or the user's repo into
+# the installer — the companion ASSUMES Docker Desktop is installed
+# and the user has a checkout somewhere. Both get resolved at runtime.
+
+win:
+  target:
+    - target: nsis
+      arch: [x64]
+  icon: build/icon.ico
+
+nsis:
+  oneClick: false
+  perMachine: false
+  allowToChangeInstallationDirectory: true
+  createDesktopShortcut: true
+  createStartMenuShortcut: true
+  shortcutName: eSpace Dev Hub Companion
+
+mac:
+  target:
+    - target: dmg
+      arch: [arm64, x64]
+  category: public.app-category.developer-tools
+  icon: build/icon.icns
+
+linux:
+  target:
+    - AppImage
+  category: Development
+  icon: build/icon.png

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@espace-devhub/desktop",
+  "version": "0.1.0",
+  "private": true,
+  "description": "eSpace Dev Hub — desktop companion (Crealogix Docker + VPN runner).",
+  "main": "dist/main/index.js",
+  "scripts": {
+    "dev": "concurrently -k -n vite,electron -c blue,green \"npm:dev:vite\" \"npm:dev:electron\"",
+    "dev:vite": "vite",
+    "dev:electron": "wait-on tcp:5173 && tsc -p tsconfig.node.json && electron .",
+    "build": "tsc -p tsconfig.node.json && vite build",
+    "dist": "npm run build && electron-builder --win nsis",
+    "dist:all": "npm run build && electron-builder -mwl",
+    "typecheck": "tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.web.json --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^22.18.10",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "concurrently": "^9.1.0",
+    "electron": "^33.2.0",
+    "electron-builder": "^25.1.8",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.5",
+    "wait-on": "^8.0.1"
+  }
+}

--- a/apps/desktop/src/main/docker.ts
+++ b/apps/desktop/src/main/docker.ts
@@ -1,0 +1,149 @@
+/**
+ * Docker compose control — wraps `docker compose` shellouts so the
+ * renderer can talk to them via IPC.
+ *
+ * Strategy: each operation spawns `docker compose` against the repo's
+ * docker-compose.yml. We resolve the repo path from the settings store
+ * (`repoPath`) so the companion app can be installed in `Program Files`
+ * while pointing at the user's checkout anywhere on disk.
+ *
+ * Why shell out instead of using a Docker SDK
+ * ────────────────────────────────────────────
+ *   - Docker Desktop ships with the `docker` CLI; the SDK doesn't
+ *     ship a default. Shelling out is the most-portable way.
+ *   - The compose stack is defined declaratively in
+ *     docker-compose.yml — we don't need fine-grained container
+ *     control here; we just want "up" and "down."
+ *
+ * Status detection
+ * ────────────────
+ * We track an in-process boolean for "we kicked off a start." This
+ * lets the tray menu reflect "starting" between the click and the
+ * first successful healthcheck. The healthcheck (in `health.ts`) is
+ * the real source of truth for "the API is reachable"; this flag
+ * just smooths the UI.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { settings } from "./settings.js";
+
+interface RunResult {
+  ok: boolean;
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+let running = false;
+let lastError: string | null = null;
+let logTail: string[] = [];
+
+const LOG_TAIL_MAX = 500;
+
+function repoPath(): string {
+  const explicit = settings.get<string>("repoPath", "");
+  if (explicit && explicit.trim()) return explicit;
+  // Best-guess default: run from wherever Electron was launched. This
+  // works in dev (we cwd to repo root) but in a packaged app the user
+  // MUST set repoPath via the settings UI before Start works.
+  return process.cwd();
+}
+
+function dockerComposeArgs(...extra: string[]): string[] {
+  // `--profile tunnel` brings up the optional CF tunnel sidecar
+  // alongside mongo + api. The companion's whole job is to expose
+  // the api to a Vercel frontend through CF Tunnel, so we want the
+  // tunnel container running by default.
+  return ["compose", "--profile", "tunnel", ...extra];
+}
+
+function run(args: string[]): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const cwd = repoPath();
+    const child: ChildProcess = spawn("docker", args, {
+      cwd,
+      shell: false,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (d) => {
+      const chunk = d.toString();
+      stdout += chunk;
+      pushLog(chunk);
+    });
+    child.stderr?.on("data", (d) => {
+      const chunk = d.toString();
+      stderr += chunk;
+      pushLog(chunk);
+    });
+    child.on("error", (err) => {
+      // `docker` not on PATH → most common cause of `spawn ENOENT` on
+      // a machine where Docker Desktop isn't installed yet.
+      lastError = err.message;
+      resolve({ ok: false, code: null, stdout, stderr: err.message });
+    });
+    child.on("close", (code) => {
+      resolve({ ok: code === 0, code, stdout, stderr });
+    });
+  });
+}
+
+function pushLog(line: string): void {
+  // Keep the most-recent LOG_TAIL_MAX lines in memory so the UI's
+  // "tail logs" panel can show context after the fact, without the
+  // app holding onto unbounded buffers.
+  const split = line.split(/\r?\n/).filter(Boolean);
+  for (const s of split) {
+    logTail.push(s);
+    if (logTail.length > LOG_TAIL_MAX) logTail.shift();
+  }
+}
+
+export async function startBackend(): Promise<{ ok: boolean; message: string }> {
+  lastError = null;
+  pushLog("[companion] starting docker compose --profile tunnel up -d");
+  const res = await run(dockerComposeArgs("up", "-d"));
+  if (!res.ok) {
+    running = false;
+    lastError = res.stderr || `docker exited with code ${res.code}`;
+    return { ok: false, message: lastError };
+  }
+  running = true;
+  pushLog("[companion] docker compose up -d returned 0");
+  return { ok: true, message: "Backend started" };
+}
+
+export async function stopBackend(
+  options: { silent?: boolean } = {},
+): Promise<{ ok: boolean; message: string }> {
+  if (!options.silent) {
+    pushLog("[companion] stopping docker compose stack");
+  }
+  const res = await run(dockerComposeArgs("down"));
+  if (!res.ok) {
+    lastError = res.stderr || `docker exited with code ${res.code}`;
+    return { ok: false, message: lastError };
+  }
+  running = false;
+  if (!options.silent) {
+    pushLog("[companion] docker compose down returned 0");
+  }
+  return { ok: true, message: "Backend stopped" };
+}
+
+export function backendStatus(): {
+  running: boolean;
+  lastError: string | null;
+  repoPath: string;
+} {
+  return {
+    running,
+    lastError,
+    repoPath: repoPath(),
+  };
+}
+
+export function tailLogs(lines: number = 100): string[] {
+  return logTail.slice(-Math.max(1, Math.min(lines, LOG_TAIL_MAX)));
+}

--- a/apps/desktop/src/main/health.ts
+++ b/apps/desktop/src/main/health.ts
@@ -1,0 +1,53 @@
+/**
+ * API healthcheck — single-shot ping to the local Express server.
+ *
+ * The IPC handler calls this on demand from the renderer; the
+ * renderer polls it on a short interval (e.g. every 3s) to show a
+ * green/red indicator next to "Backend status."
+ */
+
+const HEALTH_URL = "http://localhost:4000/healthz";
+const TIMEOUT_MS = 1500;
+
+export async function pingApi(): Promise<{
+  ok: boolean;
+  status: number | null;
+  latencyMs: number | null;
+  error: string | null;
+}> {
+  const start = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const res = await fetch(HEALTH_URL, {
+      method: "GET",
+      signal: controller.signal,
+      // Don't follow redirects — /healthz should be a flat 200. A
+      // 3xx response means we hit the wrong server; surface that
+      // instead of chasing it.
+      redirect: "manual",
+    });
+    clearTimeout(timer);
+    return {
+      ok: res.ok,
+      status: res.status,
+      latencyMs: Date.now() - start,
+      error: null,
+    };
+  } catch (err) {
+    clearTimeout(timer);
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: null,
+      latencyMs: null,
+      // Common reasons:
+      //   ECONNREFUSED   - container is down OR stopped
+      //   ETIMEDOUT      - container is starting but not listening yet
+      //   AbortError     - our own timeout fired
+      // Surface the raw message so the UI can show something useful.
+      error: message,
+    };
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,0 +1,255 @@
+/**
+ * Electron main process — eSpace Dev Hub companion.
+ *
+ * Responsibilities (Phase 1):
+ *   - Single window UI for the user
+ *   - System tray icon with quick-action menu (window visible / quit)
+ *   - IPC bridge exposing Docker compose control + API healthcheck
+ *   - Persisted settings via electron-store (CF tunnel token, last
+ *     known repo path, auto-start on login)
+ *
+ * NOT in Phase 1:
+ *   - FortiClient automation (Phase 2)
+ *   - CF tunnel auto-provisioning (Phase 3)
+ *   - Per-user API_ORIGIN registration (Phase 3)
+ *   - Auto-update (Phase 4)
+ *
+ * The companion app's job is to make running the eSpace Dev Hub
+ * backend container a one-click affair for Crealogix devs whose
+ * laptops are the only network-route to git.bcn.crealogix.net. This
+ * Phase 1 wires the controls and surfaces; future phases automate
+ * the steps the user still does by hand (connecting VPN, registering
+ * the tunnel with the server).
+ */
+
+import { app, BrowserWindow, Tray, Menu, ipcMain, shell, nativeImage } from "electron";
+import path from "node:path";
+import { startBackend, stopBackend, backendStatus, tailLogs } from "./docker";
+import { pingApi } from "./health";
+import { settings } from "./settings";
+
+// __dirname is available natively in CommonJS — no fileURLToPath
+// gymnastics needed. Electron's main process is CJS by default; we
+// keep that to avoid the ESM-in-Electron rough edges still present
+// in v33.
+const isDev = process.env.NODE_ENV === "development";
+
+let mainWindow: BrowserWindow | null = null;
+let tray: Tray | null = null;
+
+// Single-instance guard — without this, double-clicking the tray
+// icon or the desktop shortcut would spawn parallel Electron
+// processes, each trying to own port 4000 / the tunnel.
+const gotLock = app.requestSingleInstanceLock();
+if (!gotLock) {
+  app.quit();
+  process.exit(0);
+}
+
+app.on("second-instance", () => {
+  // Someone tried to launch a second instance — focus the existing
+  // window instead of spawning a new one.
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.show();
+    mainWindow.focus();
+  }
+});
+
+function createWindow(): BrowserWindow {
+  const win = new BrowserWindow({
+    width: 720,
+    height: 520,
+    minWidth: 540,
+    minHeight: 420,
+    title: "eSpace Dev Hub — Companion",
+    backgroundColor: "#0e1116",
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, "..", "preload", "index.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false, // preload needs Node access to call the IPC bridge
+    },
+  });
+
+  // Window starts hidden + reveals once content is ready — avoids
+  // the blank-white flash on Windows.
+  win.once("ready-to-show", () => win.show());
+
+  // Closing the window minimizes to tray on Windows/Linux — the app
+  // keeps running. macOS gets the classic "click dock icon to bring
+  // back" behavior via the activate event below.
+  win.on("close", (e) => {
+    if (!(app as unknown as { isQuitting?: boolean }).isQuitting) {
+      e.preventDefault();
+      win.hide();
+    }
+  });
+
+  if (isDev) {
+    win.loadURL("http://localhost:5173");
+    win.webContents.openDevTools({ mode: "detach" });
+  } else {
+    win.loadFile(path.join(__dirname, "..", "renderer", "index.html"));
+  }
+
+  return win;
+}
+
+function createTray(): Tray {
+  // Tray icon — a simple 16x16 PNG. Falling back to an empty native
+  // image if the asset is missing keeps the app from crashing on a
+  // fresh checkout where bundling hasn't packaged the icons yet.
+  const iconPath = path.join(__dirname, "..", "..", "assets", "tray.png");
+  let icon: Electron.NativeImage;
+  try {
+    icon = nativeImage.createFromPath(iconPath);
+    if (icon.isEmpty()) icon = nativeImage.createEmpty();
+  } catch {
+    icon = nativeImage.createEmpty();
+  }
+
+  const t = new Tray(icon);
+  t.setToolTip("eSpace Dev Hub Companion");
+
+  const rebuildMenu = () => {
+    const status = backendStatus();
+    const menu = Menu.buildFromTemplate([
+      {
+        label: `Backend: ${status.running ? "running" : "stopped"}`,
+        enabled: false,
+      },
+      { type: "separator" },
+      {
+        label: "Open companion window",
+        click: () => {
+          if (!mainWindow) mainWindow = createWindow();
+          mainWindow.show();
+          mainWindow.focus();
+        },
+      },
+      {
+        label: status.running ? "Stop backend" : "Start backend",
+        click: async () => {
+          if (status.running) {
+            await stopBackend();
+          } else {
+            await startBackend();
+          }
+          rebuildMenu();
+        },
+      },
+      { type: "separator" },
+      {
+        label: "Quit companion",
+        click: () => {
+          (app as unknown as { isQuitting?: boolean }).isQuitting = true;
+          app.quit();
+        },
+      },
+    ]);
+    t.setContextMenu(menu);
+  };
+  rebuildMenu();
+
+  // Refresh the menu's "running/stopped" label every 5s.
+  setInterval(rebuildMenu, 5_000);
+
+  // Single-click on Windows opens the window. macOS uses the menu
+  // bar item differently (right-click to see menu, left-click also
+  // shows it by default).
+  t.on("click", () => {
+    if (!mainWindow) mainWindow = createWindow();
+    if (mainWindow.isVisible()) {
+      mainWindow.focus();
+    } else {
+      mainWindow.show();
+    }
+  });
+
+  return t;
+}
+
+// ─── IPC bridge ─────────────────────────────────────────────────────
+// All preload-exposed channels listed in one place so the public
+// surface is auditable. Each handler returns a serialisable result
+// (or throws — Electron forwards thrown errors back to the renderer).
+
+ipcMain.handle("backend:start", async () => {
+  return startBackend();
+});
+
+ipcMain.handle("backend:stop", async () => {
+  return stopBackend();
+});
+
+ipcMain.handle("backend:status", async () => {
+  return backendStatus();
+});
+
+ipcMain.handle("backend:logs", async (_event, { lines = 100 } = {}) => {
+  return tailLogs(lines);
+});
+
+ipcMain.handle("api:ping", async () => {
+  return pingApi();
+});
+
+ipcMain.handle("settings:get", async () => {
+  return settings.all();
+});
+
+ipcMain.handle("settings:set", async (_event, patch: Record<string, unknown>) => {
+  settings.patch(patch);
+  return settings.all();
+});
+
+ipcMain.handle("shell:open-external", async (_event, url: string) => {
+  if (typeof url !== "string") throw new Error("url must be a string");
+  // Defensive — only allow http(s) URLs out of the companion. We
+  // don't want a renderer compromise to be able to launch arbitrary
+  // protocol handlers on the user's machine.
+  if (!/^https?:\/\//.test(url)) {
+    throw new Error("only http(s) URLs are allowed");
+  }
+  await shell.openExternal(url);
+});
+
+// ─── lifecycle ──────────────────────────────────────────────────────
+
+app.whenReady().then(() => {
+  // Apply the persisted auto-start setting on app launch. The user
+  // can toggle this from the settings UI later.
+  if (settings.get("autoStartAtLogin", false)) {
+    app.setLoginItemSettings({ openAtLogin: true });
+  }
+
+  mainWindow = createWindow();
+  tray = createTray();
+  void tray; // keep the ref alive — tray instances are GC'd otherwise
+});
+
+app.on("activate", () => {
+  // macOS — clicking the dock icon with no windows open re-creates one.
+  if (BrowserWindow.getAllWindows().length === 0) {
+    mainWindow = createWindow();
+  } else if (mainWindow) {
+    mainWindow.show();
+  }
+});
+
+app.on("window-all-closed", () => {
+  // Default Electron quits on window-close on Windows/Linux. We
+  // explicitly DON'T — the tray keeps running. macOS already keeps
+  // the app alive when all windows close.
+  // (Quit only via the tray "Quit" menu or `app.isQuitting = true`.)
+});
+
+app.on("before-quit", () => {
+  // Best-effort: stop the backend container when the user quits the
+  // companion. Without this, `docker compose up -d` would leave a
+  // container running in the background even after the companion is
+  // gone — surprising for the user.
+  void stopBackend({ silent: true });
+});

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -1,0 +1,82 @@
+/**
+ * Tiny JSON-file store.
+ *
+ * Schema (intentionally flat — easier to extend without migrations):
+ *   repoPath          string   absolute path to the user's espace-devhub checkout
+ *   tunnelToken       string   Cloudflare Tunnel token (used by docker compose's tunnel sidecar)
+ *   autoStartAtLogin  boolean  whether the companion launches at OS sign-in
+ *
+ * Storage location (electron's app.getPath("userData")):
+ *   Windows: %APPDATA%/eSpace Dev Hub Companion/config.json
+ *   macOS:   ~/Library/Application Support/eSpace Dev Hub Companion/config.json
+ *   Linux:   ~/.config/eSpace Dev Hub Companion/config.json
+ *
+ * We rolled our own instead of using electron-store because v10 of
+ * that library is pure ESM — pulling it into a CommonJS Electron main
+ * process triggers the "Cannot use import statement outside a module"
+ * dance Electron 33 still has rough edges around. ~40 LOC of JSON I/O
+ * is the smaller cost.
+ *
+ * SECURITY NOTE: the tunnel token is stored in plaintext. Phase 1
+ * accepts that — the token only lets someone with filesystem access
+ * route traffic to YOUR tunnel; they'd still need the api's own auth
+ * to do anything useful with it. Phase 2/4 moves this into the OS
+ * keychain via electron's safeStorage.
+ */
+
+import { app } from "electron";
+import fs from "node:fs";
+import path from "node:path";
+
+interface CompanionSchema {
+  repoPath?: string;
+  tunnelToken?: string;
+  autoStartAtLogin?: boolean;
+}
+
+const FILE_NAME = "config.json";
+
+function configPath(): string {
+  return path.join(app.getPath("userData"), FILE_NAME);
+}
+
+function read(): CompanionSchema {
+  try {
+    const raw = fs.readFileSync(configPath(), "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as CompanionSchema;
+    }
+    return {};
+  } catch {
+    // File missing or unreadable → start fresh. We never throw from
+    // this path so the companion can render even on a corrupted
+    // settings file (user can re-enter their values).
+    return {};
+  }
+}
+
+function write(data: CompanionSchema): void {
+  const p = configPath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(data, null, 2), "utf8");
+}
+
+export const settings = {
+  all(): CompanionSchema {
+    return read();
+  },
+  get<T>(key: keyof CompanionSchema, fallback: T): T {
+    const v = read()[key];
+    return v === undefined ? fallback : (v as unknown as T);
+  },
+  set<K extends keyof CompanionSchema>(key: K, value: CompanionSchema[K]): void {
+    const cur = read();
+    cur[key] = value;
+    write(cur);
+  },
+  patch(p: Partial<CompanionSchema>): void {
+    const cur = read();
+    write({ ...cur, ...p });
+  },
+};

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Preload script — runs in the renderer's process but with Node
+ * privileges available. Uses contextBridge to expose a TYPED, MINIMAL
+ * API to the renderer's `window.companion`.
+ *
+ * Rule of thumb: this file is the public surface of the main process.
+ * If a renderer needs something that isn't here, ADD A NEW BRIDGE
+ * METHOD (and a matching ipcMain.handle in main/index.ts). Don't ever
+ * grant the renderer raw `ipcRenderer` access — that's a security
+ * footgun if the renderer ever loads remote content.
+ */
+
+import { contextBridge, ipcRenderer } from "electron";
+
+const api = {
+  backend: {
+    start: () => ipcRenderer.invoke("backend:start"),
+    stop: () => ipcRenderer.invoke("backend:stop"),
+    status: () => ipcRenderer.invoke("backend:status"),
+    logs: (lines?: number) => ipcRenderer.invoke("backend:logs", { lines }),
+  },
+  api: {
+    ping: () => ipcRenderer.invoke("api:ping"),
+  },
+  settings: {
+    get: () => ipcRenderer.invoke("settings:get"),
+    set: (patch: Record<string, unknown>) =>
+      ipcRenderer.invoke("settings:set", patch),
+  },
+  shell: {
+    openExternal: (url: string) =>
+      ipcRenderer.invoke("shell:open-external", url),
+  },
+} as const;
+
+contextBridge.exposeInMainWorld("companion", api);
+
+// Re-export the type so the renderer's tsconfig can pick it up via
+// `import type { CompanionApi } from "..."` without depending on
+// the actual preload runtime.
+export type CompanionApi = typeof api;

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,0 +1,435 @@
+/**
+ * Companion-app UI. Two big sections:
+ *
+ *   1. Status — Docker container running/stopped + API healthcheck
+ *      result. Live-updates every 3s. The user's "is it working?"
+ *      glance.
+ *
+ *   2. Controls + settings — Start/Stop backend, repo path picker,
+ *      CF tunnel token. Phase 1 keeps these minimal; Phase 2 adds
+ *      VPN connect + Phase 3 wires the tunnel hostname into the
+ *      Vercel routing.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+type CompanionWindow = Window & {
+  companion: {
+    backend: {
+      start: () => Promise<{ ok: boolean; message: string }>;
+      stop: () => Promise<{ ok: boolean; message: string }>;
+      status: () => Promise<{
+        running: boolean;
+        lastError: string | null;
+        repoPath: string;
+      }>;
+      logs: (lines?: number) => Promise<string[]>;
+    };
+    api: {
+      ping: () => Promise<{
+        ok: boolean;
+        status: number | null;
+        latencyMs: number | null;
+        error: string | null;
+      }>;
+    };
+    settings: {
+      get: () => Promise<{
+        repoPath?: string;
+        tunnelToken?: string;
+        autoStartAtLogin?: boolean;
+      }>;
+      set: (patch: Record<string, unknown>) => Promise<unknown>;
+    };
+    shell: { openExternal: (url: string) => Promise<void> };
+  };
+};
+
+const companion = (window as unknown as CompanionWindow).companion;
+
+type BackendStatus = Awaited<ReturnType<typeof companion.backend.status>>;
+type ApiPing = Awaited<ReturnType<typeof companion.api.ping>>;
+type Settings = Awaited<ReturnType<typeof companion.settings.get>>;
+
+const POLL_INTERVAL_MS = 3000;
+const LOG_LINES = 50;
+
+export function App() {
+  const [status, setStatus] = useState<BackendStatus | null>(null);
+  const [ping, setPing] = useState<ApiPing | null>(null);
+  const [settings, setSettings] = useState<Settings>({});
+  const [logs, setLogs] = useState<string[]>([]);
+  const [busy, setBusy] = useState<"" | "starting" | "stopping">("");
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [s, p, ll, st] = await Promise.all([
+        companion.backend.status(),
+        companion.api.ping(),
+        companion.backend.logs(LOG_LINES),
+        companion.settings.get(),
+      ]);
+      setStatus(s);
+      setPing(p);
+      setLogs(ll);
+      setSettings(st);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const t = setInterval(refresh, POLL_INTERVAL_MS);
+    return () => clearInterval(t);
+  }, [refresh]);
+
+  const onStart = async () => {
+    setBusy("starting");
+    setError(null);
+    const r = await companion.backend.start();
+    if (!r.ok) setError(r.message);
+    setBusy("");
+    await refresh();
+  };
+  const onStop = async () => {
+    setBusy("stopping");
+    setError(null);
+    const r = await companion.backend.stop();
+    if (!r.ok) setError(r.message);
+    setBusy("");
+    await refresh();
+  };
+
+  const onSettingChange = async (key: string, value: unknown) => {
+    await companion.settings.set({ [key]: value });
+    await refresh();
+  };
+
+  return (
+    <main style={S.shell}>
+      <header style={S.header}>
+        <div>
+          <h1 style={S.title}>eSpace Dev Hub Companion</h1>
+          <p style={S.subtitle}>
+            Runs the backend container on your machine so the Vercel app can
+            reach private resources (Crealogix VPN, internal GitLab, etc.).
+          </p>
+        </div>
+        <Badge ping={ping} running={status?.running ?? false} />
+      </header>
+
+      <Section title="Backend">
+        <div style={S.row}>
+          <Stat
+            label="Container"
+            value={status?.running ? "running" : "stopped"}
+            tone={status?.running ? "good" : "muted"}
+          />
+          <Stat
+            label="API /healthz"
+            value={
+              ping?.ok
+                ? `${ping.status} · ${ping.latencyMs}ms`
+                : ping?.error
+                ? "unreachable"
+                : "—"
+            }
+            tone={ping?.ok ? "good" : ping?.error ? "bad" : "muted"}
+          />
+          <Stat
+            label="Repo"
+            value={status?.repoPath || "(not set)"}
+            tone={status?.repoPath ? "muted" : "warn"}
+          />
+        </div>
+        <div style={S.actions}>
+          <button
+            type="button"
+            style={S.btnPrimary}
+            disabled={!!busy || status?.running === true}
+            onClick={onStart}
+          >
+            {busy === "starting" ? "Starting…" : "Start backend"}
+          </button>
+          <button
+            type="button"
+            style={S.btnSecondary}
+            disabled={!!busy || status?.running === false}
+            onClick={onStop}
+          >
+            {busy === "stopping" ? "Stopping…" : "Stop backend"}
+          </button>
+        </div>
+        {(error || status?.lastError) && (
+          <div style={S.errorBanner}>{error || status?.lastError}</div>
+        )}
+      </Section>
+
+      <Section title="Settings">
+        <Field
+          label="Repo path"
+          help="Absolute path to your espace-devhub checkout. The companion runs `docker compose` from here."
+        >
+          <input
+            type="text"
+            value={settings.repoPath || ""}
+            placeholder="C:\Users\YOU\Desktop\Birdy\espace-devhub"
+            onChange={(e) => onSettingChange("repoPath", e.target.value)}
+            style={S.input}
+          />
+        </Field>
+        <Field
+          label="Cloudflare Tunnel token"
+          help="From `cloudflared tunnel token <name>`. Required for the `tunnel` profile."
+        >
+          <input
+            type="password"
+            value={settings.tunnelToken || ""}
+            placeholder="eyJhIjoi…"
+            onChange={(e) => onSettingChange("tunnelToken", e.target.value)}
+            style={S.input}
+          />
+        </Field>
+        <Field label="Auto-start at login" help="Launch the companion when you sign into Windows.">
+          <input
+            type="checkbox"
+            checked={!!settings.autoStartAtLogin}
+            onChange={(e) => onSettingChange("autoStartAtLogin", e.target.checked)}
+          />
+        </Field>
+      </Section>
+
+      <Section title="Logs">
+        <pre style={S.logs}>
+          {logs.length === 0 ? "(no logs yet — Start backend to see output)" : logs.join("\n")}
+        </pre>
+      </Section>
+
+      <footer style={S.footer}>
+        <span>
+          Phase 1 · backend control + healthcheck. FortiClient automation lands in Phase 2.
+        </span>
+        <a
+          href="#"
+          style={S.link}
+          onClick={(e) => {
+            e.preventDefault();
+            void companion.shell.openExternal(
+              "https://github.com/nova-sudo/eSpaceDev/blob/main/docs/RUN_LOCALLY.md",
+            );
+          }}
+        >
+          Setup guide ↗
+        </a>
+      </footer>
+    </main>
+  );
+}
+
+/* ─────────────────── primitives ─────────────────── */
+
+function Badge({
+  ping,
+  running,
+}: {
+  ping: ApiPing | null;
+  running: boolean;
+}) {
+  const ok = ping?.ok === true && running;
+  const partial = running && !ok;
+  const color = ok ? "var(--good)" : partial ? "var(--warn)" : "var(--bad)";
+  const label = ok ? "ready" : partial ? "starting…" : "offline";
+  return (
+    <div style={{ ...S.badge, borderColor: color, color }}>
+      <span style={{ ...S.badgeDot, background: color }} />
+      {label}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section style={S.section}>
+      <h2 style={S.sectionTitle}>{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone: "good" | "bad" | "muted" | "warn";
+}) {
+  const color = {
+    good: "var(--good)",
+    bad: "var(--bad)",
+    warn: "var(--warn)",
+    muted: "var(--muted)",
+  }[tone];
+  return (
+    <div style={S.stat}>
+      <div style={S.statLabel}>{label}</div>
+      <div style={{ ...S.statValue, color }}>{value}</div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  help,
+  children,
+}: {
+  label: string;
+  help: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label style={S.field}>
+      <span style={S.fieldLabel}>{label}</span>
+      {children}
+      <span style={S.fieldHelp}>{help}</span>
+    </label>
+  );
+}
+
+/* ─────────────────── styles ─────────────────── */
+
+const S: Record<string, React.CSSProperties> = {
+  shell: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 16,
+    padding: 24,
+    minHeight: "100vh",
+    boxSizing: "border-box",
+  },
+  header: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 16,
+  },
+  title: { fontSize: 18, margin: 0 },
+  subtitle: {
+    margin: "4px 0 0 0",
+    color: "var(--muted)",
+    fontSize: 12.5,
+    lineHeight: 1.5,
+    maxWidth: 520,
+  },
+  badge: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    padding: "4px 10px",
+    border: "1px solid",
+    borderRadius: 999,
+    fontSize: 11,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+  },
+  badgeDot: { width: 8, height: 8, borderRadius: "50%" },
+  section: {
+    background: "var(--panel)",
+    border: "1px solid var(--border)",
+    borderRadius: 8,
+    padding: 16,
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    margin: 0,
+    color: "var(--muted)",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  },
+  row: { display: "flex", gap: 24, flexWrap: "wrap" },
+  stat: { display: "flex", flexDirection: "column", gap: 2, minWidth: 120 },
+  statLabel: {
+    fontSize: 10,
+    color: "var(--muted)",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  },
+  statValue: { fontSize: 14, fontWeight: 600 },
+  actions: { display: "flex", gap: 8 },
+  btnPrimary: {
+    background: "var(--accent)",
+    color: "white",
+    border: 0,
+    borderRadius: 4,
+    padding: "8px 14px",
+    fontSize: 12,
+    fontWeight: 600,
+    cursor: "pointer",
+  },
+  btnSecondary: {
+    background: "transparent",
+    color: "var(--fg)",
+    border: "1px solid var(--border)",
+    borderRadius: 4,
+    padding: "8px 14px",
+    fontSize: 12,
+    cursor: "pointer",
+  },
+  field: { display: "flex", flexDirection: "column", gap: 4 },
+  fieldLabel: { fontSize: 12, color: "var(--fg)" },
+  fieldHelp: { fontSize: 11, color: "var(--muted)" },
+  input: {
+    background: "var(--bg)",
+    color: "var(--fg)",
+    border: "1px solid var(--border)",
+    borderRadius: 4,
+    padding: "8px 10px",
+    fontSize: 12,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  },
+  logs: {
+    margin: 0,
+    background: "var(--bg)",
+    border: "1px solid var(--border)",
+    borderRadius: 4,
+    padding: 10,
+    fontSize: 11,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    color: "var(--muted)",
+    maxHeight: 220,
+    overflow: "auto",
+    whiteSpace: "pre-wrap",
+  },
+  errorBanner: {
+    background: "rgba(248,81,73,0.1)",
+    border: "1px solid var(--bad)",
+    borderRadius: 4,
+    padding: "8px 10px",
+    color: "var(--bad)",
+    fontSize: 12,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  },
+  footer: {
+    marginTop: "auto",
+    display: "flex",
+    justifyContent: "space-between",
+    color: "var(--muted)",
+    fontSize: 11,
+  },
+  link: { color: "var(--accent)", textDecoration: "none" },
+};

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>eSpace Dev Hub — Companion</title>
+    <!--
+      Strict CSP: scripts only from our own bundle, no inline. Phase 4
+      will tighten further once we ship a real packaged build; in dev
+      we relax to allow Vite's HMR client.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws://localhost:5173 http://localhost:5173"
+    />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0e1116;
+        --panel: #161b22;
+        --border: #30363d;
+        --fg: #e6edf3;
+        --muted: #8b949e;
+        --accent: #2f81f7;
+        --good: #3fb950;
+        --bad: #f85149;
+        --warn: #d29922;
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+      }
+      html, body, #root { height: 100%; margin: 0; }
+      body { background: var(--bg); color: var(--fg); }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -1,0 +1,6 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+const container = document.getElementById("root");
+if (!container) throw new Error("missing #root");
+createRoot(container).render(<App />);

--- a/apps/desktop/tsconfig.node.json
+++ b/apps/desktop/tsconfig.node.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": false,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/main/**/*.ts", "src/preload/**/*.ts"]
+}

--- a/apps/desktop/tsconfig.web.json
+++ b/apps/desktop/tsconfig.web.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/renderer/**/*.ts", "src/renderer/**/*.tsx"]
+}

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,0 +1,28 @@
+/**
+ * Vite config for the renderer (Electron's BrowserWindow).
+ *
+ * Build output lands in `dist/renderer/`. The main process loads
+ * `dist/renderer/index.html` in production. In dev, vite serves on
+ * :5173 and main loads the URL directly.
+ */
+
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+
+export default defineConfig({
+  // Root is the renderer source folder so `index.html`'s `<script>`
+  // refs resolve relatively without prefixes.
+  root: path.resolve(__dirname, "src/renderer"),
+  plugins: [react()],
+  base: "./",
+  build: {
+    outDir: path.resolve(__dirname, "dist/renderer"),
+    emptyOutDir: true,
+    target: "chrome120",
+  },
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "eSpace Dev Hub — personal performance & evidence tracker for programmers. Integrates Jira, self-hosted GitLab, and GitHub. Monorepo root.",
   "workspaces": [
-    "apps/*",
+    "apps/api",
+    "apps/web",
     "packages/*"
   ],
   "overrides": {


### PR DESCRIPTION
## What this is
Phase 1 of the multi-PR plan for the Crealogix companion app. Ships an Electron tray app that runs the eSpace Dev Hub backend (Docker compose stack from PR #102) on the user's machine. Phases 2–4 layer FortiClient automation, per-user CF tunnel provisioning + server routing, and code signing / auto-update.

## Phase plan
| # | Scope | Status |
|---|---|---|
| **1 (this PR)** | Electron scaffold + tray + Docker control + healthcheck + settings | 🟢 ready for review |
| 2 | FortiClient automation (credentials in OS keychain, CLI invoke, status monitoring) | next PR |
| 3 | Per-user CF tunnel provisioning + server-side `GET /me/api-origin` routing | PR after that |
| 4 | Code signing (Authenticode + Apple Dev ID), auto-update, onboarding wizard | last |

## What's in this PR

### `apps/desktop/` — new workspace
**Intentionally NOT in the root npm workspaces** so Electron's ~300MB install doesn't slow every Vercel build for `apps/web` / `apps/api`. Install with `cd apps/desktop && npm install`.

### Main process (`src/main/`)
- **`index.ts`** — single-instance lock, tray icon with quick Start/Stop menu, window that hides on close (tray keeps app alive), IPC bridge exposed via `contextBridge` to the renderer.
- **`docker.ts`** — spawns `docker compose --profile tunnel up -d` / `down` from the user-configured repo path. In-memory log tail (last 500 lines). Status reflects "running" between the start command and the first healthcheck pass.
- **`health.ts`** — single-shot `fetch('http://localhost:4000/healthz')` with 1.5s timeout. Reports status code + latency + error reason.
- **`settings.ts`** — tiny JSON-file store (`%APPDATA%/eSpace Dev Hub Companion/config.json`). Rolled our own because `electron-store@10` is pure ESM and would force the main process to ESM (Electron 33 supports it, but with rough edges).

### Renderer (`src/renderer/`)
- React UI matching the dark theme of the rest of the app
- Status badge (ready / starting / offline) based on combined `container.running` + `api.ok`
- Start/Stop buttons (debounced while in flight)
- Settings: repo path, CF tunnel token, auto-start at login
- Log tail panel (last 50 lines from docker compose)

### Packaging
- **`electron-builder.yml`** — NSIS for Windows (per-user, allows install dir change, creates shortcuts), DMG for macOS (arm64 + x64), AppImage for Linux. Unsigned in Phase 1.
- **`vite.config.ts`** — renderer-only Vite build, output to `dist/renderer/`.
- **`tsconfig.node.json`** — CommonJS for main + preload (safer for Electron 33).
- **`tsconfig.web.json`** — ESNext for the renderer.

## Test plan
- [ ] `cd apps/desktop && npm install` succeeds
- [ ] `npm run dev` opens the companion window via Vite HMR + Electron
- [ ] In the window: set repo path → click **Start backend** → tray label flips to "running" → API badge turns green within ~15s
- [ ] Click **Stop backend** → container stops → badge returns to red
- [ ] Close window → app keeps running (tray); single-click tray opens window back
- [ ] Quit via tray → containers stopped, app exits cleanly
- [ ] `npm run dist` produces an unsigned NSIS installer in `dist-electron/`
- [ ] Settings persist across restart (config.json under `%APPDATA%`)
- [ ] No regression on web/api — root `npm install` shouldn't pull Electron deps (verify by `npm ls electron` returning empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)