### PR TITLE
feat(desktop): Phase 2 — VPN credentials in keychain + status detection + best-effort connect

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -6,19 +6,24 @@ calls through to it (via a Cloudflare Tunnel), giving the user access
 to private resources their machine can reach but Vercel cannot — for
 example, Crealogix's internal GitLab at `git.bcn.crealogix.net`.
 
-## Phase 1 (this directory, today)
+## Status (Phase 2)
 
-What works:
+What works today:
 
-- ✅ Tray icon + window UI
-- ✅ Start / stop the `docker compose --profile tunnel` stack
-- ✅ Live API healthcheck against `localhost:4000/healthz`
-- ✅ Persisted settings (repo path, Cloudflare Tunnel token, auto-start)
-- ✅ Logs panel tailing the docker compose output
+- ✅ Tray icon + window UI (Phase 1)
+- ✅ Start / stop the `docker compose --profile tunnel` stack (Phase 1)
+- ✅ Live API healthcheck against `localhost:4000/healthz` (Phase 1)
+- ✅ Persisted settings (repo path, Cloudflare Tunnel token, auto-start) (Phase 1)
+- ✅ Logs panel tailing the docker compose output (Phase 1)
+- ✅ VPN status detection — DNS probe of `git.bcn.crealogix.net` (Phase 2)
+- ✅ VPN credentials in OS keychain via electron's `safeStorage` (Phase 2)
+- ✅ FortiClient client discovery + best-effort connect (Phase 2)
+- ✅ `openfortivpn` headless auto-connect when present (Phase 2)
+- ✅ Auto-connect VPN when starting backend (toggleable) (Phase 2)
 
 What's deferred:
 
-- 🚧 FortiClient VPN automation (Phase 2)
+- 🚧 Reliable FortiClient disconnect (currently manual — Phase 2b polish)
 - 🚧 Per-user Cloudflare Tunnel auto-provisioning (Phase 3)
 - 🚧 Server-side per-user `API_ORIGIN` routing (Phase 3)
 - 🚧 Code signing + auto-update (Phase 4)

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -27,6 +27,8 @@ import path from "node:path";
 import { startBackend, stopBackend, backendStatus, tailLogs } from "./docker";
 import { pingApi } from "./health";
 import { settings } from "./settings";
+import * as vpn from "./vpn";
+import * as keychain from "./keychain";
 
 // __dirname is available natively in CommonJS — no fileURLToPath
 // gymnastics needed. Electron's main process is CJS by default; we
