### PR TITLE
Phase 3d — companion pairing + tunnel-registration heartbeat

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -29,6 +29,8 @@ import { pingApi } from "./health";
 import { settings } from "./settings";
 import * as vpn from "./vpn";
 import * as keychain from "./keychain";
+import * as pairing from "./pairing";
+import * as tunnelReg from "./tunnel-registration";
 
 // __dirname is available natively in CommonJS — no fileURLToPath
 // gymnastics needed. Electron's main process is CJS by default; we
@@ -95,6 +97,9 @@ function createWindow(): BrowserWindow {
   } else {
     win.loadFile(path.join(__dirname, "..", "renderer", "index.html"));
   }
+
+  // Forward pairing + registration push notifications to this window.
+  wirePushUpdates(win);
 
   return win;
 }
@@ -197,7 +202,15 @@ ipcMain.handle("backend:start", async () => {
       // recoverable state (retry the request after VPN connects).
     }
   }
-  return startBackend();
+  const result = await startBackend();
+  // Re-arm the registration heartbeat (idempotent on already-running
+  // loop) and poke it once so the server learns we're back online
+  // ahead of the next 60s tick.
+  if (result.ok) {
+    tunnelReg.startHeartbeat();
+    tunnelReg.poke();
+  }
+  return result;
 });
 
 ipcMain.handle("vpn:status", async () => {
@@ -239,6 +252,11 @@ ipcMain.handle("credentials:clear", async (_event, key: string) => {
 });
 
 ipcMain.handle("backend:stop", async () => {
+  // The tunnel runs in the same compose stack as the API. Once the
+  // user stops the stack the tunnel is gone — fall back the server's
+  // routing immediately instead of waiting 5 min for staleness to
+  // kick in.
+  void tunnelReg.stopHeartbeatAndUnregister({ silent: true });
   return stopBackend();
 });
 
@@ -260,6 +278,12 @@ ipcMain.handle("settings:get", async () => {
 
 ipcMain.handle("settings:set", async (_event, patch: Record<string, unknown>) => {
   settings.patch(patch);
+  // If the user just changed something that affects tunnel-routing,
+  // nudge the heartbeat so the server learns about it immediately
+  // instead of waiting up to 60s for the next tick.
+  if ("tunnelHostname" in patch || "apiBaseUrl" in patch) {
+    tunnelReg.poke();
+  }
   return settings.all();
 });
 
@@ -274,6 +298,61 @@ ipcMain.handle("shell:open-external", async (_event, url: string) => {
   await shell.openExternal(url);
 });
 
+// ─── pairing + tunnel registration (Phase 3d) ────────────────────────
+
+ipcMain.handle("pairing:start", async (_event, opts: { deviceName?: string } = {}) => {
+  pairing.startPairing(opts);
+  return pairing.getState();
+});
+
+ipcMain.handle("pairing:cancel", async () => {
+  pairing.cancelPairing();
+  return pairing.getState();
+});
+
+ipcMain.handle("pairing:state", async () => pairing.getState());
+
+ipcMain.handle("pairing:status", async () => ({
+  paired: pairing.isPaired(),
+  device: pairing.getPairedDevice(),
+  registration: tunnelReg.getStatus(),
+  state: pairing.getState(),
+}));
+
+ipcMain.handle("pairing:unpair", async () => {
+  // Stop heartbeat + DELETE on the server while the token is still
+  // valid, THEN clear the local token. Order matters — if we cleared
+  // the keychain first, the DELETE would 401 because there's no token
+  // to send.
+  await tunnelReg.stopHeartbeatAndUnregister({ silent: true });
+  pairing.unpair();
+  return { ok: true };
+});
+
+ipcMain.handle("tunnel:registration-status", async () => tunnelReg.getStatus());
+
+ipcMain.handle("tunnel:poke", async () => {
+  tunnelReg.poke();
+  return tunnelReg.getStatus();
+});
+
+// Forward pairing + registration state changes to the renderer so the
+// UI can re-render without polling. Set up once a window exists.
+function wirePushUpdates(win: BrowserWindow): void {
+  const sendPairing = (s: pairing.PairingState) => {
+    if (!win.isDestroyed()) win.webContents.send("pairing:state", s);
+  };
+  const sendReg = (s: tunnelReg.RegistrationStatus) => {
+    if (!win.isDestroyed()) win.webContents.send("tunnel:registration-state", s);
+  };
+  const offPairing = pairing.subscribe(sendPairing);
+  const offReg = tunnelReg.subscribe(sendReg);
+  win.on("closed", () => {
+    offPairing();
+    offReg();
+  });
+}
+
 // ─── lifecycle ──────────────────────────────────────────────────────
 
 app.whenReady().then(() => {
@@ -286,6 +365,11 @@ app.whenReady().then(() => {
   mainWindow = createWindow();
   tray = createTray();
   void tray; // keep the ref alive — tray instances are GC'd otherwise
+
+  // Phase 3d: start the tunnel-registration heartbeat. The loop
+  // gates internally on (paired? hostname set?) so it's safe to
+  // start eagerly — it just no-ops until the user finishes setup.
+  tunnelReg.startHeartbeat();
 });
 
 app.on("activate", () => {
@@ -310,4 +394,8 @@ app.on("before-quit", () => {
   // container running in the background even after the companion is
   // gone — surprising for the user.
   void stopBackend({ silent: true });
+  // Also clear the server-side tunnel registration so the catch-all
+  // falls back to the bundled API immediately (instead of waiting
+  // 5 min for staleness to time it out).
+  void tunnelReg.stopHeartbeatAndUnregister({ silent: true });
 });

--- a/apps/desktop/src/main/pairing.ts
+++ b/apps/desktop/src/main/pairing.ts
@@ -1,0 +1,290 @@
+/**
+ * Device-pairing client — talks to the Phase 3c backend endpoints to
+ * acquire a long-lived bearer token tied to the signed-in user.
+ *
+ * Flow (paralleling the server's state machine in
+ * apps/api/src/modules/companion/controller.ts):
+ *
+ *   1. We POST /api/v1/companion/pair/start → server returns
+ *      { code, expiresAt, approvalUrl }.
+ *   2. We open `approvalUrl` in the user's default browser. The user
+ *      is already signed into the web app (or signs in en route),
+ *      sees the device name + their account, and clicks Approve.
+ *   3. We poll GET /pair/poll?code=… every 2s. On the FIRST poll that
+ *      sees approvedAt non-null, the server returns
+ *      { status: "approved", token, deviceId, deviceName } and the
+ *      pairing row is consumed. Subsequent polls return "consumed".
+ *   4. We persist the token in the OS keychain (via keychain.ts) and
+ *      remember the deviceId + deviceName in settings.ts so the UI
+ *      can show "Paired as: <name>" without an extra round trip.
+ *
+ * Pairings TTL out after 5 minutes on the server (the TTL index on
+ * companion_pairings.expiresAt). We surface that as PAIRING_TIMEOUT
+ * locally and stop polling when we hit it — the user has to click
+ * Start again.
+ *
+ * No retries on network failures: the polling loop is the retry
+ * mechanism. A 4xx response (notably "pairing_expired") flips us into
+ * "expired"; the user starts over.
+ */
+
+import { shell } from "electron";
+import os from "node:os";
+import * as keychain from "./keychain";
+import { settings } from "./settings";
+
+/** SafeStorage key for the bearer token. */
+const TOKEN_KEYCHAIN_KEY = "companionBearerToken";
+
+const DEFAULT_API_BASE_URL = "https://espace-hubs.vercel.app";
+const POLL_INTERVAL_MS = 2_000;
+const PAIRING_TIMEOUT_MS = 5 * 60 * 1000;
+
+export type PairingState =
+  | { phase: "idle" }
+  | { phase: "starting" }
+  | {
+      phase: "pending";
+      code: string;
+      approvalUrl: string;
+      expiresAt: string;
+    }
+  | { phase: "approved"; deviceId: string; deviceName: string }
+  | { phase: "expired" }
+  | { phase: "error"; message: string };
+
+/**
+ * Listener registry — the IPC bridge subscribes here so it can push
+ * state changes to the renderer (via `webContents.send`). One state
+ * object at a time; new emissions overwrite the cached current state.
+ */
+type Listener = (s: PairingState) => void;
+const listeners = new Set<Listener>();
+let cachedState: PairingState = { phase: "idle" };
+
+function emit(s: PairingState): void {
+  cachedState = s;
+  for (const l of listeners) {
+    try {
+      l(s);
+    } catch {
+      // A bad listener mustn't crash the pairing flow.
+    }
+  }
+}
+
+export function getState(): PairingState {
+  return cachedState;
+}
+
+export function subscribe(l: Listener): () => void {
+  listeners.add(l);
+  return () => listeners.delete(l);
+}
+
+/** Returns the cached bearer token from the keychain, or null. */
+export function getToken(): string | null {
+  return keychain.get(TOKEN_KEYCHAIN_KEY);
+}
+
+/** True iff the keychain currently holds a paired token. */
+export function isPaired(): boolean {
+  return getToken() !== null;
+}
+
+/** Returns paired-device metadata for UI display. */
+export function getPairedDevice(): { deviceId: string | null; deviceName: string | null } {
+  return {
+    deviceId: settings.get<string | null>("pairedDeviceId", null),
+    deviceName: settings.get<string | null>("pairedDeviceName", null),
+  };
+}
+
+/** Wipe local pairing state. Does NOT call /devices/:id on the server —
+ *  the user can revoke from the Devices UI if they want server-side
+ *  revocation too. This is the "just stop using the token on this
+ *  laptop" knob. */
+export function unpair(): void {
+  keychain.clear(TOKEN_KEYCHAIN_KEY);
+  settings.patch({ pairedDeviceId: undefined, pairedDeviceName: undefined });
+  emit({ phase: "idle" });
+}
+
+function apiBase(): string {
+  const v = settings.get<string>("apiBaseUrl", "");
+  return (v && v.trim()) || DEFAULT_API_BASE_URL;
+}
+
+function defaultDeviceName(): string {
+  // OS hostname is a sensible default — recognisable to the user when
+  // they see the approval dialog. They can override it via the UI.
+  try {
+    const h = os.hostname();
+    return h || "Companion";
+  } catch {
+    return "Companion";
+  }
+}
+
+/**
+ * Cancel-token returned by `startPairing` so the renderer can abort a
+ * pending pairing (e.g. user clicked Cancel before approving).
+ */
+export interface PairingHandle {
+  cancel(): void;
+}
+
+let activeAbort: AbortController | null = null;
+
+/**
+ * Kick off a new pairing if one isn't already running. Returns
+ * immediately; observe progress via subscribe(). Subsequent calls
+ * while a pairing is active are no-ops (they don't reset state).
+ */
+export function startPairing(opts: { deviceName?: string } = {}): PairingHandle {
+  if (
+    cachedState.phase === "starting" ||
+    cachedState.phase === "pending"
+  ) {
+    return { cancel: cancelPairing };
+  }
+  activeAbort?.abort();
+  const ctrl = new AbortController();
+  activeAbort = ctrl;
+  void runPairing(opts.deviceName ?? defaultDeviceName(), ctrl.signal);
+  return { cancel: cancelPairing };
+}
+
+/**
+ * Cancel an in-flight pairing. Safe to call from anywhere (IPC,
+ * lifecycle hooks). Idempotent — calling on idle does nothing.
+ */
+export function cancelPairing(): void {
+  activeAbort?.abort();
+  activeAbort = null;
+  // Don't overwrite an "approved" terminal state — only knock pending
+  // back to idle. Otherwise the UI would lose its just-succeeded state.
+  if (
+    cachedState.phase === "starting" ||
+    cachedState.phase === "pending"
+  ) {
+    emit({ phase: "idle" });
+  }
+}
+
+async function runPairing(deviceName: string, signal: AbortSignal): Promise<void> {
+  emit({ phase: "starting" });
+  try {
+    const startRes = await fetch(`${apiBase()}/api/v1/companion/pair/start`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ deviceName }),
+      signal,
+    });
+    if (!startRes.ok) {
+      emit({ phase: "error", message: `Pair start failed (${startRes.status})` });
+      return;
+    }
+    const startBody = (await startRes.json()) as {
+      code: string;
+      expiresAt: string;
+      approvalUrl: string;
+    };
+
+    emit({
+      phase: "pending",
+      code: startBody.code,
+      approvalUrl: startBody.approvalUrl,
+      expiresAt: startBody.expiresAt,
+    });
+
+    // Best-effort: open the user's default browser straight to the
+    // approval page. Some Linux setups may not have a default
+    // browser registered — we don't treat that as fatal; the user
+    // can copy the URL from the UI.
+    void shell.openExternal(startBody.approvalUrl).catch(() => {});
+
+    // Poll loop. Stops on:
+    //   - signal aborted (user cancelled)
+    //   - hard timeout exceeded
+    //   - status flips to approved / expired / consumed / not_found
+    const deadline = Date.now() + PAIRING_TIMEOUT_MS;
+    while (!signal.aborted && Date.now() < deadline) {
+      await sleep(POLL_INTERVAL_MS, signal);
+      if (signal.aborted) return;
+
+      const pollRes = await fetch(
+        `${apiBase()}/api/v1/companion/pair/poll?code=${encodeURIComponent(startBody.code)}`,
+        { method: "GET", signal },
+      );
+      if (!pollRes.ok) {
+        // 4xx/5xx during poll — keep polling; transient network
+        // errors shouldn't kill an otherwise-valid pairing.
+        continue;
+      }
+      const body = (await pollRes.json()) as {
+        status: "pending" | "approved" | "consumed" | "expired" | "not_found";
+        token?: string;
+        deviceId?: string;
+        deviceName?: string;
+      };
+
+      if (body.status === "approved" && body.token && body.deviceId) {
+        // Persist token + metadata. Keychain set throws if safeStorage
+        // is unavailable — surface that to the UI rather than silently
+        // storing nothing.
+        try {
+          keychain.set(TOKEN_KEYCHAIN_KEY, body.token);
+        } catch (err) {
+          emit({
+            phase: "error",
+            message: `Couldn't store token in OS keychain: ${err instanceof Error ? err.message : String(err)}`,
+          });
+          return;
+        }
+        settings.patch({
+          pairedDeviceId: body.deviceId,
+          pairedDeviceName: body.deviceName ?? deviceName,
+        });
+        emit({
+          phase: "approved",
+          deviceId: body.deviceId,
+          deviceName: body.deviceName ?? deviceName,
+        });
+        return;
+      }
+      if (body.status === "expired" || body.status === "not_found") {
+        emit({ phase: "expired" });
+        return;
+      }
+      if (body.status === "consumed") {
+        // Either a previous poll already fetched the token (shouldn't
+        // happen — we're the only poller) or someone else used the
+        // same code. Treat as expired from the user's perspective.
+        emit({ phase: "expired" });
+        return;
+      }
+      // status === "pending" → keep polling.
+    }
+
+    if (Date.now() >= deadline) {
+      emit({ phase: "expired" });
+    }
+  } catch (err) {
+    if (signal.aborted) return; // user cancelled
+    emit({
+      phase: "error",
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const t = setTimeout(resolve, ms);
+    signal.addEventListener("abort", () => {
+      clearTimeout(t);
+      resolve();
+    }, { once: true });
+  });
+}

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -52,6 +52,38 @@ interface CompanionSchema {
   /** When true, clicking "Start backend" pre-flights the VPN — brings
    * it up first if it's down. */
   vpnAutoConnectOnStart?: boolean;
+
+  // ── Phase 3d: tunnel registration ────────────────────────────────
+  /**
+   * Public hostname the user's Cloudflare Tunnel exposes the local
+   * Express server at — e.g. "espace-user-42.cf-tunnel.com". Used
+   * by the companion's tunnel-registration heartbeat (POST
+   * /api/v1/me/companion-tunnel). The companion has no way to read
+   * this from `cloudflared` itself (the tunnel container only knows
+   * the token, not the hostname mapping), so the user enters it
+   * here once. Required for routing-mode to work.
+   */
+  tunnelHostname?: string;
+  /**
+   * Base URL of the eSpace Dev Hub web app the companion calls for
+   * pairing + tunnel registration. Defaults to the production
+   * Vercel deploy; configurable for staging / preview environments
+   * / on-prem deployments without rebuilding the companion.
+   */
+  apiBaseUrl?: string;
+  /**
+   * Cached server-issued device id from the most recent successful
+   * pairing. Not the bearer token (that's in the keychain) — just a
+   * UUID-shaped string used for "Unpair this device" UI. Cleared on
+   * Unpair.
+   */
+  pairedDeviceId?: string;
+  /**
+   * Display name the user gave their device during pairing. Cached
+   * so the UI can show "Paired as: <name>" without an extra round
+   * trip. Defaults to the OS hostname if the user didn't pick one.
+   */
+  pairedDeviceName?: string;
 }
 
 const FILE_NAME = "config.json";

--- a/apps/desktop/src/main/tunnel-registration.ts
+++ b/apps/desktop/src/main/tunnel-registration.ts
@@ -1,0 +1,219 @@
+/**
+ * Tunnel-registration heartbeat — keeps the server's record of
+ * `user.companionTunnel` fresh so the Vercel catch-all routes /api/v1/*
+ * for this user to OUR Cloudflare Tunnel.
+ *
+ * Why a heartbeat (vs. one-shot register)
+ * ────────────────────────────────────────
+ * The catch-all treats a registration as STALE if `lastSeenAt` is older
+ * than COMPANION_STALE_AFTER_MS (5 min, in
+ * apps/api/src/modules/auth/controller.ts). A laptop in standby, a
+ * crashed companion, or a closed lid all stop the heartbeat — within
+ * 5 min the server falls back to the bundled API automatically.
+ *
+ * Cadence
+ * ───────
+ *   - First register fires immediately when conditions are met (token
+ *     + hostname + tunnel container running).
+ *   - Subsequent heartbeats every HEARTBEAT_INTERVAL_MS.
+ *   - On Stop backend / app quit, we send DELETE /me/companion-tunnel
+ *     so the server doesn't leave a routing pointer dangling.
+ *
+ * Failure handling
+ * ────────────────
+ * A failed POST is logged-and-retried at the next tick. We DON'T
+ * surface every transient network error to the UI — only persistent
+ * failures (e.g. 401 = token revoked, 403 = role lost, 4xx schema
+ * rejections). The renderer reads getStatus() to show a banner.
+ */
+
+import * as pairing from "./pairing";
+import { settings } from "./settings";
+
+const DEFAULT_API_BASE_URL = "https://espace-hubs.vercel.app";
+const HEARTBEAT_INTERVAL_MS = 60_000;
+const REGISTER_RETRY_AFTER_MS = 5_000;
+
+export type RegistrationStatus =
+  | { phase: "idle"; reason: string }
+  | { phase: "registering" }
+  | { phase: "registered"; hostname: string; lastSeenAt: string }
+  | { phase: "error"; message: string };
+
+type Listener = (s: RegistrationStatus) => void;
+const listeners = new Set<Listener>();
+let cached: RegistrationStatus = { phase: "idle", reason: "not started" };
+
+function emit(s: RegistrationStatus): void {
+  cached = s;
+  for (const l of listeners) {
+    try {
+      l(s);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export function getStatus(): RegistrationStatus {
+  return cached;
+}
+
+export function subscribe(l: Listener): () => void {
+  listeners.add(l);
+  return () => listeners.delete(l);
+}
+
+function apiBase(): string {
+  const v = settings.get<string>("apiBaseUrl", "");
+  return (v && v.trim()) || DEFAULT_API_BASE_URL;
+}
+
+function tunnelHostname(): string | null {
+  const v = settings.get<string>("tunnelHostname", "");
+  const trimmed = (v || "").trim();
+  return trimmed || null;
+}
+
+let timer: NodeJS.Timeout | null = null;
+let stopping = false;
+
+/**
+ * Begin the heartbeat loop. Idempotent — calling twice is a no-op.
+ * The loop checks gating conditions on each tick (token? hostname?)
+ * so the user can pair / set the hostname AFTER the loop started and
+ * registration will Just Start.
+ */
+export function startHeartbeat(): void {
+  if (timer) return;
+  stopping = false;
+  void tick();
+  timer = setInterval(() => void tick(), HEARTBEAT_INTERVAL_MS);
+}
+
+/**
+ * Stop the heartbeat AND send DELETE /me/companion-tunnel so the server
+ * clears the routing pointer. Use this on Stop backend / app quit so
+ * the catch-all falls back to the bundled API cleanly. Returns once
+ * the DELETE round-trips (or fails — we don't block quit on it).
+ */
+export async function stopHeartbeatAndUnregister(opts: { silent?: boolean } = {}): Promise<void> {
+  stopping = true;
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  const token = pairing.getToken();
+  if (!token) {
+    emit({ phase: "idle", reason: "no token" });
+    return;
+  }
+  try {
+    const res = await fetch(`${apiBase()}/api/v1/me/companion-tunnel`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (!opts.silent && !res.ok) {
+      // eslint-disable-next-line no-console
+      console.warn("[tunnel-reg] DELETE returned", res.status);
+    }
+  } catch (err) {
+    if (!opts.silent) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[tunnel-reg] DELETE failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+  emit({ phase: "idle", reason: "unregistered" });
+}
+
+async function tick(): Promise<void> {
+  if (stopping) return;
+  const token = pairing.getToken();
+  if (!token) {
+    emit({ phase: "idle", reason: "not paired" });
+    return;
+  }
+  const hostname = tunnelHostname();
+  if (!hostname) {
+    emit({ phase: "idle", reason: "no tunnel hostname configured" });
+    return;
+  }
+  // We don't check Docker / cloudflared container state here — the
+  // server's freshness gate handles "companion claims X but X is
+  // unreachable" by returning 502 on the catch-all proxy. Adding a
+  // tunnel-side healthcheck before registering would be redundant.
+
+  if (cached.phase !== "registered") emit({ phase: "registering" });
+
+  try {
+    const res = await fetch(`${apiBase()}/api/v1/me/companion-tunnel`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ hostname }),
+    });
+    if (res.status === 401) {
+      // Token revoked or invalid. Stop the loop — re-pair is the
+      // only path forward, the user has to act.
+      stopping = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+      emit({
+        phase: "error",
+        message:
+          "Bearer token rejected (401). Re-pair the companion from the Devices section.",
+      });
+      return;
+    }
+    if (!res.ok) {
+      emit({
+        phase: "error",
+        message: `Register failed (${res.status})`,
+      });
+      // Don't tear down the loop — interval keeps trying so a
+      // transient failure self-heals.
+      return;
+    }
+    const body = (await res.json()) as {
+      companionTunnel?: {
+        hostname: string;
+        lastSeenAt: string;
+      };
+    };
+    if (body.companionTunnel) {
+      emit({
+        phase: "registered",
+        hostname: body.companionTunnel.hostname,
+        lastSeenAt: body.companionTunnel.lastSeenAt,
+      });
+    }
+  } catch (err) {
+    emit({
+      phase: "error",
+      message: err instanceof Error ? err.message : String(err),
+    });
+    // Schedule a faster retry once — transient DNS / TCP failures
+    // shouldn't wait a full minute. The loop interval still ticks
+    // on top of this; we just nudge sooner.
+    setTimeout(() => {
+      if (!stopping) void tick();
+    }, REGISTER_RETRY_AFTER_MS);
+  }
+}
+
+/**
+ * Trigger an immediate heartbeat without waiting for the next interval.
+ * Called when the user enters their tunnel hostname for the first time,
+ * after pairing succeeds, etc.
+ */
+export function poke(): void {
+  if (stopping) return;
+  void tick();
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -48,6 +48,35 @@ const api = {
     openExternal: (url: string) =>
       ipcRenderer.invoke("shell:open-external", url),
   },
+  // ── pairing + tunnel registration (Phase 3d) ─────────────────────
+  pairing: {
+    start: (opts: { deviceName?: string } = {}) =>
+      ipcRenderer.invoke("pairing:start", opts),
+    cancel: () => ipcRenderer.invoke("pairing:cancel"),
+    state: () => ipcRenderer.invoke("pairing:state"),
+    status: () => ipcRenderer.invoke("pairing:status"),
+    unpair: () => ipcRenderer.invoke("pairing:unpair"),
+    /**
+     * Subscribe to push updates of the pairing state. Returns an
+     * unsubscribe function — renderers should call it on unmount to
+     * avoid leaking listeners across hot-reloads.
+     */
+    onState: (cb: (s: unknown) => void) => {
+      const handler = (_e: unknown, s: unknown) => cb(s);
+      ipcRenderer.on("pairing:state", handler);
+      return () => ipcRenderer.off("pairing:state", handler);
+    },
+  },
+  tunnel: {
+    registrationStatus: () =>
+      ipcRenderer.invoke("tunnel:registration-status"),
+    poke: () => ipcRenderer.invoke("tunnel:poke"),
+    onRegistrationState: (cb: (s: unknown) => void) => {
+      const handler = (_e: unknown, s: unknown) => cb(s);
+      ipcRenderer.on("tunnel:registration-state", handler);
+      return () => ipcRenderer.off("tunnel:registration-state", handler);
+    },
+  },
 } as const;
 
 contextBridge.exposeInMainWorld("companion", api);

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -63,12 +63,53 @@ type CompanionWindow = Window & {
         vpnProfile?: string;
         vpnGatedHost?: string;
         vpnAutoConnectOnStart?: boolean;
+        tunnelHostname?: string;
+        apiBaseUrl?: string;
+        pairedDeviceId?: string;
+        pairedDeviceName?: string;
       }>;
       set: (patch: Record<string, unknown>) => Promise<unknown>;
     };
     shell: { openExternal: (url: string) => Promise<void> };
+    pairing: {
+      start: (opts?: { deviceName?: string }) => Promise<PairingState>;
+      cancel: () => Promise<PairingState>;
+      state: () => Promise<PairingState>;
+      status: () => Promise<{
+        paired: boolean;
+        device: { deviceId: string | null; deviceName: string | null };
+        registration: RegistrationStatus;
+        state: PairingState;
+      }>;
+      unpair: () => Promise<{ ok: boolean }>;
+      onState: (cb: (s: PairingState) => void) => () => void;
+    };
+    tunnel: {
+      registrationStatus: () => Promise<RegistrationStatus>;
+      poke: () => Promise<RegistrationStatus>;
+      onRegistrationState: (cb: (s: RegistrationStatus) => void) => () => void;
+    };
   };
 };
+
+type PairingState =
+  | { phase: "idle" }
+  | { phase: "starting" }
+  | {
+      phase: "pending";
+      code: string;
+      approvalUrl: string;
+      expiresAt: string;
+    }
+  | { phase: "approved"; deviceId: string; deviceName: string }
+  | { phase: "expired" }
+  | { phase: "error"; message: string };
+
+type RegistrationStatus =
+  | { phase: "idle"; reason: string }
+  | { phase: "registering" }
+  | { phase: "registered"; hostname: string; lastSeenAt: string }
+  | { phase: "error"; message: string };
 
 const companion = (window as unknown as CompanionWindow).companion;
 
@@ -93,10 +134,20 @@ export function App() {
   const [vpnPwdDraft, setVpnPwdDraft] = useState("");
   const [busy, setBusy] = useState<"" | "starting" | "stopping" | "vpn-connect" | "vpn-disconnect">("");
   const [error, setError] = useState<string | null>(null);
+  const [pairingState, setPairingState] = useState<PairingState>({ phase: "idle" });
+  const [registration, setRegistration] = useState<RegistrationStatus>({
+    phase: "idle",
+    reason: "loading…",
+  });
+  const [paired, setPaired] = useState(false);
+  const [pairedDevice, setPairedDevice] = useState<{
+    deviceId: string | null;
+    deviceName: string | null;
+  }>({ deviceId: null, deviceName: null });
 
   const refresh = useCallback(async () => {
     try {
-      const [s, p, ll, st, vs, vc, vp] = await Promise.all([
+      const [s, p, ll, st, vs, vc, vp, pairingStatus] = await Promise.all([
         companion.backend.status(),
         companion.api.ping(),
         companion.backend.logs(LOG_LINES),
@@ -104,6 +155,7 @@ export function App() {
         companion.vpn.status(),
         companion.vpn.discoverClient(),
         companion.credentials.has("vpnPassword"),
+        companion.pairing.status(),
       ]);
       setStatus(s);
       setPing(p);
@@ -112,6 +164,10 @@ export function App() {
       setVpn(vs);
       setVpnClient(vc);
       setVpnPwdFlag(vp);
+      setPaired(pairingStatus.paired);
+      setPairedDevice(pairingStatus.device);
+      setRegistration(pairingStatus.registration);
+      setPairingState(pairingStatus.state);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -122,6 +178,17 @@ export function App() {
     const t = setInterval(refresh, POLL_INTERVAL_MS);
     return () => clearInterval(t);
   }, [refresh]);
+
+  // Push subscriptions — pairing + registration state changes flow
+  // through immediately, no need to wait for the 3s polling tick.
+  useEffect(() => {
+    const offPairing = companion.pairing.onState((s) => setPairingState(s));
+    const offReg = companion.tunnel.onRegistrationState((s) => setRegistration(s));
+    return () => {
+      offPairing();
+      offReg();
+    };
+  }, []);
 
   const onStart = async () => {
     setBusy("starting");
@@ -179,6 +246,28 @@ export function App() {
   const onClearPassword = async () => {
     await companion.credentials.clear("vpnPassword");
     await refresh();
+  };
+
+  /* ── Pairing actions ─────────────────────────────────────────── */
+
+  const onStartPairing = async () => {
+    setError(null);
+    await companion.pairing.start({});
+  };
+
+  const onCancelPairing = async () => {
+    await companion.pairing.cancel();
+  };
+
+  const onUnpair = async () => {
+    await companion.pairing.unpair();
+    await refresh();
+  };
+
+  const onOpenApprovalUrl = async () => {
+    if (pairingState.phase === "pending") {
+      await companion.shell.openExternal(pairingState.approvalUrl);
+    }
   };
 
   return (
@@ -396,6 +485,98 @@ export function App() {
         </Field>
       </Section>
 
+      <Section title="Pairing & Routing">
+        <div style={S.row}>
+          <Stat
+            label="Pairing"
+            value={paired ? "linked" : "not paired"}
+            tone={paired ? "good" : "warn"}
+          />
+          <Stat
+            label="Device"
+            value={pairedDevice.deviceName || "—"}
+            tone="muted"
+          />
+          <Stat
+            label="Server routing"
+            value={
+              registration.phase === "registered"
+                ? "active"
+                : registration.phase === "registering"
+                ? "publishing…"
+                : registration.phase === "error"
+                ? "error"
+                : "idle"
+            }
+            tone={
+              registration.phase === "registered"
+                ? "good"
+                : registration.phase === "error"
+                ? "bad"
+                : "muted"
+            }
+          />
+          <Stat
+            label="Last heartbeat"
+            value={
+              registration.phase === "registered"
+                ? new Date(registration.lastSeenAt).toLocaleTimeString()
+                : "—"
+            }
+            tone="muted"
+          />
+        </div>
+
+        {/* Pairing state machine — the active branch swaps in. */}
+        <PairingBlock
+          state={pairingState}
+          paired={paired}
+          onStart={onStartPairing}
+          onCancel={onCancelPairing}
+          onUnpair={onUnpair}
+          onOpenUrl={onOpenApprovalUrl}
+        />
+
+        {/* Inline registration error banner — surfaces "token revoked"
+            etc. so the user knows to re-pair. Idle is silent. */}
+        {registration.phase === "error" && (
+          <div style={S.errorBanner}>{registration.message}</div>
+        )}
+        {registration.phase === "idle" && paired && (
+          <p style={S.helpInline}>
+            {registration.reason === "no tunnel hostname configured"
+              ? "Set your tunnel hostname below to start publishing your routing."
+              : `Registration idle: ${registration.reason}`}
+          </p>
+        )}
+
+        <Field
+          label="Tunnel hostname"
+          help="Public DNS the Cloudflare Tunnel exposes your local backend at — e.g. espace-user-42.cf-tunnel.com. The server PROXIES your /api/v1/* requests here while this companion is online."
+        >
+          <input
+            type="text"
+            value={settings.tunnelHostname || ""}
+            placeholder="espace-user-42.cf-tunnel.com"
+            onChange={(e) => onSettingChange("tunnelHostname", e.target.value)}
+            style={S.input}
+          />
+        </Field>
+
+        <Field
+          label="Web app URL"
+          help="The Vercel deployment the companion calls for pairing + tunnel registration. Defaults to https://espace-hubs.vercel.app — only change for staging/preview."
+        >
+          <input
+            type="text"
+            value={settings.apiBaseUrl || ""}
+            placeholder="https://espace-hubs.vercel.app"
+            onChange={(e) => onSettingChange("apiBaseUrl", e.target.value)}
+            style={S.input}
+          />
+        </Field>
+      </Section>
+
       <Section title="Settings">
         <Field
           label="Repo path"
@@ -438,7 +619,7 @@ export function App() {
 
       <footer style={S.footer}>
         <span>
-          Phase 2 · backend + VPN. Per-user tunnel routing lands in Phase 3.
+          Phase 3 · pairing + per-user tunnel routing active.
         </span>
         <a
           href="#"
@@ -512,6 +693,117 @@ function Stat({
     <div style={S.stat}>
       <div style={S.statLabel}>{label}</div>
       <div style={{ ...S.statValue, color }}>{value}</div>
+    </div>
+  );
+}
+
+function PairingBlock({
+  state,
+  paired,
+  onStart,
+  onCancel,
+  onUnpair,
+  onOpenUrl,
+}: {
+  state: PairingState;
+  paired: boolean;
+  onStart: () => void;
+  onCancel: () => void;
+  onUnpair: () => void;
+  onOpenUrl: () => void;
+}) {
+  // Renderer state is driven by both `paired` (do we have a token in
+  // the keychain?) and `state.phase` (what's the active pairing flow
+  // doing right now?). Six cases — covered explicitly so the surface
+  // is auditable rather than implicit.
+
+  if (state.phase === "pending") {
+    return (
+      <div style={S.pairCard}>
+        <div style={S.pairCode}>{state.code}</div>
+        <p style={S.pairCopy}>
+          Approve this code in your browser. We've opened the approval page —
+          if it didn't open, click below.
+        </p>
+        <div style={S.actions}>
+          <button type="button" style={S.btnPrimary} onClick={onOpenUrl}>
+            Re-open approval page
+          </button>
+          <button type="button" style={S.btnSecondary} onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+        <p style={S.helpInline}>
+          Expires at {new Date(state.expiresAt).toLocaleTimeString()}.
+        </p>
+      </div>
+    );
+  }
+
+  if (state.phase === "starting") {
+    return (
+      <div style={S.pairCard}>
+        <p style={S.pairCopy}>Opening pairing request…</p>
+      </div>
+    );
+  }
+
+  if (state.phase === "approved") {
+    return (
+      <div style={S.pairCard}>
+        <p style={S.pairCopy}>
+          Paired as <strong>{state.deviceName}</strong>. The companion will
+          register its tunnel hostname automatically.
+        </p>
+      </div>
+    );
+  }
+
+  if (state.phase === "expired") {
+    return (
+      <div style={S.pairCard}>
+        <p style={S.pairCopy}>
+          Pairing timed out before approval. Pairing codes are valid for 5
+          minutes — start again to get a new one.
+        </p>
+        <div style={S.actions}>
+          <button type="button" style={S.btnPrimary} onClick={onStart}>
+            Pair again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.phase === "error") {
+    return (
+      <div style={S.errorBanner}>
+        Pairing failed: {state.message}
+        <div style={{ ...S.actions, marginTop: 8 }}>
+          <button type="button" style={S.btnSecondary} onClick={onStart}>
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // phase === "idle": either fresh (not paired) or already paired.
+  if (paired) {
+    return (
+      <div style={S.actions}>
+        <button type="button" style={S.btnSecondary} onClick={onUnpair}>
+          Unpair this device
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={S.actions}>
+      <button type="button" style={S.btnPrimary} onClick={onStart}>
+        Pair this device
+      </button>
     </div>
   );
 }
@@ -668,6 +960,28 @@ const S: Record<string, React.CSSProperties> = {
     color: "var(--bad)",
     fontSize: 12,
     fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  },
+  pairCard: {
+    border: "1px solid var(--border)",
+    borderRadius: 6,
+    padding: 14,
+    background: "var(--bg)",
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  },
+  pairCode: {
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 22,
+    letterSpacing: 4,
+    fontWeight: 700,
+    color: "var(--accent)",
+  },
+  pairCopy: {
+    margin: 0,
+    fontSize: 12.5,
+    color: "var(--fg)",
+    lineHeight: 1.5,
   },
   footer: {
     marginTop: "auto",


### PR DESCRIPTION
> **Stacked on #107**. Merge that first; this PR's diff will collapse to just the desktop changes once it does.

## Summary

- Pairing client in the main process: opens a pair-start request → opens approval URL in the default browser → polls until approved → persists the bearer token in `safeStorage`.
- Tunnel-registration heartbeat: every 60s while paired + `tunnelHostname` is set, POSTs `/me/companion-tunnel` with `Authorization: Bearer <token>` so the server-side routing stays fresh.
- IPC + push subscriptions so the renderer reflects pairing + registration state in real time (no 3s poll lag).
- New "Pairing & Routing" section in the companion UI between VPN and Settings.

## Why now

PR #107 stood up the device-pairing endpoints; without a client that drives them, the server side is dormant. This is the missing companion-side half that closes the routing loop end-to-end:

1. User installs companion → clicks Pair → browser approval round-trips → bearer token lands on the laptop.
2. User enters their Cloudflare Tunnel hostname → heartbeat starts publishing it.
3. Vercel catch-all (Phase 3b) proxies `/api/v1/*` to that hostname on the next request.

## Lifecycle hooks

| Event                | Action                                              |
|----------------------|-----------------------------------------------------|
| `app.whenReady`      | `startHeartbeat()` (gated internally — no-ops until paired) |
| `backend:start` ok   | `poke()` so we register without waiting 60s         |
| `backend:stop`       | `stopHeartbeatAndUnregister()` — DELETE on server   |
| `app.before-quit`    | `stopHeartbeatAndUnregister({ silent: true })`      |
| Settings change (`tunnelHostname` / `apiBaseUrl`) | `poke()`              |

## Failure handling

- 401 from heartbeat → token revoked. Loop tears down + surfaces "re-pair from Devices section."
- Transient 5xx / network errors → keep polling; the 60s interval is the retry. We nudge a 5s retry on outright network failures for snappier recovery.
- Pairing 5-min TTL exceeded → flips to `expired`; user can click Pair again.

## Test plan

- [ ] On a fresh install, "Pairing" badge shows `not paired`. Clicking Pair opens the approval URL.
- [ ] Approval URL displays correct device name + the user's account email (browser is already logged in).
- [ ] On approve, companion logs `phase: "approved"`, badge flips to `linked`, token is in safeStorage.
- [ ] With `tunnelHostname` set, "Server routing" flips to `active` within ~2s.
- [ ] Heartbeat stays alive: stat `Last heartbeat` updates roughly every minute.
- [ ] Stop backend → DELETE fires; `/api/v1/me/api-origin` immediately returns `source: "bundled"` for that user.
- [ ] Quit companion → DELETE also fires.
- [ ] Manually revoke the device via `DELETE /companion/devices/:id` in the browser → next heartbeat returns 401 → companion shows "Bearer token rejected. Re-pair…" banner, loop stops.
- [ ] Pairing code timeout (don't approve for 5 min): companion flips to `expired`; Pair again works.
- [ ] Cancel button on the pending dialog returns the UI to idle without polling further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)