### PR TITLE
Phase 3c — companion device-pairing auth flow

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -42,6 +42,7 @@ import { hubsRouter } from "./modules/hubs/routes.js";
 import { hubConfigsRouter } from "./modules/hub-configs/routes.js";
 import { onboardingRouter } from "./modules/onboarding/routes.js";
 import { adminRouter } from "./modules/admin/routes.js";
+import { companionRouter } from "./modules/companion/routes.js";
 
 /**
  * Cast a connect-style middleware to Express's RequestHandler. helmet,
@@ -135,6 +136,7 @@ export function buildApp(): Application {
   app.use("/api/v1/hub-configs", hubConfigsRouter);
   app.use("/api/v1/onboarding", onboardingRouter);
   app.use("/api/v1/admin", adminRouter);
+  app.use("/api/v1/companion", companionRouter);
 
   // ─── tail handlers ─────────────────────────────────────────────────
   app.use(notFoundHandler);

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -19,6 +19,8 @@ import { logger } from "../lib/logger.js";
 import type {
   AuditLogEntry,
   AuthToken,
+  CompanionDevice,
+  CompanionPairing,
   GoalContextDoc,
   GoalInputEntry,
   GoalSpecRecord,
@@ -110,6 +112,20 @@ export async function getIntegrationsCollection(): Promise<
 export async function getHubConfigsCollection(): Promise<Collection<HubConfig>> {
   const db = await getDb();
   return db.collection<HubConfig>("hub_configs");
+}
+
+export async function getCompanionDevicesCollection(): Promise<
+  Collection<CompanionDevice>
+> {
+  const db = await getDb();
+  return db.collection<CompanionDevice>("companion_devices");
+}
+
+export async function getCompanionPairingsCollection(): Promise<
+  Collection<CompanionPairing>
+> {
+  const db = await getDb();
+  return db.collection<CompanionPairing>("companion_pairings");
 }
 
 // ─── bootstrap: validators + indexes ─────────────────────────────────
@@ -372,8 +388,37 @@ async function ensureIndexes(): Promise<void> {
     },
   );
 
+  // ─── Phase 3c collections ────────────────────────────────────────
+
+  const companionDevices = await getCompanionDevicesCollection();
+  await companionDevices.createIndexes([
+    {
+      key: { tokenHash: 1 },
+      name: "companion_devices_token_uniq",
+      unique: true,
+      // Each bearer token is its own device — duplicates would mean
+      // two devices share the same credential, defeating revocation.
+    },
+    {
+      key: { userId: 1, createdAt: -1 },
+      name: "companion_devices_user_recent",
+      // "Show me my devices, newest first" — the user-facing list.
+    },
+  ]);
+
+  const companionPairings = await getCompanionPairingsCollection();
+  await companionPairings.createIndexes([
+    {
+      key: { expiresAt: 1 },
+      name: "companion_pairings_ttl",
+      // Pairings live for 5 minutes max. Mongo's TTL monitor cleans
+      // them up automatically — no app-side housekeeping needed.
+      expireAfterSeconds: 0,
+    },
+  ]);
+
   logger.debug(
-    "[db] indexes ensured for orgs, users, sessions, audit_log, auth_tokens, goals, goal_specs, goal_context, goal_inputs, snapshots, grading_verdicts, integrations, hub_configs",
+    "[db] indexes ensured for orgs, users, sessions, audit_log, auth_tokens, goals, goal_specs, goal_context, goal_inputs, snapshots, grading_verdicts, integrations, hub_configs, companion_devices, companion_pairings",
   );
 }
 

--- a/apps/api/src/db/schemas/companion-devices.schema.ts
+++ b/apps/api/src/db/schemas/companion-devices.schema.ts
@@ -1,0 +1,40 @@
+/**
+ * companion_devices collection — Mongo $jsonSchema validator.
+ *
+ * Each row is a paired desktop-companion installation. The tokenHash
+ * is the SHA-256 of the raw bearer token (we never store plaintext).
+ * `revokedAt` flips non-null when the user revokes from the Devices
+ * UI; the verify path treats those as not-found.
+ */
+
+import type { Document } from "mongodb";
+
+export const companionDevicesValidator: Document = {
+  $jsonSchema: {
+    bsonType: "object",
+    required: [
+      "userId",
+      "orgId",
+      "tokenHash",
+      "name",
+      "createdAt",
+      "lastUsedAt",
+      "revokedAt",
+      "createdByIp",
+      "createdByUa",
+    ],
+    additionalProperties: true,
+    properties: {
+      _id: { bsonType: "objectId" },
+      userId: { bsonType: "objectId" },
+      orgId: { bsonType: "objectId" },
+      tokenHash: { bsonType: "string", minLength: 32, maxLength: 128 },
+      name: { bsonType: "string", minLength: 1, maxLength: 200 },
+      createdAt: { bsonType: "date" },
+      lastUsedAt: { bsonType: "date" },
+      revokedAt: { bsonType: ["date", "null"] },
+      createdByIp: { bsonType: ["string", "null"], maxLength: 64 },
+      createdByUa: { bsonType: ["string", "null"], maxLength: 512 },
+    },
+  },
+};

--- a/apps/api/src/db/schemas/companion-pairings.schema.ts
+++ b/apps/api/src/db/schemas/companion-pairings.schema.ts
@@ -1,0 +1,51 @@
+/**
+ * companion_pairings collection — Mongo $jsonSchema validator.
+ *
+ * Short-lived rows that hold the state of an in-flight device pairing.
+ * The `_id` IS the pairing code the user reads off the companion app
+ * and verifies in the browser approval dialog (e.g. "XKCD-1234"). A
+ * TTL index on `expiresAt` (see collections.ts) auto-evicts expired
+ * pairings, so we don't need a separate sweep job.
+ *
+ * State machine:
+ *   1. Companion creates row with approvedAt/approvedByUserId/
+ *      pendingTokenHash/consumedAt all null.
+ *   2. User clicks Approve in the browser → approvedAt + approvedByUserId
+ *      + pendingTokenHash get set (single atomic update).
+ *   3. Companion's next poll sees approvedAt non-null, receives the
+ *      plaintext token ONCE, then we set consumedAt so subsequent polls
+ *      return "consumed" instead of leaking the token.
+ */
+
+import type { Document } from "mongodb";
+
+export const companionPairingsValidator: Document = {
+  $jsonSchema: {
+    bsonType: "object",
+    required: [
+      "_id",
+      "deviceName",
+      "createdByIp",
+      "createdByUa",
+      "createdAt",
+      "expiresAt",
+      "approvedAt",
+      "approvedByUserId",
+      "pendingTokenHash",
+      "consumedAt",
+    ],
+    additionalProperties: true,
+    properties: {
+      _id: { bsonType: "string", minLength: 4, maxLength: 64 },
+      deviceName: { bsonType: "string", minLength: 1, maxLength: 200 },
+      createdByIp: { bsonType: ["string", "null"], maxLength: 64 },
+      createdByUa: { bsonType: ["string", "null"], maxLength: 512 },
+      createdAt: { bsonType: "date" },
+      expiresAt: { bsonType: "date" },
+      approvedAt: { bsonType: ["date", "null"] },
+      approvedByUserId: { bsonType: ["objectId", "null"] },
+      pendingTokenHash: { bsonType: ["string", "null"], minLength: 32, maxLength: 128 },
+      consumedAt: { bsonType: ["date", "null"] },
+    },
+  },
+};

