### PR TITLE
feat(api,web): Phase 3a + 3b — per-user companion-tunnel routing

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,7 +26,9 @@
   "dependencies": {
     "@espace-devhub/shared": "*",
     "@node-rs/argon2": "^2.0.2",
+    "@types/cookie": "^0.6.0",
     "@types/cookie-parser": "^1.4.9",
+    "@types/cookie-signature": "^1.1.2",
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.23",
     "@types/node": "^22.18.10",

--- a/apps/api/src/db/schemas/users.schema.ts
+++ b/apps/api/src/db/schemas/users.schema.ts
@@ -104,6 +104,20 @@ export const usersValidator: Document = {
         bsonType: ["string", "null"],
         enum: [...ALL_ENGAGEMENTS, null],
       },
+      // Companion-app registration (Phase 3). When set, the Vercel
+      // catch-all proxies /api/v1/* requests for this user to the
+      // companion's tunnel hostname instead of running the bundled
+      // Express app. Nullable so legacy rows + non-companion users
+      // pass validation.
+      companionTunnel: {
+        bsonType: ["object", "null"],
+        required: ["hostname", "registeredAt", "lastSeenAt"],
+        properties: {
+          hostname: { bsonType: "string", minLength: 4, maxLength: 256 },
+          registeredAt: { bsonType: "date" },
+          lastSeenAt: { bsonType: "date" },
+        },
+      },
     },
   },
 };