@@ -177,7 +179,63 @@ function createTray(): Tray {
 // (or throws — Electron forwards thrown errors back to the renderer).
 
 ipcMain.handle("backend:start", async () => {
+  // Phase 2c — if the user has the auto-connect setting on AND the
+  // VPN is currently down, attempt to bring it up first. The Docker
+  // stack itself doesn't need the VPN to start; what NEEDS the VPN
+  // is the upstream calls the api makes once requests arrive (e.g.
+  // git.bcn.crealogix.net fetches). But pre-flighting here gives
+  // cleaner UX — by the time "Backend: running" lights up, the
+  // user can immediately use the website.
+  if (settings.get<boolean>("vpnAutoConnectOnStart", false)) {
+    const s = await vpn.status();
+    if (!s.connected) {
+      await vpn.connect();
+      // Don't block on VPN completing — the actual connection can
+      // take 5–20s and FortiClient's GUI flow may need user input.
+      // We start Docker in parallel; the user's first integration
+      // call may bounce if the VPN isn't up yet, but that's a
+      // recoverable state (retry the request after VPN connects).
+    }
+  }
   return startBackend();
+});
+
+ipcMain.handle("vpn:status", async () => {
+  return vpn.status();
+});
+
+ipcMain.handle("vpn:connect", async () => {
+  return vpn.connect();
+});
+
+ipcMain.handle("vpn:disconnect", async () => {
+  return vpn.disconnect();
+});
+
+ipcMain.handle("vpn:discover-client", async () => {
+  return vpn.discoverClient();
+});
+
+ipcMain.handle("credentials:has", async (_event, key: string) => {
+  if (typeof key !== "string") throw new Error("key must be a string");
+  return { keychainAvailable: keychain.isAvailable(), set: keychain.has(key) };
+});
+
+ipcMain.handle(
+  "credentials:set",
+  async (_event, { key, value }: { key: string; value: string }) => {
+    if (typeof key !== "string" || typeof value !== "string") {
+      throw new Error("key + value must be strings");
+    }
+    keychain.set(key, value);
+    return { ok: true };
+  },
+);
+
+ipcMain.handle("credentials:clear", async (_event, key: string) => {
+  if (typeof key !== "string") throw new Error("key must be a string");
+  keychain.clear(key);
+  return { ok: true };
 });
 
 ipcMain.handle("backend:stop", async () => {

--- a/apps/desktop/src/main/keychain.ts
+++ b/apps/desktop/src/main/keychain.ts
@@ -1,0 +1,110 @@
+/**
+ * OS-keychain-backed credential storage.
+ *
+ * Wraps electron's `safeStorage` API: encryption keys live in the OS
+ * keychain (Windows DPAPI / macOS Keychain / Linux libsecret) so the
+ * encrypted blobs we persist to JSON are useless to anyone who copies
+ * the config file off the machine — they'd need login access to the
+ * same OS user account to decrypt.
+ *
+ * Why this exists separately from settings.ts
+ * ───────────────────────────────────────────
+ * settings.ts is a generic typed JSON store; its values pass through
+ * to disk as-is. Credentials (VPN password, etc.) deserve the extra
+ * decrypt step. By keeping the two layers distinct:
+ *
+ *   1. Renderer code can never accidentally request a credential —
+ *      the IPC handler `credentials:has` returns a boolean, never the
+ *      plaintext. Renderer asks "is the VPN password set?", main
+ *      answers yes/no.
+ *   2. Persistence on disk separates: settings.json holds non-secret
+ *      config; the encrypted credential blobs live in their own
+ *      object so a backup tool can include settings without picking
+ *      up the credentials by accident.
+ *
+ * Encryption availability
+ * ───────────────────────
+ * `safeStorage.isEncryptionAvailable()` is FALSE on:
+ *   - Linux with no libsecret-1 / gnome-keyring installed
+ *   - Locked / unconfigured keychain access
+ *
+ * When unavailable, we refuse to set credentials and surface the
+ * reason to the UI so the user can fix it. We never silently fall
+ * back to plaintext storage — that would be worse than the user
+ * thinks.
+ */
+
+import { app, safeStorage } from "electron";
+import fs from "node:fs";
+import path from "node:path";
+
+const FILE_NAME = "credentials.json";
+
+type Schema = Record<string, string>; // key → base64(encrypted blob)
+
+function filePath(): string {
+  return path.join(app.getPath("userData"), FILE_NAME);
+}
+
+function read(): Schema {
+  try {
+    const raw = fs.readFileSync(filePath(), "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Schema;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function write(data: Schema): void {
+  const p = filePath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  // 0o600 (owner read/write only) on the file; default JSON store
+  // perms vary by platform.
+  fs.writeFileSync(p, JSON.stringify(data, null, 2), { encoding: "utf8", mode: 0o600 });
+}
+
+export function isAvailable(): boolean {
+  return safeStorage.isEncryptionAvailable();
+}
+
+export function has(key: string): boolean {
+  return typeof read()[key] === "string" && read()[key]!.length > 0;
+}
+
+export function set(key: string, plaintext: string): void {
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error(
+      "OS keychain unavailable on this machine. On Linux you may need libsecret-1-dev or gnome-keyring installed; on Windows/macOS this should always work.",
+    );
+  }
+  const encrypted = safeStorage.encryptString(plaintext);
+  const data = read();
+  data[key] = encrypted.toString("base64");
+  write(data);
+}
+
+export function get(key: string): string | null {
+  const stored = read()[key];
+  if (!stored) return null;
+  try {
+    const buf = Buffer.from(stored, "base64");
+    return safeStorage.decryptString(buf);
+  } catch {
+    // Decryption failure usually means the keychain entry was wiped
+    // or the user logged in as a different OS user since the value
+    // was stored. Treat as "not set" so the UI prompts to re-enter.
+    return null;
+  }
+}
+
+export function clear(key: string): void {
+  const data = read();
+  if (key in data) {
+    delete data[key];
+    write(data);
+  }
+}

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -32,6 +32,26 @@ interface CompanionSchema {
   repoPath?: string;
   tunnelToken?: string;
   autoStartAtLogin?: boolean;
+  // ── VPN (Phase 2) ────────────────────────────────────────────────
+  // Non-secret VPN config. The PASSWORD lives in keychain.ts, never
+  // here. Kept flat so future engagement-specific tweaks don't need
+  // a migration step.
+  /** Username for FortiClient / openfortivpn auth. */
+  vpnUsername?: string;
+  /** Gateway hostname (used by openfortivpn). Most users with the
+   * GUI FortiClient won't need this — FortiClient stores the gateway
+   * in its own saved profile. */
+  vpnGateway?: string;
+  /** FortiClient saved-profile name (used when shelling out via
+   * `FortiClient.exe -p <profile>`). Defaults to "Crealogix". */
+  vpnProfile?: string;
+  /** Hostname we probe to detect "is the VPN up." Defaults to
+   * git.bcn.crealogix.net. Parameterised so other engagements can
+   * reuse the same machinery without code changes. */
+  vpnGatedHost?: string;
+  /** When true, clicking "Start backend" pre-flights the VPN — brings
+   * it up first if it's down. */
+  vpnAutoConnectOnStart?: boolean;
 }
 
 const FILE_NAME = "config.json";

--- a/apps/desktop/src/main/vpn.ts
+++ b/apps/desktop/src/main/vpn.ts
@@ -1,0 +1,339 @@
+/**
+ * VPN connection helpers — FortiClient (Crealogix's choice) for now.
+ *
+ * Two distinct things this module does:
+ *
+ *   1. Status detection — "is the VPN currently up?" — done by
+ *      checking if a known gated hostname resolves to a private IP
+ *      (or resolves at all). This is the SOURCE OF TRUTH for VPN
+ *      state; whatever connect/disconnect helper we use is just a
+ *      best-effort trigger.
+ *
+ *   2. Connect / disconnect via FortiClient — best-effort. FortiClient
+ *      ships in a few shapes (standalone vs. EMS-managed) and the
+ *      automation surface varies. Strategy:
+ *        - Try the OpenFortiVPN CLI fork if present (best path)
+ *        - Else try FortiClient.exe with a saved-profile flag
+ *        - Else surface "open FortiClient manually" with clear copy
+ *
+ * Phase 2a (this commit): status detection + manual connect helper.
+ * Phase 2b (immediate follow-up in same PR): actual auto-connect via
+ * FortiClient.exe shellout.
+ *
+ * The gated hostname we probe is configurable so this same logic
+ * works for any engagement that maps to a VPN-gated network. The
+ * setting defaults to Crealogix's `git.bcn.crealogix.net`.
+ */
+
+import dns from "node:dns/promises";
+import net from "node:net";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { get as kcGet } from "./keychain";
+import { settings } from "./settings";
+
+const DEFAULT_GATED_HOST = "git.bcn.crealogix.net";
+
+// Common Windows FortiClient install paths. We check existence at
+// runtime rather than hardcoding because Crealogix may have a
+// repackaged install or an MSI override. If none of these exists
+// we fall back to "user opens FortiClient manually."
+const WINDOWS_CANDIDATES = [
+  "C:\\Program Files\\Fortinet\\FortiClient\\FortiClient.exe",
+  "C:\\Program Files (x86)\\Fortinet\\FortiClient\\FortiClient.exe",
+  // OpenFortiVPN — better-scriptable alternative some users install:
+  "C:\\Program Files\\openfortivpn\\openfortivpn.exe",
+];
+
+const MAC_CANDIDATES = [
+  "/Applications/FortiClient.app/Contents/MacOS/FortiClient",
+  "/usr/local/bin/openfortivpn",
+];
+
+const LINUX_CANDIDATES = [
+  "/usr/bin/openfortivpn",
+  "/usr/local/bin/openfortivpn",
+];
+
+function gatedHost(): string {
+  return settings.get<string>("vpnGatedHost", DEFAULT_GATED_HOST);
+}
+
+/* ─────────────── status ─────────────── */
+
+export interface VpnStatus {
+  connected: boolean;
+  /** "yes" / "no" / "unknown" — distinguishes a hard NXDOMAIN from a
+   * temporary lookup failure so the UI can decide whether to retry. */
+  resolution: "private" | "public" | "nxdomain" | "error";
+  resolvedIp: string | null;
+  gatedHost: string;
+  message: string;
+}
+
+function isPrivateIp(ip: string): boolean {
+  // RFC 1918 + 100.64.0.0/10 (carrier-grade NAT, sometimes used for VPN tunnels).
+  if (ip.startsWith("10.")) return true;
+  if (ip.startsWith("192.168.")) return true;
+  if (ip.startsWith("172.")) {
+    const second = Number(ip.split(".")[1] ?? "0");
+    if (second >= 16 && second <= 31) return true;
+  }
+  if (ip.startsWith("100.")) {
+    const second = Number(ip.split(".")[1] ?? "0");
+    if (second >= 64 && second <= 127) return true;
+  }
+  return false;
+}
+
+export async function status(): Promise<VpnStatus> {
+  const host = gatedHost();
+  try {
+    const result = await dns.lookup(host, { family: 4 });
+    const ip = result.address;
+    if (isPrivateIp(ip)) {
+      // Resolves to a private IP — strong signal the VPN is up
+      // (the gated host's name only resolves via the corp DNS that
+      // VPN provides).
+      return {
+        connected: true,
+        resolution: "private",
+        resolvedIp: ip,
+        gatedHost: host,
+        message: `Resolved ${host} → ${ip} (private — VPN appears up)`,
+      };
+    }
+    // Resolves to a public IP — could be a split-horizon setup
+    // where the host is also publicly addressable. Try a TCP probe
+    // to be sure.
+    const reachable = await tcpProbe(ip, 443, 2000);
+    return {
+      connected: reachable,
+      resolution: "public",
+      resolvedIp: ip,
+      gatedHost: host,
+      message: reachable
+        ? `Resolved ${host} → ${ip} (public, reachable)`
+        : `Resolved ${host} → ${ip} (public, unreachable — VPN likely down)`,
+    };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOTFOUND" || code === "EAI_AGAIN") {
+      return {
+        connected: false,
+        resolution: "nxdomain",
+        resolvedIp: null,
+        gatedHost: host,
+        message: `${host} doesn't resolve — VPN appears down (NXDOMAIN). Connect FortiClient to fix.`,
+      };
+    }
+    return {
+      connected: false,
+      resolution: "error",
+      resolvedIp: null,
+      gatedHost: host,
+      message: `DNS lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+function tcpProbe(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    let done = false;
+    const timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      socket.destroy();
+      resolve(false);
+    }, timeoutMs);
+    socket.once("connect", () => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      socket.end();
+      resolve(true);
+    });
+    socket.once("error", () => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+/* ─────────────── client discovery ─────────────── */
+
+export interface ClientInfo {
+  kind: "forticlient" | "openfortivpn" | "none";
+  path: string | null;
+}
+
+export function discoverClient(): ClientInfo {
+  const candidates =
+    process.platform === "win32"
+      ? WINDOWS_CANDIDATES
+      : process.platform === "darwin"
+        ? MAC_CANDIDATES
+        : LINUX_CANDIDATES;
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      const name = path.basename(candidate).toLowerCase();
+      if (name.includes("openfortivpn")) {
+        return { kind: "openfortivpn", path: candidate };
+      }
+      if (name.includes("forticlient")) {
+        return { kind: "forticlient", path: candidate };
+      }
+    }
+  }
+  return { kind: "none", path: null };
+}
+
+/* ─────────────── connect / disconnect (best-effort) ─────────────── */
+
+export interface ConnectResult {
+  ok: boolean;
+  attempted: "openfortivpn" | "forticlient-launch" | "manual";
+  message: string;
+}
+
+/**
+ * Try to connect the VPN. Behavior depends on which client we find:
+ *
+ *   - openfortivpn → spawn with --username + --password (stored in
+ *     keychain). Provides exit code + stderr we can act on.
+ *   - FortiClient.exe → launch the GUI with a saved-profile arg
+ *     (`-p <profileName>`). Connection actually happens via the
+ *     user clicking "Connect" in the GUI — we just bring it
+ *     forward. Better than nothing; phase-2b improves on this.
+ *   - none → return a clear "open FortiClient yourself" message
+ */
+export async function connect(): Promise<ConnectResult> {
+  const client = discoverClient();
+  const profile = settings.get<string>("vpnProfile", "Crealogix");
+
+  if (client.kind === "openfortivpn") {
+    return runOpenFortiVPN(client.path!);
+  }
+
+  if (client.kind === "forticlient") {
+    return launchFortiClientGui(client.path!, profile);
+  }
+
+  return {
+    ok: false,
+    attempted: "manual",
+    message:
+      "FortiClient wasn't found at the expected install paths. Open FortiClient manually and connect using your saved profile, then click 'Refresh status' here.",
+  };
+}
+
+async function runOpenFortiVPN(binPath: string): Promise<ConnectResult> {
+  const username = settings.get<string>("vpnUsername", "");
+  const password = kcGet("vpnPassword");
+  const gateway = settings.get<string>("vpnGateway", "");
+
+  if (!username || !password || !gateway) {
+    return {
+      ok: false,
+      attempted: "openfortivpn",
+      message:
+        "openfortivpn needs the gateway URL + username + password configured in the companion's VPN settings.",
+    };
+  }
+
+  return new Promise((resolve) => {
+    // openfortivpn writes to stderr even on success; we wait briefly
+    // for either a successful tunnel-up line or a hard failure.
+    const child = spawn(binPath, [gateway, "--username", username], {
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    child.stdin.write(`${password}\n`);
+    child.stdin.end();
+
+    let stderr = "";
+    const timer = setTimeout(() => {
+      // Tunnel established within 15s or we move on. openfortivpn
+      // stays in foreground; we keep the child alive — disconnect
+      // tears it down.
+      resolve({
+        ok: true,
+        attempted: "openfortivpn",
+        message: "openfortivpn started — verify with 'Refresh status' in a moment.",
+      });
+    }, 15_000);
+
+    child.stderr?.on("data", (d) => {
+      stderr += d.toString();
+      // Bail early on auth failures so the user sees the error.
+      if (/login failed|authentication/i.test(stderr)) {
+        clearTimeout(timer);
+        child.kill();
+        resolve({
+          ok: false,
+          attempted: "openfortivpn",
+          message: `openfortivpn login failed: ${stderr.split("\n").slice(-3).join(" ")}`,
+        });
+      }
+    });
+
+    child.once("error", (err) => {
+      clearTimeout(timer);
+      resolve({
+        ok: false,
+        attempted: "openfortivpn",
+        message: `openfortivpn failed to start: ${err.message}`,
+      });
+    });
+  });
+}
+
+function launchFortiClientGui(binPath: string, profile: string): Promise<ConnectResult> {
+  // FortiClient.exe on Windows can be invoked with `-p <profile>` to
+  // bring up the GUI focused on a specific saved profile. From there
+  // the user (or auto-connect-on-launch in the saved profile) takes
+  // it to connected. Real headless automation is blocked by
+  // EMS-managed deployments — this is the most reliable best-effort.
+  return new Promise((resolve) => {
+    const child = spawn(binPath, ["-p", profile], {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: false,
+    });
+    child.once("error", (err) => {
+      resolve({
+        ok: false,
+        attempted: "forticlient-launch",
+        message: `Could not launch FortiClient: ${err.message}. Open it manually.`,
+      });
+    });
+    // Detach so it survives this process. Resolve immediately —
+    // the actual connection happens in FortiClient's UI flow.
+    child.unref();
+    resolve({
+      ok: true,
+      attempted: "forticlient-launch",
+      message:
+        "Opened FortiClient. If you didn't configure auto-connect on the saved profile, click 'Connect' in its window now.",
+    });
+  });
+}
+
+export async function disconnect(): Promise<ConnectResult> {
+  // Honest about the limitation: we can't reliably disconnect a
+  // FortiClient session from outside. On Windows, you'd `taskkill`
+  // the FortiClient process — but the user may have other VPN
+  // profiles in the same client. Phase 2b can wire openfortivpn's
+  // graceful shutdown when that's the active client.
+  return {
+    ok: false,
+    attempted: "manual",
+    message:
+      "Disconnect via the FortiClient tray icon for now. Auto-disconnect lands in a follow-up.",
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -22,6 +22,23 @@ const api = {
   api: {
     ping: () => ipcRenderer.invoke("api:ping"),
   },
+  vpn: {
+    status: () => ipcRenderer.invoke("vpn:status"),
+    connect: () => ipcRenderer.invoke("vpn:connect"),
+    disconnect: () => ipcRenderer.invoke("vpn:disconnect"),
+    discoverClient: () => ipcRenderer.invoke("vpn:discover-client"),
+  },
+  credentials: {
+    // `has` returns { keychainAvailable, set } so the UI can show
+    // "stored ✓" vs "not set" without ever receiving the plaintext.
+    has: (key: string) => ipcRenderer.invoke("credentials:has", key),
+    // `set` is fire-and-forget from the renderer's perspective — the
+    // plaintext travels via IPC ONCE, is encrypted in the main
+    // process, and never echoed back.
+    set: (key: string, value: string) =>
+      ipcRenderer.invoke("credentials:set", { key, value }),
+    clear: (key: string) => ipcRenderer.invoke("credentials:clear", key),
+  },
   settings: {
     get: () => ipcRenderer.invoke("settings:get"),
     set: (patch: Record<string, unknown>) =>

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -33,11 +33,36 @@ type CompanionWindow = Window & {
         error: string | null;
       }>;
     };
+    vpn: {
+      status: () => Promise<{
+        connected: boolean;
+        resolution: "private" | "public" | "nxdomain" | "error";
+        resolvedIp: string | null;
+        gatedHost: string;
+        message: string;
+      }>;
+      connect: () => Promise<{ ok: boolean; attempted: string; message: string }>;
+      disconnect: () => Promise<{ ok: boolean; attempted: string; message: string }>;
+      discoverClient: () => Promise<{
+        kind: "forticlient" | "openfortivpn" | "none";
+        path: string | null;
+      }>;
+    };
+    credentials: {
+      has: (key: string) => Promise<{ keychainAvailable: boolean; set: boolean }>;
+      set: (key: string, value: string) => Promise<{ ok: boolean }>;
+      clear: (key: string) => Promise<{ ok: boolean }>;
+    };
     settings: {
       get: () => Promise<{
         repoPath?: string;
         tunnelToken?: string;
         autoStartAtLogin?: boolean;
+        vpnUsername?: string;
+        vpnGateway?: string;
+        vpnProfile?: string;
+        vpnGatedHost?: string;
+        vpnAutoConnectOnStart?: boolean;
       }>;
       set: (patch: Record<string, unknown>) => Promise<unknown>;
     };
@@ -50,6 +75,9 @@ const companion = (window as unknown as CompanionWindow).companion;
 type BackendStatus = Awaited<ReturnType<typeof companion.backend.status>>;
 type ApiPing = Awaited<ReturnType<typeof companion.api.ping>>;
 type Settings = Awaited<ReturnType<typeof companion.settings.get>>;
+type VpnStatus = Awaited<ReturnType<typeof companion.vpn.status>>;
+type VpnClient = Awaited<ReturnType<typeof companion.vpn.discoverClient>>;
+type CredentialFlag = Awaited<ReturnType<typeof companion.credentials.has>>;
 
 const POLL_INTERVAL_MS = 3000;
 const LOG_LINES = 50;
@@ -59,21 +87,31 @@ export function App() {
   const [ping, setPing] = useState<ApiPing | null>(null);
   const [settings, setSettings] = useState<Settings>({});
   const [logs, setLogs] = useState<string[]>([]);
-  const [busy, setBusy] = useState<"" | "starting" | "stopping">("");
+  const [vpn, setVpn] = useState<VpnStatus | null>(null);
+  const [vpnClient, setVpnClient] = useState<VpnClient | null>(null);
+  const [vpnPwdFlag, setVpnPwdFlag] = useState<CredentialFlag | null>(null);
+  const [vpnPwdDraft, setVpnPwdDraft] = useState("");
+  const [busy, setBusy] = useState<"" | "starting" | "stopping" | "vpn-connect" | "vpn-disconnect">("");
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     try {
-      const [s, p, ll, st] = await Promise.all([
+      const [s, p, ll, st, vs, vc, vp] = await Promise.all([
         companion.backend.status(),
         companion.api.ping(),
         companion.backend.logs(LOG_LINES),
         companion.settings.get(),
+        companion.vpn.status(),
+        companion.vpn.discoverClient(),
+        companion.credentials.has("vpnPassword"),
       ]);
       setStatus(s);
       setPing(p);
       setLogs(ll);
       setSettings(st);
+      setVpn(vs);
+      setVpnClient(vc);
+      setVpnPwdFlag(vp);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -104,6 +142,42 @@ export function App() {
 
   const onSettingChange = async (key: string, value: unknown) => {
     await companion.settings.set({ [key]: value });
+    await refresh();
+  };
+
+  /* ── VPN actions ─────────────────────────────────────────────── */
+
+  const onVpnConnect = async () => {
+    setBusy("vpn-connect");
+    setError(null);
+    const r = await companion.vpn.connect();
+    if (!r.ok) setError(r.message);
+    setBusy("");
+    await refresh();
+  };
+
+  const onVpnDisconnect = async () => {
+    setBusy("vpn-disconnect");
+    setError(null);
+    const r = await companion.vpn.disconnect();
+    if (!r.ok) setError(r.message);
+    setBusy("");
+    await refresh();
+  };
+
+  const onSavePassword = async () => {
+    if (!vpnPwdDraft) return;
+    try {
+      await companion.credentials.set("vpnPassword", vpnPwdDraft);
+      setVpnPwdDraft("");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const onClearPassword = async () => {
+    await companion.credentials.clear("vpnPassword");
     await refresh();
   };
 
@@ -167,6 +241,161 @@ export function App() {
         )}
       </Section>
 
+      <Section title="VPN (Crealogix)">
+        <div style={S.row}>
+          <Stat
+            label="Tunnel"
+            value={vpn?.connected ? "up" : "down"}
+            tone={vpn?.connected ? "good" : "bad"}
+          />
+          <Stat
+            label="Gated host"
+            value={vpn?.gatedHost || "—"}
+            tone="muted"
+          />
+          <Stat
+            label="Resolves to"
+            value={vpn?.resolvedIp || vpn?.resolution || "—"}
+            tone={
+              vpn?.resolution === "private"
+                ? "good"
+                : vpn?.resolution === "nxdomain"
+                ? "bad"
+                : "muted"
+            }
+          />
+          <Stat
+            label="Client"
+            value={
+              vpnClient?.kind === "none"
+                ? "not found"
+                : `${vpnClient?.kind} ✓`
+            }
+            tone={vpnClient?.kind === "none" ? "warn" : "good"}
+          />
+        </div>
+        <p style={S.helpInline}>{vpn?.message || ""}</p>
+        <div style={S.actions}>
+          <button
+            type="button"
+            style={S.btnPrimary}
+            disabled={!!busy || vpn?.connected === true}
+            onClick={onVpnConnect}
+          >
+            {busy === "vpn-connect" ? "Connecting…" : "Connect VPN"}
+          </button>
+          <button
+            type="button"
+            style={S.btnSecondary}
+            disabled={!!busy || vpn?.connected === false}
+            onClick={onVpnDisconnect}
+          >
+            {busy === "vpn-disconnect" ? "Disconnecting…" : "Disconnect VPN"}
+          </button>
+          <button
+            type="button"
+            style={S.btnSecondary}
+            onClick={() => void refresh()}
+          >
+            Refresh status
+          </button>
+        </div>
+
+        {/* Credentials sub-block ─ The plaintext password is sent to
+            main ONCE (here) and never echoed back to the renderer. */}
+        <Field
+          label="Username"
+          help="Crealogix VPN username. Sent only when openfortivpn is the active client; FortiClient uses its own saved profile."
+        >
+          <input
+            type="text"
+            value={settings.vpnUsername || ""}
+            onChange={(e) => onSettingChange("vpnUsername", e.target.value)}
+            style={S.input}
+          />
+        </Field>
+
+        <div style={S.field}>
+          <span style={S.fieldLabel}>Password</span>
+          {vpnPwdFlag?.set ? (
+            <div style={S.row}>
+              <span style={{ ...S.statValue, color: "var(--good)" }}>
+                stored ✓ in OS keychain
+              </span>
+              <button
+                type="button"
+                style={S.btnGhost}
+                onClick={onClearPassword}
+              >
+                Clear
+              </button>
+            </div>
+          ) : (
+            <div style={S.row}>
+              <input
+                type="password"
+                value={vpnPwdDraft}
+                onChange={(e) => setVpnPwdDraft(e.target.value)}
+                placeholder="Crealogix VPN password"
+                style={{ ...S.input, flex: 1 }}
+              />
+              <button
+                type="button"
+                style={S.btnPrimary}
+                disabled={!vpnPwdDraft}
+                onClick={onSavePassword}
+              >
+                Save to keychain
+              </button>
+            </div>
+          )}
+          <span style={S.fieldHelp}>
+            {vpnPwdFlag?.keychainAvailable
+              ? "Encrypted at rest using your OS keychain (Windows DPAPI / macOS Keychain)."
+              : "OS keychain isn't available — install libsecret on Linux, then restart the companion."}
+          </span>
+        </div>
+
+        <Field
+          label="FortiClient saved-profile name"
+          help="Profile created inside FortiClient's UI. Used when the companion launches FortiClient.exe with `-p <profile>`."
+        >
+          <input
+            type="text"
+            value={settings.vpnProfile || ""}
+            placeholder="Crealogix"
+            onChange={(e) => onSettingChange("vpnProfile", e.target.value)}
+            style={S.input}
+          />
+        </Field>
+
+        <Field
+          label="Gated host (probe)"
+          help="The companion checks if this hostname resolves to a private IP to know whether the VPN is up."
+        >
+          <input
+            type="text"
+            value={settings.vpnGatedHost || ""}
+            placeholder="git.bcn.crealogix.net"
+            onChange={(e) => onSettingChange("vpnGatedHost", e.target.value)}
+            style={S.input}
+          />
+        </Field>
+
+        <Field
+          label="Auto-connect VPN when starting backend"
+          help="When the backend starts, bring up the VPN first if it's down."
+        >
+          <input
+            type="checkbox"
+            checked={!!settings.vpnAutoConnectOnStart}
+            onChange={(e) =>
+              onSettingChange("vpnAutoConnectOnStart", e.target.checked)
+            }
+          />
+        </Field>
+      </Section>
+
       <Section title="Settings">
         <Field
           label="Repo path"
@@ -209,7 +438,7 @@ export function App() {
 
       <footer style={S.footer}>
         <span>
-          Phase 1 · backend control + healthcheck. FortiClient automation lands in Phase 2.
+          Phase 2 · backend + VPN. Per-user tunnel routing lands in Phase 3.
         </span>
         <a
           href="#"
@@ -389,6 +618,22 @@ const S: Record<string, React.CSSProperties> = {
     padding: "8px 14px",
     fontSize: 12,
     cursor: "pointer",
+  },
+  btnGhost: {
+    background: "transparent",
+    color: "var(--muted)",
+    border: 0,
+    padding: "4px 8px",
+    fontSize: 11,
+    cursor: "pointer",
+    textDecoration: "underline",
+  },
+  helpInline: {
+    fontSize: 11,
+    color: "var(--muted)",
+    margin: 0,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    lineHeight: 1.4,
   },
   field: { display: "flex", flexDirection: "column", gap: 4 },
   fieldLabel: { fontSize: 12, color: "var(--fg)" },


### PR DESCRIPTION
## What this is
Phase 2 of the companion app. Stacks on **PR #104 (Phase 1)** — review that first; this PR's diff will collapse once #104 lands on main.

The companion now KNOWS the VPN state, can store credentials in the OS keychain, and best-effort triggers FortiClient / openfortivpn to bring the tunnel up. The "Start backend" click can pre-flight the VPN check so users don't get confused by failing integration calls right after startup.

## Phase plan recap
| # | Scope | Status |
|---|---|---|
| 1 | Electron scaffold + tray + Docker control | PR #104 ⏳ |
| **2 (this PR)** | VPN credentials + status + best-effort connect | 🟢 ready for review |
| 3 | Per-user CF tunnel + server routing | next |
| 4 | Code signing + auto-update + onboarding wizard | last |

## Architecture additions

### `src/main/keychain.ts` (new)
Wraps electron's `safeStorage`. Storage file (`credentials.json` under `userData`) is separate from `settings.json` so a config backup doesn't accidentally include secrets. Refuses to store when the OS keychain is unavailable — never silently falls back to plaintext.

### `src/main/vpn.ts` (new)
Two distinct things:

1. **`status()`** — DNS-probes a known gated host (`git.bcn.crealogix.net` by default). Returns one of:
   - `private` — resolves to RFC 1918 IP → VPN appears up
   - `public` — resolves to public IP → falls back to TCP probe
   - `nxdomain` — doesn't resolve → VPN appears down (matches earlier diagnosis of Crealogix's split-horizon)
   - `error` — DNS lookup failed for an unknown reason

2. **`connect()` / `discoverClient()`** — finds FortiClient or openfortivpn at platform-specific install paths, then:
   - **openfortivpn** → headless, uses username + password from settings/keychain, full automation
   - **FortiClient.exe** → launches GUI with `-p <saved-profile>`. User may need to click "Connect" inside FortiClient (EMS-managed installs block third-party automation)
   - **neither found** → returns a clear "open FortiClient yourself" message

### IPC + UI
- New IPC: `vpn:{status,connect,disconnect,discover-client}` + `credentials:{has,set,clear}`
- `backend:start` now respects `vpnAutoConnectOnStart` setting
- New "VPN (Crealogix)" section between Backend and Settings: live status badges, Connect/Disconnect/Refresh buttons, credentials sub-block, profile name, probe host, auto-connect toggle

### Security model
- Plaintext password is sent to main process **once**, encrypted via OS keychain, never echoed back to the renderer
- Renderer can ask "is the password set?" (boolean) but cannot retrieve the actual value
- `credentials.json` file mode set to 0o600

## Honest limitations
1. **FortiClient disconnect** is currently manual (returns a "use the tray icon" message). Reliable cross-platform process control will come in a Phase 2b polish PR.
2. **EMS-managed FortiClient installs** (common at enterprises with Endpoint Management Server) block third-party automation. For those, the companion can only bring the FortiClient window forward — the user still clicks "Connect" inside FortiClient.
3. **`openfortivpn` is the cleaner path** — installing it gives us full headless control. We surface this in the UI when present.

## Test plan
- [ ] `npm run dev` — companion opens with new VPN section
- [ ] Disconnected from corporate VPN: VPN section shows "down" (red) + NXDOMAIN message
- [ ] Connected via VPN: VPN section shows "up" (green) + resolved private IP
- [ ] Set a VPN password → renderer shows "stored ✓" + Clear button
- [ ] Clear the password → renderer shows the input field again
- [ ] Click Connect VPN (with FortiClient installed): FortiClient window comes forward
- [ ] Click Connect VPN (with openfortivpn installed + creds saved): tunnel comes up within ~15s
- [ ] Click Connect VPN (with NEITHER installed): "FortiClient wasn't found at expected paths" message
- [ ] Enable "auto-connect on start" → click Start backend with VPN down → VPN attempt fires before Docker starts
- [ ] Verify no plaintext password ever appears in the renderer's network log or React state

🤖 Generated with [Claude Code](https://claude.com/claude-code)