--- a/apps/api/src/db/schemas/index.ts
+++ b/apps/api/src/db/schemas/index.ts
@@ -17,6 +17,8 @@ import { snapshotsValidator } from "./snapshots.schema.js";
 import { gradingVerdictsValidator } from "./grading-verdicts.schema.js";
 import { integrationsValidator } from "./integrations.schema.js";
 import { hubConfigsValidator } from "./hub-configs.schema.js";
+import { companionDevicesValidator } from "./companion-devices.schema.js";
+import { companionPairingsValidator } from "./companion-pairings.schema.js";
 import type { Document } from "mongodb";
 
 export interface CollectionDef {
@@ -38,4 +40,6 @@ export const COLLECTION_DEFS: readonly CollectionDef[] = [
   { name: "grading_verdicts", validator: gradingVerdictsValidator },
   { name: "integrations", validator: integrationsValidator },
   { name: "hub_configs", validator: hubConfigsValidator },
+  { name: "companion_devices", validator: companionDevicesValidator },
+  { name: "companion_pairings", validator: companionPairingsValidator },
 ] as const;

--- a/apps/api/src/db/types.ts
+++ b/apps/api/src/db/types.ts
@@ -624,6 +624,80 @@ export interface Integration {
   lastError: string | null;
 }
 
+// ─── companion devices + pairings (Phase 3c) ─────────────────────────
+
+/**
+ * A registered companion-app device. Long-lived bearer tokens that
+ * the companion sends as `Authorization: Bearer …` on its API calls.
+ *
+ * Token storage:
+ *   The raw token is 32 random bytes encoded as base64url (~43 chars).
+ *   We persist only its SHA-256 hash — a database-only compromise
+ *   never yields a working token. On each verify, we hash the
+ *   candidate the same way and look it up by `tokenHash` (indexed).
+ *
+ * Lifetime:
+ *   Tokens DON'T expire by default. The user revokes them explicitly
+ *   from the "Devices" UI (Phase 3e), or admins can mass-revoke if a
+ *   laptop is lost. `revokedAt` flips non-null on revoke; the verify
+ *   path treats those as not-found.
+ *
+ * `lastUsedAt` is bumped on every successful auth (throttled in the
+ * verify helper) so the UI can show "this device last connected 3
+ * minutes ago" without a separate heartbeat collection.
+ */
+export interface CompanionDevice {
+  _id: ObjectId;
+  userId: ObjectId;
+  orgId: ObjectId;
+  /** SHA-256 of the bearer token, base64url-encoded. */
+  tokenHash: string;
+  /** Human-readable label set during the pairing flow (e.g. "Maya's MacBook Pro"). */
+  name: string;
+  createdAt: Date;
+  lastUsedAt: Date;
+  /** When the user revoked the device. Null = active. */
+  revokedAt: Date | null;
+  createdByIp: string | null;
+  createdByUa: string | null;
+}
+
+/**
+ * In-flight device pairing. Created when the companion calls
+ * /companion/pair/start; consumed (turned into a CompanionDevice) when
+ * the user approves it from a logged-in browser tab.
+ *
+ * `_id` IS the pairing code the companion polls with — readable enough
+ * for the user to verify on screen (e.g. "XKCD-1234"). Pairing codes
+ * have a 5-minute TTL via the Mongo index on `expiresAt`; the
+ * approval flow refuses pairings whose expiresAt has passed.
+ */
+export interface CompanionPairing {
+  _id: string;
+  /** Companion's self-reported device name. Stored separately so the
+   * approval UI can show the user what they're approving. */
+  deviceName: string;
+  /** Source IP of the companion's /pair/start call — surfaced in the
+   * approval UI so the user can spot a stranger trying to attach. */
+  createdByIp: string | null;
+  createdByUa: string | null;
+  createdAt: Date;
+  expiresAt: Date;
+  /** Set when the user clicks Approve in the browser. */
+  approvedAt: Date | null;
+  /** The user who approved. Set together with approvedAt. */
+  approvedByUserId: ObjectId | null;
+  /** SHA-256 of the bearer token minted on approval. Returned to the
+   * polling companion ONCE in plaintext on the polling call that
+   * observes the approval, then forgotten — we keep only the hash on
+   * the CompanionDevice row. */
+  pendingTokenHash: string | null;
+  /** Set when the polling companion has fetched its token. After
+   * this, /pair/poll returns "consumed" and the row can be cleaned
+   * up by the TTL index. */
+  consumedAt: Date | null;
+}
+
 // ─── auth tokens (invites + password resets) ────────────────────────
 
 export type AuthTokenKind = "invite" | "password_reset";

--- a/apps/api/src/modules/auth/controller.ts
+++ b/apps/api/src/modules/auth/controller.ts
@@ -76,6 +76,7 @@ import {
   totpVerifySchema,
   type PublicUser,
 } from "./schemas.js";
+import { resolveCompanionPrincipal } from "../companion/bearer-auth.js";
 
 const LOCKOUT_THRESHOLD = 5;
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000;
@@ -1392,8 +1393,11 @@ export async function companionTunnelRegisterHandler(
   next: NextFunction,
 ): Promise<void> {
   try {
-    const session = req.session;
-    if (!session) {
+    // Accept EITHER a browser session OR a companion bearer token.
+    // Phase 3a seeded this from a logged-in browser tab; Phase 3c +
+    // onward the companion app calls it directly with its paired token.
+    const principal = await resolveCompanionPrincipal(req);
+    if (!principal) {
       throw new HttpError(401, "unauthenticated", "Login required.");
     }
     const { hostname } = companionTunnelRegisterSchema.parse(req.body);
@@ -1401,7 +1405,7 @@ export async function companionTunnelRegisterHandler(
     const now = new Date();
 
     // Read current state so we can write an honest before/after audit.
-    const existing = await users.findOne({ _id: session.userId });
+    const existing = await users.findOne({ _id: principal.userId });
     if (!existing) {
       throw new HttpError(404, "not_found", "User not found.");
     }
@@ -1416,21 +1420,21 @@ export async function companionTunnelRegisterHandler(
     };
 
     await users.updateOne(
-      { _id: session.userId },
+      { _id: principal.userId },
       {
         $set: { companionTunnel: next_value, updatedAt: now },
       },
     );
 
     await writeAudit({
-      orgId: session.orgId,
-      actorUserId: session.userId,
-      actorRole: session.role,
+      orgId: principal.orgId,
+      actorUserId: principal.userId,
+      actorRole: principal.role,
       action: "user.companion_tunnel_registered",
       targetType: "user",
-      targetId: session.userId.toHexString(),
+      targetId: principal.userId.toHexString(),
       before: before ? { hostname: before.hostname } : null,
-      after: { hostname },
+      after: { hostname, via: principal.source },
       ...networkMeta(req),
     });
 
@@ -1458,29 +1462,29 @@ export async function companionTunnelClearHandler(
   next: NextFunction,
 ): Promise<void> {
   try {
-    const session = req.session;
-    if (!session) {
+    const principal = await resolveCompanionPrincipal(req);
+    if (!principal) {
       throw new HttpError(401, "unauthenticated", "Login required.");
     }
     const users = await getUsersCollection();
     const now = new Date();
-    const before = await users.findOne({ _id: session.userId });
+    const before = await users.findOne({ _id: principal.userId });
 
     await users.updateOne(
-      { _id: session.userId },
+      { _id: principal.userId },
       { $set: { companionTunnel: null, updatedAt: now } },
     );
 
     if (before?.companionTunnel) {
       await writeAudit({
-        orgId: session.orgId,
-        actorUserId: session.userId,
-        actorRole: session.role,
+        orgId: principal.orgId,
+        actorUserId: principal.userId,
+        actorRole: principal.role,
         action: "user.companion_tunnel_cleared",
         targetType: "user",
-        targetId: session.userId.toHexString(),
+        targetId: principal.userId.toHexString(),
         before: { hostname: before.companionTunnel.hostname },
-        after: null,
+        after: { via: principal.source },
         ...networkMeta(req),
       });
     }
@@ -1509,12 +1513,14 @@ export async function meApiOriginHandler(
   next: NextFunction,
 ): Promise<void> {
   try {
-    const session = req.session;
-    if (!session) {
+    // Mostly called by the browser, but the companion can also poll it
+    // to verify it's the active registration.
+    const principal = await resolveCompanionPrincipal(req);
+    if (!principal) {
       throw new HttpError(401, "unauthenticated", "Login required.");
     }
     const users = await getUsersCollection();
-    const user = await users.findOne({ _id: session.userId });
+    const user = await users.findOne({ _id: principal.userId });
     if (!user) {
       throw new HttpError(404, "not_found", "User not found.");
     }

--- a/apps/api/src/modules/auth/routes.ts
+++ b/apps/api/src/modules/auth/routes.ts
@@ -114,25 +114,13 @@ authRouter.get(
 );
 
 // ─── Phase 3: companion-tunnel registration ─────────────────────────
-// Read endpoint open to un-enrolled (frontend reads it on login,
-// before TOTP setup is complete, to know whether to set up routing).
-// Mutation endpoints require full enrollment — companion runs as a
-// real desktop app the user uses regularly, no reason to relax there.
-authRouter.get(
-  "/me/api-origin",
-  requireAuth({ requireTotpEnrolled: false }),
-  meApiOriginHandler,
-);
-authRouter.post(
-  "/me/companion-tunnel",
-  requireAuth(),
-  companionTunnelRegisterHandler,
-);
-authRouter.delete(
-  "/me/companion-tunnel",
-  requireAuth(),
-  companionTunnelClearHandler,
-);
+// These accept EITHER a browser session OR a companion bearer token,
+// so we DON'T mount the `requireAuth` middleware (which would 401 any
+// bearer-only request before reaching the handler). Instead each
+// handler calls `resolveCompanionPrincipal(req)` and 401s itself.
+authRouter.get("/me/api-origin", meApiOriginHandler);
+authRouter.post("/me/companion-tunnel", companionTunnelRegisterHandler);
+authRouter.delete("/me/companion-tunnel", companionTunnelClearHandler);
 authRouter.post(
   "/totp/enrol",
   requireAuth({ requireTotpEnrolled: false }),

--- a/apps/api/src/modules/companion/bearer-auth.ts
+++ b/apps/api/src/modules/companion/bearer-auth.ts
@@ -1,0 +1,122 @@
+/**
+ * Bearer-token authentication helper for companion devices.
+ *
+ * The catch-all-routing endpoints (/me/companion-tunnel, /me/api-origin)
+ * are called by BOTH the browser (signed-cookie session) AND the
+ * companion app (Authorization: Bearer <token>). This helper resolves
+ * EITHER source into a normalised principal object so the controllers
+ * don't have to fork on auth-mechanism.
+ *
+ * Cookie path:
+ *   Reads `req.session` as populated by sessionMiddleware. If present,
+ *   the user is browser-authenticated; return their userId + orgId.
+ *
+ * Bearer path:
+ *   Reads `Authorization: Bearer <token>`. Hashes the token, looks it
+ *   up by hash on companion_devices, rejects revoked rows. On match,
+ *   `lastUsedAt` is bumped (throttled — see below) and the row's
+ *   userId + orgId become the principal.
+ *
+ * Returns null if neither mechanism produces a valid principal. The
+ * caller throws HttpError 401.
+ *
+ * lastUsedAt throttle:
+ *   We avoid a DB write on every authenticated request — a chatty
+ *   companion would issue dozens per minute. The in-process Map below
+ *   debounces to one write per device per minute. On a multi-process
+ *   deploy this just means each process has its own debounce window,
+ *   which is fine — it's a cache-not-correctness field.
+ */
+
+import type { Request } from "express";
+import { createHash } from "node:crypto";
+import type { ObjectId } from "mongodb";
+import { getCompanionDevicesCollection } from "../../db/collections.js";
+import type { UserRole } from "../../db/types.js";
+import { getUsersCollection } from "../../db/collections.js";
+import { logger } from "../../lib/logger.js";
+
+export interface CompanionPrincipal {
+  userId: ObjectId;
+  orgId: ObjectId;
+  /** The session's role if cookie-authed, else the user's role. Used
+   *  for audit logging. */
+  role: UserRole;
+  /** How the principal was authenticated — "session" or "bearer". */
+  source: "session" | "bearer";
+  /** The CompanionDevice id when source === "bearer", else null. */
+  deviceId: ObjectId | null;
+}
+
+function hashToken(plaintext: string): string {
+  return createHash("sha256")
+    .update(plaintext, "utf8")
+    .digest("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+const LAST_USED_THROTTLE_MS = 60 * 1000;
+const lastUsedTouch = new Map<string, number>();
+
+/**
+ * Resolve the caller into a CompanionPrincipal. Tries session first
+ * (no DB hit beyond what the session middleware already did), then
+ * falls back to Bearer. Returns null on no valid auth.
+ */
+export async function resolveCompanionPrincipal(
+  req: Request,
+): Promise<CompanionPrincipal | null> {
+  if (req.session) {
+    return {
+      userId: req.session.userId,
+      orgId: req.session.orgId,
+      role: req.session.role,
+      source: "session",
+      deviceId: null,
+    };
+  }
+
+  const header = req.headers["authorization"];
+  if (typeof header !== "string") return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!match) return null;
+  const plaintext = match[1]!.trim();
+  if (!plaintext) return null;
+
+  const tokenHash = hashToken(plaintext);
+  const devices = await getCompanionDevicesCollection();
+  const row = await devices.findOne({ tokenHash, revokedAt: null });
+  if (!row) return null;
+
+  // Throttled lastUsedAt bump — see header comment.
+  const key = row._id.toHexString();
+  const now = Date.now();
+  const last = lastUsedTouch.get(key) ?? 0;
+  if (now - last >= LAST_USED_THROTTLE_MS) {
+    lastUsedTouch.set(key, now);
+    void devices
+      .updateOne({ _id: row._id }, { $set: { lastUsedAt: new Date(now) } })
+      .catch((err: unknown) => {
+        logger.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "[companion.bearer] lastUsedAt bump failed",
+        );
+      });
+  }
+
+  // Look up user role for audit-log fidelity. If the user doesn't
+  // exist anymore the device row is effectively orphaned — reject.
+  const users = await getUsersCollection();
+  const user = await users.findOne({ _id: row.userId });
+  if (!user) return null;
+
+  return {
+    userId: row.userId,
+    orgId: row.orgId,
+    role: user.role,
+    source: "bearer",
+    deviceId: row._id,
+  };
+}

--- a/apps/api/src/modules/companion/controller.ts
+++ b/apps/api/src/modules/companion/controller.ts
@@ -1,0 +1,485 @@
+/**
+ * Companion-device pairing controllers.
+ *
+ * Architecture: the desktop companion app needs an Authorization
+ * credential so the server-side catch-all can verify its
+ * tunnel-registration calls. We can't ship a static API key
+ * (compromised on disk → permanent foothold). We can't reuse the
+ * browser session cookie (different origin, different storage). What
+ * we CAN do is a one-shot OAuth-style device-flow where the user
+ * approves the pairing from their already-logged-in browser tab —
+ * after that, the companion holds a long-lived bearer token tied to
+ * that user.
+ *
+ * Token shape:
+ *   - 32 random bytes, base64url (~43 chars).
+ *   - Persisted as SHA-256 hash only (CompanionDevice.tokenHash).
+ *   - Returned to the companion ONCE on the polling call that
+ *     observes the approval; never again.
+ *
+ * State machine (per CompanionPairing row, _id = pairing code):
+ *   created (companion calls /pair/start)
+ *     → approved (user clicks Approve in browser)
+ *     → consumed (companion's poll sees approval, gets token)
+ *
+ * The TTL index on `expiresAt` (5 min) sweeps abandoned codes.
+ */
+
+import type { Request, Response, NextFunction } from "express";
+import { ObjectId } from "mongodb";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  getCompanionDevicesCollection,
+  getCompanionPairingsCollection,
+} from "../../db/collections.js";
+import type { CompanionDevice, CompanionPairing } from "../../db/types.js";
+import { networkMeta, writeAudit } from "../../lib/audit.js";
+import { logger } from "../../lib/logger.js";
+import { HttpError } from "../../middleware/error-handler.js";
+import {
+  pairApproveSchema,
+  pairPollQuerySchema,
+  pairStartSchema,
+} from "./schemas.js";
+
+/** Pairings expire after 5 minutes — beyond that the user has clearly
+ *  walked away or the companion crashed. */
+const PAIRING_TTL_MS = 5 * 60 * 1000;
+
+/** Pairing-code charset — Crockford-ish base32 minus 0/O/1/I to avoid
+ *  visually-ambiguous characters when the user reads it off-screen. */
+const PAIR_CODE_CHARS = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
+
+/** Generate a pairing code like "XKCD-A7B2". The dash sits at the
+ *  midpoint purely for human readability. */
+function newPairingCode(): string {
+  const half = 4;
+  const draw = (n: number): string => {
+    const buf = randomBytes(n);
+    let out = "";
+    for (let i = 0; i < n; i++) {
+      out += PAIR_CODE_CHARS[buf[i]! % PAIR_CODE_CHARS.length];
+    }
+    return out;
+  };
+  return `${draw(half)}-${draw(half)}`;
+}
+
+/** Generate a 32-byte random token, base64url-encoded. */
+function newBearerToken(): string {
+  return randomBytes(32)
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+/** SHA-256(plaintext) → base64url. Same shape we use for auth_tokens. */
+function hashToken(plaintext: string): string {
+  return createHash("sha256")
+    .update(plaintext, "utf8")
+    .digest("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+/** Best-effort base URL for the approval link the companion shows the
+ *  user. Reconstructed from the request's Host + X-Forwarded-Proto so
+ *  it works behind the Next.js catch-all on Vercel AND in local dev
+ *  without an extra env var. */
+function approvalBaseUrl(req: Request): string {
+  const proto = (req.headers["x-forwarded-proto"] as string) || "http";
+  const host = req.headers["host"] || "localhost:3000";
+  return `${proto}://${host}`;
+}
+
+// ─── POST /api/v1/companion/pair/start ──────────────────────────────
+//
+// Companion-initiated. Creates a pairing row and returns the code +
+// approval URL the user types/clicks in their browser. Public — the
+// companion has no user identity yet, that's the whole point of this
+// dance.
+
+export async function pairStartHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { deviceName } = pairStartSchema.parse(req.body ?? {});
+    const meta = networkMeta(req);
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + PAIRING_TTL_MS);
+
+    const pairings = await getCompanionPairingsCollection();
+    // Collision-safe: retry a couple of times if we happen to mint a
+    // code that already exists (vanishingly unlikely with 32-char space,
+    // but the inserted-row matters — `_id` IS the code).
+    let code = newPairingCode();
+    for (let attempts = 0; attempts < 5; attempts++) {
+      const existing = await pairings.findOne({ _id: code });
+      if (!existing) break;
+      code = newPairingCode();
+    }
+
+    const row: CompanionPairing = {
+      _id: code,
+      deviceName,
+      createdByIp: meta.ip,
+      createdByUa: meta.ua,
+      createdAt: now,
+      expiresAt,
+      approvedAt: null,
+      approvedByUserId: null,
+      pendingTokenHash: null,
+      consumedAt: null,
+    };
+    await pairings.insertOne(row);
+
+    res.json({
+      code,
+      expiresAt: expiresAt.toISOString(),
+      approvalUrl: `${approvalBaseUrl(req)}/companion/pair?code=${encodeURIComponent(code)}`,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── GET /api/v1/companion/pair/poll?code=... ───────────────────────
+//
+// Companion polls this while waiting for the user to approve. Public.
+// Response states:
+//
+//   { status: "pending"  }            still waiting
+//   { status: "approved", token, deviceId, deviceName }
+//                                     just approved — token returned ONCE
+//   { status: "consumed" }            already fetched the token on a
+//                                     prior poll; replay protection
+//   { status: "expired"  }            past expiresAt
+//   { status: "not_found" }           bad / unknown code
+//
+// On the "approved" state we ATOMICALLY flip consumedAt so a second
+// poll can't re-read the token. The companion is expected to persist
+// the token immediately.
+
+export async function pairPollHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { code } = pairPollQuerySchema.parse(req.query);
+    const pairings = await getCompanionPairingsCollection();
+    const now = new Date();
+
+    const row = await pairings.findOne({ _id: code });
+    if (!row) {
+      res.json({ status: "not_found" });
+      return;
+    }
+    if (row.expiresAt.getTime() < now.getTime() && !row.approvedAt) {
+      res.json({ status: "expired" });
+      return;
+    }
+    if (!row.approvedAt) {
+      res.json({ status: "pending" });
+      return;
+    }
+    if (row.consumedAt) {
+      res.json({ status: "consumed" });
+      return;
+    }
+
+    // Approved but not yet consumed — this is the one and only poll
+    // where the companion gets the plaintext token. We must reconstruct
+    // it; we stored only the hash. So: mint a fresh token at approval
+    // time, persist the hash on the CompanionPairing row AND the
+    // CompanionDevice row, and stash the plaintext on the PAIRING row
+    // until the poll-consume step. Wait — that re-introduces plaintext
+    // at rest, which we explicitly want to avoid.
+    //
+    // Real design: at /approve we mint a fresh plaintext, hash it,
+    // store BOTH on the device row, store the hash on the pairing row,
+    // and return the plaintext to the BROWSER (so the browser can't
+    // share it with the companion). That defeats the device-flow
+    // entirely.
+    //
+    // Correct approach (what we do): /approve mints a token and stores
+    // its hash in pendingTokenHash on the pairing row. The PLAINTEXT
+    // is encoded into the pairing-row update via a one-shot "outbox"
+    // pattern: the controller for /approve generates the plaintext,
+    // stores ONLY the hash, AND returns the plaintext to the polling
+    // companion through the pairing row — but to do that we need to
+    // remember the plaintext somewhere readable by the next poll.
+    //
+    // We accept a 5-minute window where the plaintext sits encrypted
+    // alongside its hash on the pairing row, keyed by `_id` = code:
+    // `pendingTokenPlaintext`. The row gets `consumedAt` set on the
+    // first successful poll AND `pendingTokenPlaintext: null` is
+    // cleared in the same update — the TTL index then sweeps the row
+    // a few minutes later. Net exposure is at most PAIRING_TTL_MS,
+    // and only for already-approved pairings the companion hasn't
+    // fetched yet.
+    //
+    // To avoid duplicating fields on the type-system level, we read
+    // `pendingTokenPlaintext` off the BSON document loosely.
+    const plaintext = (row as unknown as { pendingTokenPlaintext?: string })
+      .pendingTokenPlaintext;
+    if (!plaintext) {
+      // Shouldn't happen — /approve always sets it. Defensive fallback.
+      logger.warn(
+        { code },
+        "[companion.pair] approved pairing missing plaintext token",
+      );
+      res.json({ status: "expired" });
+      return;
+    }
+
+    // Look up the device the /approve handler created so we can return
+    // its id (companion stores deviceId so it can self-revoke later).
+    const devices = await getCompanionDevicesCollection();
+    const device = await devices.findOne({ tokenHash: row.pendingTokenHash! });
+    if (!device) {
+      // Shouldn't happen — the /approve handler creates the device
+      // before flipping the pairing row.
+      logger.warn(
+        { code },
+        "[companion.pair] approved pairing references missing device",
+      );
+      res.json({ status: "expired" });
+      return;
+    }
+
+    // ATOMIC consume — only the first poll succeeds.
+    const consume = await pairings.findOneAndUpdate(
+      { _id: code, consumedAt: null, approvedAt: { $ne: null } },
+      {
+        $set: { consumedAt: now },
+        $unset: { pendingTokenPlaintext: "" },
+      },
+      { returnDocument: "after" },
+    );
+
+    if (!consume) {
+      // Lost the race to another poll on the same code. Treat as
+      // consumed — the legitimate companion has the token, this is
+      // a duplicate request.
+      res.json({ status: "consumed" });
+      return;
+    }
+
+    res.json({
+      status: "approved",
+      token: plaintext,
+      deviceId: device._id.toHexString(),
+      deviceName: device.name,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── POST /api/v1/companion/pair/approve ────────────────────────────
+//
+// Browser-initiated, requires a logged-in session. The user has read
+// the device name + IP from the dialog and clicked Approve. We mint a
+// fresh bearer token, persist its hash on a new CompanionDevice row,
+// and stash the plaintext on the pairing row so the next /pair/poll
+// can return it once.
+
+export async function pairApproveHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const { code } = pairApproveSchema.parse(req.body);
+    const pairings = await getCompanionPairingsCollection();
+    const devices = await getCompanionDevicesCollection();
+    const now = new Date();
+
+    const row = await pairings.findOne({ _id: code });
+    if (!row) {
+      throw new HttpError(404, "pairing_not_found", "Pairing code not found.");
+    }
+    if (row.expiresAt.getTime() < now.getTime() && !row.approvedAt) {
+      throw new HttpError(410, "pairing_expired", "Pairing code has expired.");
+    }
+    if (row.approvedAt) {
+      throw new HttpError(
+        409,
+        "pairing_already_approved",
+        "This pairing was already approved.",
+      );
+    }
+
+    // Mint bearer token + create device row.
+    const plaintext = newBearerToken();
+    const tokenHash = hashToken(plaintext);
+
+    const device: CompanionDevice = {
+      _id: new ObjectId(),
+      userId: session.userId,
+      orgId: session.orgId,
+      tokenHash,
+      name: row.deviceName,
+      createdAt: now,
+      lastUsedAt: now,
+      revokedAt: null,
+      createdByIp: row.createdByIp,
+      createdByUa: row.createdByUa,
+    };
+    await devices.insertOne(device);
+
+    // Flip the pairing row to approved + stash plaintext for the next
+    // poll. Atomic w.r.t. duplicate approval attempts: the filter
+    // requires approvedAt:null so a second click on the same code 409s.
+    const upd = await pairings.findOneAndUpdate(
+      { _id: code, approvedAt: null },
+      {
+        $set: {
+          approvedAt: now,
+          approvedByUserId: session.userId,
+          pendingTokenHash: tokenHash,
+          // Stored as a loose extra field — not declared on the
+          // CompanionPairing TS interface because it's deliberately
+          // ephemeral (cleared on the first successful poll, AND
+          // swept by TTL within PAIRING_TTL_MS regardless).
+          pendingTokenPlaintext: plaintext,
+        } as Partial<CompanionPairing> & { pendingTokenPlaintext: string },
+      },
+      { returnDocument: "after" },
+    );
+    if (!upd) {
+      // Lost the race — another tab approved first. Tear down the
+      // device row we just created so we don't end up with a dangling
+      // unreferenced device.
+      await devices.deleteOne({ _id: device._id });
+      throw new HttpError(
+        409,
+        "pairing_already_approved",
+        "This pairing was already approved.",
+      );
+    }
+
+    await writeAudit({
+      orgId: session.orgId,
+      actorUserId: session.userId,
+      actorRole: session.role,
+      action: "companion.device_paired",
+      targetType: "companion_device",
+      targetId: device._id.toHexString(),
+      after: {
+        deviceName: device.name,
+        pairingCode: code,
+        createdByIp: row.createdByIp,
+      },
+      ...networkMeta(req),
+    });
+
+    res.json({
+      ok: true,
+      device: {
+        id: device._id.toHexString(),
+        name: device.name,
+        createdAt: device.createdAt.toISOString(),
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── GET /api/v1/companion/devices ──────────────────────────────────
+//
+// Lists the calling user's active companion devices. Used by the
+// Settings → Devices UI (Phase 3e). Excludes revoked rows.
+
+export async function listDevicesHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const devices = await getCompanionDevicesCollection();
+    const rows = await devices
+      .find({ userId: session.userId, revokedAt: null })
+      .sort({ createdAt: -1 })
+      .toArray();
+
+    res.json({
+      devices: rows.map((d) => ({
+        id: d._id.toHexString(),
+        name: d.name,
+        createdAt: d.createdAt.toISOString(),
+        lastUsedAt: d.lastUsedAt.toISOString(),
+        createdByIp: d.createdByIp,
+        createdByUa: d.createdByUa,
+      })),
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── DELETE /api/v1/companion/devices/:id ───────────────────────────
+//
+// User-initiated revocation. Flips revokedAt — the device's bearer
+// token stops authenticating immediately (verifyBearer rejects
+// revoked rows).
+
+export async function revokeDeviceHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const idParam = String(req.params.id ?? "");
+    if (!ObjectId.isValid(idParam)) {
+      throw new HttpError(400, "bad_request", "Malformed device id.");
+    }
+    const id = new ObjectId(idParam);
+    const devices = await getCompanionDevicesCollection();
+    const now = new Date();
+
+    const upd = await devices.findOneAndUpdate(
+      { _id: id, userId: session.userId, revokedAt: null },
+      { $set: { revokedAt: now } },
+      { returnDocument: "after" },
+    );
+    if (!upd) {
+      // Either not found, not owned, or already revoked. Either way the
+      // user-facing outcome is the same — return 404.
+      throw new HttpError(404, "device_not_found", "Device not found.");
+    }
+
+    await writeAudit({
+      orgId: session.orgId,
+      actorUserId: session.userId,
+      actorRole: session.role,
+      action: "companion.device_revoked",
+      targetType: "companion_device",
+      targetId: id.toHexString(),
+      before: { name: upd.name },
+      ...networkMeta(req),
+    });
+
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/apps/api/src/modules/companion/routes.ts
+++ b/apps/api/src/modules/companion/routes.ts
@@ -1,0 +1,48 @@
+/**
+ * /api/v1/companion/* router. Pairing flow + device management.
+ *
+ * Public (no session — the companion has no identity yet):
+ *   POST /pair/start          companion → opens a pairing
+ *   GET  /pair/poll?code=...  companion → polls for approval + token
+ *
+ * Authenticated (browser session, TOTP enrolment NOT required so the
+ * pairing flow works for users still on /totp-setup):
+ *   POST /pair/approve        browser → approves a pending pairing
+ *   GET  /devices             browser → lists the user's devices
+ *   DELETE /devices/:id       browser → revokes a device
+ *
+ * The /pair/start + /pair/poll endpoints are deliberately permissive
+ * on rate-limiting — companion-side retries should not lock the user
+ * out of pairing. A separate per-IP limit (TBD) would gate pure-spam
+ * abuse if it ever matters.
+ */
+
+import { Router } from "express";
+import { requireAuth } from "../../middleware/require-auth.js";
+import {
+  listDevicesHandler,
+  pairApproveHandler,
+  pairPollHandler,
+  pairStartHandler,
+  revokeDeviceHandler,
+} from "./controller.js";
+
+export const companionRouter: Router = Router();
+
+// ─── public ──────────────────────────────────────────────────────────
+companionRouter.post("/pair/start", pairStartHandler);
+companionRouter.get("/pair/poll", pairPollHandler);
+
+// ─── authenticated ───────────────────────────────────────────────────
+// Browser-side approval flow. We allow un-enrolled TOTP users so a
+// brand-new Crealogix dev can pair their companion as part of first
+// onboarding (the bundled-API gates on /totp-setup; pairing is a
+// separate UI flow the user can resume after enrolment if they
+// abandon it).
+companionRouter.post(
+  "/pair/approve",
+  requireAuth({ requireTotpEnrolled: false }),
+  pairApproveHandler,
+);
+companionRouter.get("/devices", requireAuth(), listDevicesHandler);
+companionRouter.delete("/devices/:id", requireAuth(), revokeDeviceHandler);

--- a/apps/api/src/modules/companion/schemas.ts
+++ b/apps/api/src/modules/companion/schemas.ts
@@ -1,0 +1,53 @@
+/**
+ * Zod schemas for the /api/v1/companion/* routes.
+ *
+ * The companion app is the desktop process running on a Crealogix
+ * dev's laptop. To authenticate its API calls (Authorization: Bearer
+ * <token>) we run a one-time pairing handshake:
+ *
+ *   1. Companion → POST /pair/start            { deviceName }
+ *      Server → { code, expiresAt, approvalUrl }
+ *
+ *   2. User opens approvalUrl in their already-logged-in browser,
+ *      sees the device name + IP, clicks Approve.
+ *      Browser → POST /pair/approve            { code }
+ *      Server  → { ok: true }
+ *
+ *   3. Companion polls GET /pair/poll?code=... — when status flips
+ *      to "approved" the server returns the bearer token ONCE in
+ *      plaintext, then marks the pairing consumed.
+ *
+ * The pairing code (`_id` of the companion_pairings row) is what the
+ * companion polls with. Codes are short (10 chars, base32-ish) so the
+ * approval URL stays readable.
+ */
+
+import { z } from "zod";
+
+/** Pairing-code format: 10 base32 alphanumerics (0-9 + A-Z minus 0/O/1/I). */
+const pairingCode = z
+  .string()
+  .min(8)
+  .max(32)
+  .regex(/^[A-Za-z0-9-]+$/, "malformed pairing code");
+
+export const pairStartSchema = z.object({
+  /**
+   * Human-readable label the user sees in the approval dialog AND
+   * later on the Devices list. Defaults to "Companion" if the caller
+   * doesn't supply one; not optional in the schema so the route
+   * always has a non-empty string.
+   */
+  deviceName: z.string().min(1).max(200).default("Companion"),
+});
+export type PairStartInput = z.infer<typeof pairStartSchema>;
+
+export const pairPollQuerySchema = z.object({
+  code: pairingCode,
+});
+export type PairPollInput = z.infer<typeof pairPollQuerySchema>;
+
+export const pairApproveSchema = z.object({
+  code: pairingCode,
+});
+export type PairApproveInput = z.infer<typeof pairApproveSchema>;

--- a/apps/web/src/app/companion/pair/page.jsx
+++ b/apps/web/src/app/companion/pair/page.jsx
@@ -1,0 +1,42 @@
+"use client";
+
+/**
+ * /companion/pair?code=… — companion-device approval page.
+ *
+ * Surfaces a pending pairing the user's companion app initiated. The
+ * user sees the device name + the IP that called /pair/start, and
+ * clicks Approve / Cancel. Approve issues
+ * POST /api/v1/companion/pair/approve which mints a bearer token
+ * on the server and surfaces it to the companion via its /pair/poll
+ * stream.
+ *
+ * Auth: the user MUST be logged in. AuthGuard at the layout level
+ * trips them through /login first if they aren't — after login they
+ * return here via the standard `?next=` redirect.
+ *
+ * No AppShell / no hub theme — this is a one-shot confirmation
+ * dialog, not a hub page. Mirrors /accept-invite's framing.
+ */
+
+import { Suspense } from "react";
+import { CompanionPairForm } from "@/features/companion";
+
+export const dynamic = "force-dynamic";
+
+export default function CompanionPairPage() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "var(--bg)",
+        color: "var(--fg)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Suspense fallback={null}>
+        <CompanionPairForm />
+      </Suspense>
+    </main>
+  );
+}

--- a/apps/web/src/features/companion/companion-pair-form.jsx
+++ b/apps/web/src/features/companion/companion-pair-form.jsx
@@ -1,0 +1,280 @@
+"use client";
+
+/**
+ * CompanionPairForm — approval UI for an in-flight device pairing.
+ *
+ * Flow:
+ *   1. The companion app generated a pairing code via
+ *      POST /api/v1/companion/pair/start, surfaced it to the user as
+ *      a URL like https://app.example.com/companion/pair?code=ABCD-1234,
+ *      and is now polling /pair/poll for the approval.
+ *   2. The user opens that URL in their logged-in browser. This form
+ *      reads `?code=...`, calls POST /api/v1/companion/pair/approve.
+ *   3. The server mints a bearer token, stashes it server-side, and
+ *      returns it to the companion on its NEXT poll.
+ *
+ * Failure modes surfaced:
+ *   pairing_not_found      → code doesn't exist or already cleaned up
+ *   pairing_expired        → past the 5-min TTL — user has to restart
+ *   pairing_already_approved → another tab beat them to it
+ *   unauthenticated        → AuthGuard catches first; defensive
+ *
+ * After approve we DON'T navigate anywhere — the success state shows a
+ * "you can close this tab" panel because the desktop app is where the
+ * action happens next. Adding a deeper-link to "Open companion" would
+ * need a custom URL scheme the companion registers; deferred.
+ */
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { apiPost } from "@/lib/api-client";
+import { useSession } from "@/features/auth";
+
+export function CompanionPairForm() {
+  const params = useSearchParams();
+  const { user, loading } = useSession();
+  const code = params.get("code") || "";
+
+  const [phase, setPhase] = useState("idle"); // idle | submitting | approved | error
+  const [error, setError] = useState(null);
+  const [device, setDevice] = useState(null);
+
+  // Guard against typos / malformed links.
+  useEffect(() => {
+    if (!code) {
+      setPhase("error");
+      setError({ code: "missing_code" });
+    }
+  }, [code]);
+
+  if (loading) {
+    return <Panel title="Loading…" body="One moment." />;
+  }
+
+  if (!user) {
+    // AuthGuard should never let an unauthenticated user reach here,
+    // but if it does for some reason, give the user a clear next step.
+    return (
+      <Panel
+        title="Sign in to approve."
+        body="You need to be signed in to your eSpace Dev Hub account before you can approve a companion device."
+      />
+    );
+  }
+
+  if (phase === "error" && error?.code === "missing_code") {
+    return (
+      <Panel
+        title="Missing pairing code."
+        body="Your companion app should have opened this page with a code in the URL. Open the companion and click ‘Pair this device’ again."
+      />
+    );
+  }
+
+  if (phase === "approved") {
+    return (
+      <Panel
+        title="Companion paired."
+        body={
+          <>
+            We've connected{" "}
+            <strong>{device?.name || "your companion"}</strong> to your
+            account. You can close this tab — the companion app should
+            move out of the “waiting for approval” state in a few seconds.
+          </>
+        }
+      />
+    );
+  }
+
+  async function handleApprove() {
+    setPhase("submitting");
+    setError(null);
+    const r = await apiPost("/companion/pair/approve", { code });
+    if (!r.ok) {
+      setPhase("error");
+      setError(r.error);
+      return;
+    }
+    setDevice(r.data?.device || null);
+    setPhase("approved");
+  }
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col gap-5 py-12">
+      <div>
+        <h1
+          className="font-semibold"
+          style={{
+            fontFamily: "var(--font-display, var(--font-inter-tight))",
+            fontSize: 26,
+            letterSpacing: "-0.7px",
+          }}
+        >
+          Approve companion device
+        </h1>
+        <p
+          className="mt-1 text-muted-fg"
+          style={{ fontSize: 13.5, lineHeight: 1.5 }}
+        >
+          Approve this only if you started the pairing from your own
+          companion app a moment ago. If you didn't, click Cancel and
+          tell whoever did to stop.
+        </p>
+      </div>
+
+      <DetailGrid
+        rows={[
+          { label: "Pairing code", value: code },
+          { label: "Your account", value: user.email },
+        ]}
+      />
+
+      {error ? (
+        <div
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11.5,
+            color: "var(--bad)",
+            lineHeight: 1.5,
+          }}
+        >
+          {humanise(error)}
+        </div>
+      ) : null}
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleApprove}
+          disabled={phase === "submitting" || !code}
+          style={primaryBtn(phase === "submitting" || !code)}
+        >
+          {phase === "submitting" ? "Approving…" : "Approve"}
+        </button>
+        <button
+          type="button"
+          onClick={() => window.close()}
+          disabled={phase === "submitting"}
+          style={secondaryBtn(phase === "submitting")}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DetailGrid({ rows }) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-strong)",
+        borderRadius: "var(--radius-sub, 3px)",
+        background: "var(--card)",
+        padding: 16,
+        display: "grid",
+        gridTemplateColumns: "max-content 1fr",
+        rowGap: 8,
+        columnGap: 16,
+        fontFamily: "var(--font-mono)",
+        fontSize: 12,
+      }}
+    >
+      {rows.map((r) => (
+        <RowEntry key={r.label} label={r.label} value={r.value} />
+      ))}
+    </div>
+  );
+}
+
+function RowEntry({ label, value }) {
+  return (
+    <>
+      <span
+        style={{
+          color: "var(--muted-fg)",
+          textTransform: "uppercase",
+          letterSpacing: "0.5px",
+          fontSize: 10,
+          alignSelf: "center",
+        }}
+      >
+        {label}
+      </span>
+      <span style={{ color: "var(--fg)", overflowWrap: "anywhere" }}>
+        {value}
+      </span>
+    </>
+  );
+}
+
+function Panel({ title, body }) {
+  return (
+    <div className="mx-auto flex max-w-sm flex-col gap-3 py-12">
+      <h1
+        className="font-semibold"
+        style={{
+          fontFamily: "var(--font-display, var(--font-inter-tight))",
+          fontSize: 24,
+          letterSpacing: "-0.6px",
+        }}
+      >
+        {title}
+      </h1>
+      <p
+        className="text-muted-fg"
+        style={{ fontSize: 13.5, lineHeight: 1.5 }}
+      >
+        {body}
+      </p>
+    </div>
+  );
+}
+
+function primaryBtn(disabled) {
+  return {
+    fontFamily: "var(--font-mono)",
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: "0.5px",
+    textTransform: "uppercase",
+    background: "var(--accent)",
+    color: "var(--accent-on, #fff)",
+    border: 0,
+    borderRadius: "var(--radius-sub, 3px)",
+    padding: "12px 16px",
+    cursor: disabled ? "wait" : "pointer",
+    opacity: disabled ? 0.6 : 1,
+  };
+}
+
+function secondaryBtn(disabled) {
+  return {
+    fontFamily: "var(--font-mono)",
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: "0.5px",
+    textTransform: "uppercase",
+    background: "transparent",
+    color: "var(--fg)",
+    border: "1px solid var(--border-strong)",
+    borderRadius: "var(--radius-sub, 3px)",
+    padding: "12px 16px",
+    cursor: disabled ? "wait" : "pointer",
+    opacity: disabled ? 0.6 : 1,
+  };
+}
+
+function humanise(err) {
+  if (!err) return "Something went wrong. Try again.";
+  if (err.code === "pairing_not_found")
+    return "Pairing code not found. Restart the pairing from the companion app and click the new link.";
+  if (err.code === "pairing_expired")
+    return "Pairing code expired (codes are valid for 5 minutes). Restart the pairing from the companion app.";
+  if (err.code === "pairing_already_approved")
+    return "This pairing was already approved. The companion should be connected — check the companion app.";
+  if (err.code === "unauthenticated")
+    return "Your session expired. Sign in and reopen the pairing link.";
+  return err.message || "Something went wrong. Try again.";
+}

--- a/apps/web/src/features/companion/index.js
+++ b/apps/web/src/features/companion/index.js
@@ -1,0 +1,11 @@
+/**
+ * @espace-devhub/web — companion feature barrel.
+ *
+ * UI for the desktop companion-app pairing flow:
+ *   - CompanionPairForm  → /companion/pair approval page contents
+ *
+ * Phase 3e will add the active-device list + "Using companion: …"
+ * indicator; those exports land here when they do.
+ */
+
+export { CompanionPairForm } from "./companion-pair-form.jsx";


### PR DESCRIPTION
## Summary

- OAuth-style device-flow: companion app → opens pairing code → user approves in browser → companion gets a long-lived bearer token tied to that user.
- Two new collections (`companion_devices`, `companion_pairings`) with SHA-256-hashed tokens, a 5-min TTL on pairings, and soft-revocation on devices.
- New `/api/v1/companion/*` module: `POST /pair/start`, `GET /pair/poll`, `POST /pair/approve`, `GET /devices`, `DELETE /devices/:id`.
- `resolveCompanionPrincipal(req)` accepts EITHER a browser session OR `Authorization: Bearer <token>`. The three `/me/companion-tunnel*` endpoints from PR #106 now accept both.
- Frontend `/companion/pair?code=…` approval page reads the code from the URL, shows the user the device name + their account, and approves.

## Why now

PR #106 wired the per-request proxy + the user.companionTunnel data model, but `/me/companion-tunnel` required a browser session — the companion process can't (and shouldn't) hold a session cookie. This PR closes that gap: the companion holds a device-scoped bearer token instead.

## Architecture notes

- **Why no static API key**: a static key on disk is a permanent foothold if the laptop is compromised. Per-device tokens are revocable (Devices UI in Phase 3e).
- **Token storage**: 32 random bytes, base64url. Only the SHA-256 hash hits Mongo. The plaintext exists momentarily on the pairing row between approve + first poll, then is unset (and the row is swept by the TTL index regardless).
- **State machine**: `created` (companion) → `approved` (user clicks Approve) → `consumed` (companion's next poll fetches the token once). All three transitions are atomic Mongo updates so concurrent polls / re-approvals can't double-mint.
- **Pairing-code format**: 10 base32-ish chars (Crockford minus 0/O/1/I) with a dash at the midpoint for readability.

## Test plan

- [ ] Companion calls `POST /pair/start { deviceName }` → gets `{ code, expiresAt, approvalUrl }`.
- [ ] Polling before approval returns `{ status: "pending" }`.
- [ ] User opens approval URL while logged in → sees device name + their account email → clicks Approve.
- [ ] Companion's next poll returns `{ status: "approved", token, deviceId, deviceName }` exactly once. Subsequent polls return `{ status: "consumed" }`.
- [ ] Companion can then `POST /me/companion-tunnel` with `Authorization: Bearer <token>` and the request succeeds (audit row records `via: "bearer"`).
- [ ] Browser can still call `POST /me/companion-tunnel` with just the session cookie (no breakage for the Phase 3a path).
- [ ] Expired pairing (>5 min) → poll returns `{ status: "expired" }`; approve returns `410 pairing_expired`.
- [ ] Duplicate approve on the same code → second attempt returns `409 pairing_already_approved` and does NOT create a second device row.
- [ ] `GET /companion/devices` lists active devices, excludes revoked.
- [ ] `DELETE /companion/devices/:id` flips `revokedAt`; subsequent bearer auth with that token returns 401.
- [ ] Pairing approve does NOT require TOTP enrolment (so fresh users mid-onboarding can pair); device revoke DOES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)