--- a/apps/api/src/db/types.ts
+++ b/apps/api/src/db/types.ts
@@ -221,6 +221,32 @@ export interface User {
   department?: string | null;
 
   /**
+   * Companion-app registration. When set, the Vercel catch-all
+   * (apps/web/src/pages/api/v1/[...path].ts) PROXIES every /api/v1/*
+   * call for this user to `hostname` instead of running the bundled
+   * Express app. Used by Crealogix-engagement users whose backend
+   * runs on their own laptop because Vercel can't reach private
+   * upstreams like git.bcn.crealogix.net.
+   *
+   *   hostname        Public DNS the companion-side tunnel exposes
+   *                   the local Express server at (e.g.
+   *                   "user-42.cf-tunnel.com"). HTTPS implicit.
+   *   registeredAt    First time the companion announced itself.
+   *   lastSeenAt      Last successful heartbeat. The catch-all
+   *                   refuses to proxy to a stale registration
+   *                   (older than COMPANION_STALE_AFTER_MS); falls
+   *                   back to the bundled API in that case.
+   *
+   * Optional/nullable on existing rows — backward-compatible with
+   * users created before this field shipped.
+   */
+  companionTunnel?: {
+    hostname: string;
+    registeredAt: Date;
+    lastSeenAt: Date;
+  } | null;
+
+  /**
    * Engagement assignment — which client/project this dev's
    * integration credentials resolve to. Each value maps to an
    * `<UPPERCASE>_*` env-var prefix that holds the engagement's

--- a/apps/api/src/lib/companion-routing.ts
+++ b/apps/api/src/lib/companion-routing.ts
@@ -1,0 +1,86 @@
+/**
+ * Companion-routing resolver — given an HTTP request, returns the
+ * companion-tunnel origin to proxy to, or null when the request
+ * should be served by the bundled API.
+ *
+ * Used by the Vercel catch-all (`apps/web/src/pages/api/v1/[...path].ts`)
+ * to dispatch /api/v1/* traffic to a user's personal companion when
+ * one is registered + fresh. Lives in @espace-devhub/api because:
+ *
+ *   1. It needs the same SESSION_SECRET + session-lookup logic the
+ *      auth module uses.
+ *   2. The catch-all already imports from @espace-devhub/api for
+ *      buildApp() — colocating this helper means one dynamic import,
+ *      one warm-container cost.
+ *
+ * Security model
+ * ──────────────
+ * We do a FULL server-side lookup (no header trust) so a malicious
+ * client can't redirect their requests to another user's tunnel:
+ *
+ *   1. Read the signed session cookie from the raw Cookie header
+ *   2. Verify the signature with SESSION_SECRET
+ *   3. Look up the session in Mongo → get userId
+ *   4. Look up the user → read their companionTunnel.hostname
+ *   5. Check the registration is fresh (last heartbeat < 5 min)
+ *
+ * If all five succeed, return `https://<hostname>`. Otherwise null.
+ *
+ * Performance: this is a 2-doc Mongo read (session + user) per
+ * request that has a session cookie. Both are indexed lookups by
+ * primary key; in p50 should add <5ms. Cold-start on a serverless
+ * container is dominated by the buildApp() compile + first Mongo
+ * connect, not this helper.
+ */
+
+import type { IncomingMessage } from "node:http";
+import { parse as parseCookieHeader } from "cookie";
+import { unsign } from "cookie-signature";
+import { env } from "../config/env.js";
+import { lookupSession } from "../modules/auth/session.js";
+import { SESSION_COOKIE_NAME } from "../modules/auth/cookies.js";
+import { getUsersCollection } from "../db/collections.js";
+
+const COMPANION_STALE_AFTER_MS = 5 * 60 * 1000;
+
+export async function resolveCompanionOrigin(
+  req: IncomingMessage,
+): Promise<string | null> {
+  try {
+    const cookieHeader = req.headers.cookie;
+    if (!cookieHeader || typeof cookieHeader !== "string") return null;
+
+    const cookies = parseCookieHeader(cookieHeader);
+    const raw = cookies[SESSION_COOKIE_NAME];
+    if (!raw) return null;
+
+    // Express's signed cookies are stored with an "s:" prefix on the
+    // value followed by a "." separator and the HMAC signature. We
+    // strip the prefix and unsign to recover the original sessionId.
+    if (!raw.startsWith("s:")) return null;
+    const unsigned = unsign(raw.slice(2), env.SESSION_SECRET);
+    if (!unsigned) return null;
+
+    const session = await lookupSession(unsigned);
+    if (!session) return null;
+
+    const users = await getUsersCollection();
+    const user = await users.findOne(
+      { _id: session.userId },
+      { projection: { companionTunnel: 1 } },
+    );
+    const tunnel = user?.companionTunnel;
+    if (!tunnel || !tunnel.hostname) return null;
+
+    const ageMs = Date.now() - new Date(tunnel.lastSeenAt).getTime();
+    if (ageMs >= COMPANION_STALE_AFTER_MS) return null;
+
+    return `https://${tunnel.hostname}`;
+  } catch {
+    // Defensive: ANY failure during routing resolution falls through
+    // to the bundled API. We never want a transient Mongo blip to
+    // 500 the whole catch-all just because the companion lookup
+    // didn't succeed.
+    return null;
+  }
+}

--- a/apps/api/src/modules/auth/controller.ts
+++ b/apps/api/src/modules/auth/controller.ts
@@ -65,6 +65,7 @@ import {
 } from "./cookies.js";
 import {
   acceptInviteSchema,
+  companionTunnelRegisterSchema,
   inviteSchema,
   loginSchema,
   passwordResetRequestSchema,
@@ -1347,6 +1348,194 @@ export async function signupHandler(
 
     res.json({
       user: toPublicUser({ ...userDoc, _id: insertedId }),
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── Phase 3: companion-tunnel registration + api-origin lookup ──────
+
+const COMPANION_STALE_AFTER_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Returns true if the user's companionTunnel registration is fresh
+ * enough to route real traffic to. A stale registration (no heartbeat
+ * in >5 min) is treated as "companion offline"; the caller falls back
+ * to the bundled API or surfaces an "open companion" banner.
+ */
+function isCompanionFresh(t: {
+  hostname: string;
+  registeredAt: Date;
+  lastSeenAt: Date;
+} | null | undefined): boolean {
+  if (!t || !t.hostname) return false;
+  const ageMs = Date.now() - new Date(t.lastSeenAt).getTime();
+  return ageMs < COMPANION_STALE_AFTER_MS;
+}
+
+// ─── POST /api/v1/me/companion-tunnel ─────────────────────────────────
+//
+// Called by the desktop companion app once its tunnel + Docker stack
+// are up. Registers (or refreshes) the user's tunnel hostname.
+// Authenticated via the regular session cookie (the companion will
+// have one after the Phase 3c device-pairing flow lands; in Phase 3a
+// the user can call this from a logged-in browser tab to seed it).
+//
+// Audit: writes user.companion_tunnel_registered. Lets admins see
+// when a Crealogix dev brought their backend online without exposing
+// the hostname publicly.
+
+export async function companionTunnelRegisterHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const { hostname } = companionTunnelRegisterSchema.parse(req.body);
+    const users = await getUsersCollection();
+    const now = new Date();
+
+    // Read current state so we can write an honest before/after audit.
+    const existing = await users.findOne({ _id: session.userId });
+    if (!existing) {
+      throw new HttpError(404, "not_found", "User not found.");
+    }
+    const before = existing.companionTunnel ?? null;
+
+    const next_value = {
+      hostname,
+      // Preserve original registeredAt across heartbeats so admins
+      // can see "this user first brought their companion online at X."
+      registeredAt: before?.hostname === hostname ? before.registeredAt : now,
+      lastSeenAt: now,
+    };
+
+    await users.updateOne(
+      { _id: session.userId },
+      {
+        $set: { companionTunnel: next_value, updatedAt: now },
+      },
+    );
+
+    await writeAudit({
+      orgId: session.orgId,
+      actorUserId: session.userId,
+      actorRole: session.role,
+      action: "user.companion_tunnel_registered",
+      targetType: "user",
+      targetId: session.userId.toHexString(),
+      before: before ? { hostname: before.hostname } : null,
+      after: { hostname },
+      ...networkMeta(req),
+    });
+
+    res.json({
+      companionTunnel: {
+        hostname,
+        registeredAt: next_value.registeredAt.toISOString(),
+        lastSeenAt: next_value.lastSeenAt.toISOString(),
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── DELETE /api/v1/me/companion-tunnel ────────────────────────────────
+//
+// Called by the companion when the user clicks Stop backend / Quit.
+// Cleanly removes the registration so the catch-all stops routing to
+// a dead tunnel and falls back to the bundled API.
+
+export async function companionTunnelClearHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const users = await getUsersCollection();
+    const now = new Date();
+    const before = await users.findOne({ _id: session.userId });
+
+    await users.updateOne(
+      { _id: session.userId },
+      { $set: { companionTunnel: null, updatedAt: now } },
+    );
+
+    if (before?.companionTunnel) {
+      await writeAudit({
+        orgId: session.orgId,
+        actorUserId: session.userId,
+        actorRole: session.role,
+        action: "user.companion_tunnel_cleared",
+        targetType: "user",
+        targetId: session.userId.toHexString(),
+        before: { hostname: before.companionTunnel.hostname },
+        after: null,
+        ...networkMeta(req),
+      });
+    }
+
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── GET /api/v1/me/api-origin ────────────────────────────────────────
+//
+// Frontend calls this on login to decide which origin to route
+// /api/v1/* calls to. Returns:
+//   { origin: "<companion-hostname>", source: "companion" }    when fresh
+//   { origin: null, source: "bundled" }                        otherwise
+//
+// The frontend's apiFetch wrapper uses `source: "companion"` as the
+// signal to set the `X-Companion-Origin` header on subsequent calls
+// so the catch-all knows to proxy. (The catch-all also re-verifies
+// the origin server-side — it doesn't trust the header alone.)
+
+export async function meApiOriginHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const users = await getUsersCollection();
+    const user = await users.findOne({ _id: session.userId });
+    if (!user) {
+      throw new HttpError(404, "not_found", "User not found.");
+    }
+
+    if (isCompanionFresh(user.companionTunnel)) {
+      res.json({
+        origin: `https://${user.companionTunnel!.hostname}`,
+        source: "companion",
+        lastSeenAt: user.companionTunnel!.lastSeenAt.toISOString(),
+      });
+      return;
+    }
+
+    res.json({
+      origin: null,
+      source: "bundled",
+      // Hint to the frontend about why we fell back so the UI can
+      // show a useful banner (e.g. "Companion last seen 2h ago —
+      // open it to resume").
+      lastSeenAt: user.companionTunnel?.lastSeenAt?.toISOString() ?? null,
+      staleHostname: user.companionTunnel?.hostname ?? null,
     });
   } catch (err) {
     next(err);

--- a/apps/api/src/modules/auth/routes.ts
+++ b/apps/api/src/modules/auth/routes.ts
@@ -39,9 +39,12 @@ import {
 } from "../../middleware/rate-limit.js";
 import {
   acceptInviteHandler,
+  companionTunnelClearHandler,
+  companionTunnelRegisterHandler,
   inviteHandler,
   loginHandler,
   logoutHandler,
+  meApiOriginHandler,
   meEngagementConfigHandler,
   meHandler,
   passwordResetHandler,
@@ -108,6 +111,27 @@ authRouter.get(
   "/me/engagement-config",
   requireAuth({ requireTotpEnrolled: false }),
   meEngagementConfigHandler,
+);
+
+// ─── Phase 3: companion-tunnel registration ─────────────────────────
+// Read endpoint open to un-enrolled (frontend reads it on login,
+// before TOTP setup is complete, to know whether to set up routing).
+// Mutation endpoints require full enrollment — companion runs as a
+// real desktop app the user uses regularly, no reason to relax there.
+authRouter.get(
+  "/me/api-origin",
+  requireAuth({ requireTotpEnrolled: false }),
+  meApiOriginHandler,
+);
+authRouter.post(
+  "/me/companion-tunnel",
+  requireAuth(),
+  companionTunnelRegisterHandler,
+);
+authRouter.delete(
+  "/me/companion-tunnel",
+  requireAuth(),
+  companionTunnelClearHandler,
 );
 authRouter.post(
   "/totp/enrol",

--- a/apps/api/src/modules/auth/schemas.ts
+++ b/apps/api/src/modules/auth/schemas.ts
@@ -181,3 +181,33 @@ export interface PublicUser {
    */
   engagement: string;
 }
+
+// ─── companion-tunnel registration (Phase 3) ─────────────────────────
+
+/**
+ * POST /api/v1/me/companion-tunnel body.
+ *
+ * `hostname` is the public DNS the user's companion app exposes
+ * its local Express server at — e.g. "espace-user-42.cf-tunnel.com".
+ * We accept it as a bare hostname; the proxy always sends HTTPS.
+ *
+ * Constraints:
+ *   - 4..256 chars
+ *   - lower-cased alpha-num + dots + hyphens (basic DNS-host charset)
+ *   - no scheme (https://) — we add it ourselves on outbound proxy
+ *   - no path / query — same reason
+ */
+export const companionTunnelRegisterSchema = z.object({
+  hostname: z
+    .string()
+    .min(4)
+    .max(256)
+    .regex(
+      /^[a-z0-9][a-z0-9.-]*[a-z0-9]$/i,
+      "hostname must be a bare DNS name (no scheme, no path, no query)",
+    )
+    .transform((s) => s.toLowerCase().trim()),
+});
+export type CompanionTunnelRegisterInput = z.infer<
+  typeof companionTunnelRegisterSchema
+>;

--- a/apps/api/src/serverless.ts
+++ b/apps/api/src/serverless.ts
@@ -26,3 +26,8 @@ export { buildApp } from "./app.js";
 export { connect, disconnect, getDb } from "./db/client.js";
 export { bootstrap } from "./db/collections.js";
 export { seedDefaultOrg } from "./db/seed.js";
+// Phase 3: the catch-all calls this BEFORE invoking the Express app
+// to decide whether to proxy the request to a user-specific companion
+// tunnel instead. Returns the origin to proxy to, or null to fall
+// through to buildApp().
+export { resolveCompanionOrigin } from "./lib/companion-routing.js";

--- a/apps/web/src/pages/api/v1/[...path].ts
+++ b/apps/web/src/pages/api/v1/[...path].ts
@@ -59,8 +59,135 @@
 
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { Application } from "express";
+import type { IncomingMessage } from "node:http";
+import https from "node:https";
 
 let appPromise: Promise<Application> | null = null;
+let resolveCompanionOrigin:
+  | ((req: IncomingMessage) => Promise<string | null>)
+  | null = null;
+
+// Hop-by-hop headers per RFC 7230 §6.1 — these MUST NOT be forwarded
+// when proxying. The rest of the request headers (including the
+// session Cookie) pass through unchanged so the companion's API sees
+// the same authenticated request the browser sent.
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  // Vercel-injected headers — the companion has no use for them and
+  // some confuse cookie/CSP middleware downstream.
+  "host",
+  "x-vercel-id",
+  "x-vercel-deployment-url",
+  "x-vercel-forwarded-for",
+  "x-vercel-ip-city",
+  "x-vercel-ip-country",
+  "x-vercel-ip-country-region",
+  "x-vercel-ip-latitude",
+  "x-vercel-ip-longitude",
+  "x-vercel-ip-timezone",
+  "x-vercel-ip-as-number",
+  "x-vercel-ip-continent",
+  "x-vercel-proxied-for",
+  "x-vercel-proxy-signature",
+  "x-vercel-proxy-signature-ts",
+  "x-vercel-sc-basepath",
+  "x-vercel-sc-headers",
+  "x-vercel-sc-host",
+  "x-vercel-enable-rewrite-caching",
+  "x-vercel-internal-timing",
+  "x-vercel-oidc-token",
+  "x-vercel-ja4-digest",
+  "x-vercel-ept",
+  "x-matched-path",
+  "x-real-ip",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-proto",
+  "x-forwarded-port",
+  "forwarded",
+  "x-invocation-id",
+]);
+
+function filterHeaders(
+  headers: NextApiRequest["headers"],
+  targetHost: string,
+): Record<string, string> {
+  const out: Record<string, string> = { host: targetHost };
+  for (const [k, v] of Object.entries(headers)) {
+    if (v == null) continue;
+    if (HOP_BY_HOP.has(k.toLowerCase())) continue;
+    out[k] = Array.isArray(v) ? v.join(", ") : v;
+  }
+  return out;
+}
+
+function proxyToCompanion(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  origin: string,
+): Promise<void> {
+  const target = new URL(req.url || "/", origin);
+  return new Promise((resolve) => {
+    const proxyReq = https.request(
+      {
+        hostname: target.hostname,
+        port: target.port || 443,
+        path: target.pathname + target.search,
+        method: req.method,
+        headers: filterHeaders(req.headers, target.hostname),
+      },
+      (proxyRes) => {
+        // Forward all upstream headers verbatim. Notably Set-Cookie
+        // (if the companion mints a session) flows back to the
+        // browser; the browser scopes it to espace-hubs.vercel.app
+        // because the response comes from there, not the tunnel
+        // hostname directly.
+        const headers = { ...proxyRes.headers };
+        for (const k of Object.keys(headers)) {
+          if (HOP_BY_HOP.has(k.toLowerCase())) delete headers[k];
+        }
+        res.writeHead(proxyRes.statusCode || 502, headers);
+        proxyRes.pipe(res);
+        proxyRes.on("end", () => resolve());
+        proxyRes.on("error", () => resolve());
+      },
+    );
+    proxyReq.on("error", (err) => {
+      // Companion unreachable — surface a clear error so the frontend
+      // can show "open your companion." We DON'T fall back to the
+      // bundled API here because the bundled API can't fetch from the
+      // user's private upstreams anyway (that was the whole reason
+      // we routed to the companion). A bundled response would just
+      // produce broken tile data and confuse the user.
+      // eslint-disable-next-line no-console
+      console.warn("[catch-all] companion proxy failed:", err.message);
+      if (!res.headersSent) {
+        res.statusCode = 502;
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify({
+            error: {
+              code: "companion_unreachable",
+              message: `Couldn't reach your companion at ${target.hostname}: ${err.message}. Open the companion app and try again.`,
+            },
+          }),
+        );
+      }
+      resolve();
+    });
+    // Stream the request body through — handles large bodies +
+    // streaming uploads without buffering everything in memory.
+    req.pipe(proxyReq);
+    req.on("error", () => proxyReq.destroy());
+  });
+}
 
 async function getApp(): Promise<Application> {
   if (!appPromise) {
@@ -71,6 +198,9 @@ async function getApp(): Promise<Application> {
       // the first /api/v1/* hit on a fresh container).
       const mod = await import("@espace-devhub/api");
       const app = mod.buildApp();
+      // Phase 3: capture the companion-routing resolver so we can
+      // ask it on every request whether to proxy instead.
+      resolveCompanionOrigin = mod.resolveCompanionOrigin;
       // Kick off the Mongo + bootstrap pipeline in the background.
       // We don't `await` it here so the first request can start
       // processing immediately — any handler that needs the DB
@@ -106,6 +236,30 @@ export default async function handler(
   res: NextApiResponse,
 ): Promise<void> {
   const app = await getApp();
+
+  // Phase 3 routing decision — does this user have a fresh companion
+  // tunnel registered? If yes, proxy the whole request there and skip
+  // the bundled Express app entirely. The resolver does a Mongo
+  // lookup keyed by the user's session; on null we fall through to
+  // the bundled path, preserving today's behavior for the 99% of
+  // users (and 100% of unauthenticated requests).
+  if (resolveCompanionOrigin) {
+    try {
+      const origin = await resolveCompanionOrigin(req);
+      if (origin) {
+        return proxyToCompanion(req, res, origin);
+      }
+    } catch (err) {
+      // Routing decision MUST be non-fatal — if Mongo is briefly
+      // unreachable for the resolver, we still want to serve the
+      // request via the bundled app rather than 500.
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[catch-all] companion-routing resolution failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
 
   // Next pre-parses cookies onto `req.cookies` before handing the
   // request to us. Express's `cookie-parser` short-circuits when it

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "espace-devhub",
       "version": "0.1.0",
       "workspaces": [
-        "apps/*",
+        "apps/api",
+        "apps/web",
         "packages/*"
       ]
     },
@@ -18,7 +19,9 @@
       "dependencies": {
         "@espace-devhub/shared": "*",
         "@node-rs/argon2": "^2.0.2",
+        "@types/cookie": "^0.6.0",
         "@types/cookie-parser": "^1.4.9",
+        "@types/cookie-signature": "^1.1.2",
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.23",
         "@types/node": "^22.18.10",
@@ -3869,6 +3872,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
     "node_modules/@types/cookie-parser": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
@@ -3876,6 +3885,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/express": "*"
+      }
+    },
+    "node_modules/@types/cookie-signature": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookie-signature/-/cookie-signature-1.1.2.tgz",
+      "integrity": "sha512-2OhrZV2LVnUAXklUFwuYUTokalh/dUb8rqt70OW6ByMSxYpauPZ+kfNLknX3aJyjY5iu8i3cUyoLZP9Fn37tTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/cors": {


### PR DESCRIPTION
## What this is
The architectural piece that makes the companion-app workstream actually useful. Backend records a per-user tunnel hostname; the Vercel catch-all checks for one on every `/api/v1/*` request and proxies through to the user's machine when present.

**Net effect**: a Crealogix user with their companion running can use the deployed Vercel app and all their `/api/v1/*` calls execute on their laptop's Docker stack — which CAN reach `git.bcn.crealogix.net`. Everyone else (no companion, espace engagement, etc.) keeps hitting the bundled API exactly as today.

## Phase 3a — data model + endpoints

| Where | What |
|---|---|
| `apps/api/src/db/types.ts` | `User.companionTunnel: { hostname, registeredAt, lastSeenAt }` — nullable, backward-compatible |
| `apps/api/src/db/schemas/users.schema.ts` | matching `$jsonSchema` validator |
| `apps/api/src/modules/auth/schemas.ts` | `companionTunnelRegisterSchema` (lowercase bare DNS host, no scheme/path/query) |
| `apps/api/src/modules/auth/controller.ts` | three new handlers, all audit-logged |
| `apps/api/src/modules/auth/routes.ts` | wired under `requireAuth` |

New endpoints:
- **POST `/me/companion-tunnel`** body `{ hostname }` — register/refresh
- **DELETE `/me/companion-tunnel`** — clear (companion calls this on Stop)
- **GET `/me/api-origin`** — frontend asks "where do my `/api/v1/*` calls go?" → `{ origin: <url>, source: "companion"|"bundled", lastSeenAt }` (5-minute staleness threshold)

## Phase 3b — per-request proxy

| Where | What |
|---|---|
| `apps/api/src/lib/companion-routing.ts` (NEW) | `resolveCompanionOrigin(req)` — reads signed session cookie, verifies signature, looks up user, returns the companion URL or null |
| `apps/api/src/serverless.ts` | exports the resolver for the catch-all |
| `apps/web/src/pages/api/v1/[...path].ts` | calls resolver BEFORE dispatching to bundled Express; on hit, full streaming proxy via Node's `https` module with hop-by-hop header stripping |

### Security model
**No header trust.** The resolver does a real session lookup against Mongo, so a malicious client can't redirect their requests to another user's tunnel by spoofing headers. Cost: one extra indexed Mongo read per `/api/v1/*` request that has a session cookie — single-digit ms p50.

### Defensive proxy behavior
- On companion-unreachable: returns `502 { code: "companion_unreachable", ... }`. Does NOT fall back to the bundled API — that API can't reach the user's private upstreams either; serving stale tile data would just confuse them.
- On resolver failure (transient Mongo blip): falls through to bundled API. Preserves availability for the request that triggered the blip.

## Not in this PR (deferred to follow-ups)
- **3c**: device-pairing auth so the companion can authenticate to call `POST /me/companion-tunnel` (right now you'd need to set the tunnel via mongosh or a browser session)
- **3d**: companion-side auto-register + periodic heartbeat
- **3e**: frontend UX — "Using companion: \<host>" indicator + "Companion offline" banner

## How to test today
1. Mongo insert by hand:
   ```js
   db.users.updateOne(
     { email: "you@example.com" },
     { $set: { companionTunnel: {
         hostname: "your-tunnel.cf-tunnel.com",
         registeredAt: new Date(),
         lastSeenAt: new Date(),
     } } }
   )
   ```
2. Run the companion (PR #105 merged) → `docker compose --profile tunnel up` → CF tunnel serving the api on `your-tunnel.cf-tunnel.com`.
3. Open `espace-hubs.vercel.app`, log in.
4. DevTools → Network → `/api/v1/*` responses now come from YOUR companion (verify by stopping the companion → next request returns `502 companion_unreachable`).

## Test plan
- [ ] User without `companionTunnel`: requests hit bundled API (no regression)
- [ ] User with FRESH `companionTunnel`: requests proxy to the tunnel
- [ ] User with STALE `companionTunnel` (lastSeenAt > 5min): falls back to bundled
- [ ] `GET /me/api-origin` returns `{ source: "companion", origin: "https://..." }` for fresh, `{ source: "bundled", origin: null }` otherwise
- [ ] `POST /me/companion-tunnel` audits `user.companion_tunnel_registered`
- [ ] `DELETE /me/companion-tunnel` clears the field + audits
- [ ] Cookie + Set-Cookie pass through the proxy intact (login → /me on the companion still works)
- [ ] Streaming endpoint (`/api/v1/ai/classify-goals` NDJSON) still streams through the proxy
- [ ] Companion process killed mid-request: 502 with `code: "companion_unreachable"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)