### PR TITLE
Phase 3d — companion auto-register + heartbeat

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -29,6 +29,8 @@ import { pingApi } from "./health";
 import { settings } from "./settings";
 import * as vpn from "./vpn";
 import * as keychain from "./keychain";
+import * as pair from "./pair";
+import * as tunnel from "./tunnel-register";
 
 // __dirname is available natively in CommonJS — no fileURLToPath
 // gymnastics needed. Electron's main process is CJS by default; we
@@ -197,7 +199,22 @@ ipcMain.handle("backend:start", async () => {
       // recoverable state (retry the request after VPN connects).
     }
   }
-  return startBackend();
+  const result = await startBackend();
+
+  // Phase 3d — after Docker is up, register the tunnel hostname with
+  // the Dev Hub so its catch-all proxies this user's API calls here
+  // instead of running the bundled Express app. Best-effort: if
+  // pairing isn't done or the hostname isn't configured we surface
+  // the reason in tunnel.getState() but don't fail the start.
+  if (
+    result.ok &&
+    settings.get<boolean>("tunnelAutoRegister", true) &&
+    pair.status().paired
+  ) {
+    void tunnel.start();
+  }
+
+  return result;
 });
 
 ipcMain.handle("vpn:status", async () => {
@@ -239,7 +256,45 @@ ipcMain.handle("credentials:clear", async (_event, key: string) => {
 });
 
 ipcMain.handle("backend:stop", async () => {
+  // Phase 3d — clear the tunnel registration BEFORE tearing down
+  // Docker. Order matters: if we stop Docker first, the catch-all
+  // could route an in-flight request to a hostname that no longer
+  // resolves, surfacing "companion_unreachable" instead of a clean
+  // bundled-API fallback.
+  await tunnel.stop();
   return stopBackend();
+});
+
+// ─── companion pairing IPC ───────────────────────────────────────────
+ipcMain.handle("companion:status", async () => {
+  return { ...pair.status(), tunnel: tunnel.getState() };
+});
+
+ipcMain.handle("companion:pair", async () => {
+  return pair.pair();
+});
+
+ipcMain.handle("companion:pair-cancel", async () => {
+  pair.cancelPairing();
+  return { ok: true };
+});
+
+ipcMain.handle("companion:unpair", async () => {
+  // Local-only forget. Devices-UI revoke (Phase 3e) is a separate
+  // path that hits DELETE /api/v1/companion/devices/:id with the
+  // browser session.
+  await tunnel.stop();
+  pair.unpair();
+  return { ok: true };
+});
+
+ipcMain.handle("tunnel:register", async () => {
+  return tunnel.start();
+});
+
+ipcMain.handle("tunnel:clear", async () => {
+  await tunnel.stop();
+  return { ok: true };
 });
 
 ipcMain.handle("backend:status", async () => {
@@ -305,9 +360,11 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
-  // Best-effort: stop the backend container when the user quits the
-  // companion. Without this, `docker compose up -d` would leave a
-  // container running in the background even after the companion is
-  // gone — surprising for the user.
+  // Best-effort: clear the tunnel registration so the Vercel
+  // catch-all stops proxying to a hostname we're about to take down,
+  // then stop the backend container. Without this, `docker compose
+  // up -d` would leave a container running in the background even
+  // after the companion is gone — surprising for the user.
+  void tunnel.stop();
   void stopBackend({ silent: true });
 });

--- a/apps/desktop/src/main/pair.ts
+++ b/apps/desktop/src/main/pair.ts
@@ -1,0 +1,350 @@
+/**
+ * Companion-side device pairing.
+ *
+ * The server-side flow lives in apps/api/src/modules/companion (Phase
+ * 3c, PR #107). This module is the desktop counterpart:
+ *
+ *   1. POST /api/v1/companion/pair/start { deviceName }
+ *      → { code, expiresAt, approvalUrl }
+ *
+ *   2. Open `approvalUrl` in the user's default browser. They're
+ *      already logged into the Dev Hub there; they click Approve.
+ *
+ *   3. Poll GET /api/v1/companion/pair/poll?code=... until it returns
+ *      `{ status: "approved", token, deviceId, deviceName }`. Up to
+ *      ~4½ minutes — the server expires the pairing at the 5-minute
+ *      mark, so we give up just before that.
+ *
+ *   4. Persist the bearer token via keychain.ts (safeStorage). From
+ *      that point on, any /me/companion-tunnel call carries it as
+ *      `Authorization: Bearer <token>`.
+ *
+ * The token NEVER returns to the renderer. The renderer asks
+ * `companion.pair.status()` and gets back a boolean + the device
+ * name; the plaintext lives only in OS keychain-encrypted form on
+ * disk and in this module's memory while signing requests.
+ *
+ * Re-pairing: calling `pair()` while a token is already stored just
+ * replaces it. The old device row stays valid on the server (and is
+ * cleanly revocable from the Devices UI in Phase 3e) — that lets the
+ * user pair a laptop they've already paired without first revoking.
+ */
+
+import { shell } from "electron";
+import os from "node:os";
+import * as keychain from "./keychain.js";
+import { settings } from "./settings.js";
+
+/** Public URL we default to when the user hasn't customised
+ *  `apiBaseUrl` in settings. Production deployment of the frontend. */
+const DEFAULT_API_BASE_URL = "https://espace-hubs.vercel.app";
+
+/** Keychain key under which the bearer token + device metadata live. */
+const TOKEN_KEY = "companionToken";
+const DEVICE_META_KEY = "companionDeviceMeta";
+
+/** Server-side TTL is 5 minutes. We stop polling ~30s short of that so
+ *  we don't race the cleanup. */
+const POLL_TIMEOUT_MS = 270_000;
+/** How often to poll /pair/poll. Balance is between "responsive to
+ *  the user clicking Approve" and "don't hammer the API." 2s is the
+ *  same cadence the existing health-ping uses. */
+const POLL_INTERVAL_MS = 2000;
+
+export interface PairResult {
+  ok: boolean;
+  deviceId?: string;
+  deviceName?: string;
+  message: string;
+}
+
+export interface PairStatus {
+  /** Whether we hold a bearer token on this machine. */
+  paired: boolean;
+  /** The label the server returned at pair-approval time. */
+  deviceName: string | null;
+  /** Server's ObjectId for this device — needed for self-revoke. */
+  deviceId: string | null;
+}
+
+interface PendingPairing {
+  code: string;
+  expiresAt: number;
+  approvalUrl: string;
+}
+
+let currentPolling: AbortController | null = null;
+
+function apiBaseUrl(): string {
+  const explicit = settings.get<string>("apiBaseUrl", "");
+  return (explicit && explicit.trim() ? explicit : DEFAULT_API_BASE_URL).replace(
+    /\/$/,
+    "",
+  );
+}
+
+function defaultDeviceName(): string {
+  // Fallback: "<hostname> (Companion)". Users can rename via the
+  // Devices UI later (Phase 3e). os.hostname() works on every
+  // platform Electron supports.
+  const host = os.hostname() || "Unknown";
+  return `${host} (Companion)`;
+}
+
+/** Returns the active bearer token, or null if we've never paired. */
+export function getToken(): string | null {
+  return keychain.get(TOKEN_KEY);
+}
+
+/** Light status lookup for the renderer — never leaks the token. */
+export function status(): PairStatus {
+  const tokenSet = keychain.has(TOKEN_KEY);
+  if (!tokenSet) {
+    return { paired: false, deviceName: null, deviceId: null };
+  }
+  const metaRaw = keychain.get(DEVICE_META_KEY);
+  if (!metaRaw) {
+    // Token exists but metadata's gone — treat as paired but
+    // unlabelled. UI shows "(unknown device)" and offers re-pair.
+    return { paired: true, deviceName: null, deviceId: null };
+  }
+  try {
+    const parsed = JSON.parse(metaRaw) as {
+      deviceId: string;
+      deviceName: string;
+    };
+    return {
+      paired: true,
+      deviceName: parsed.deviceName || null,
+      deviceId: parsed.deviceId || null,
+    };
+  } catch {
+    return { paired: true, deviceName: null, deviceId: null };
+  }
+}
+
+/**
+ * Cancel any in-flight polling loop. Idempotent — no-op when nothing
+ * is running. Called when the user clicks Cancel in the UI, or when
+ * the renderer triggers a fresh pair() while one is already underway.
+ */
+export function cancelPairing(): void {
+  if (currentPolling) {
+    currentPolling.abort();
+    currentPolling = null;
+  }
+}
+
+/**
+ * Run the full pairing handshake. Resolves when:
+ *   - the user approves in the browser (`ok: true`)
+ *   - the pairing expires server-side (`ok: false`)
+ *   - the user cancels via cancelPairing() (`ok: false`)
+ *
+ * Caller is the IPC handler; it returns the PairResult to the
+ * renderer so the UI can show success or surface the failure.
+ */
+export async function pair(): Promise<PairResult> {
+  cancelPairing();
+
+  const base = apiBaseUrl();
+  let pending: PendingPairing;
+  try {
+    pending = await startPairing(base);
+  } catch (err) {
+    return {
+      ok: false,
+      message:
+        err instanceof Error
+          ? `Couldn't start pairing — ${err.message}`
+          : "Couldn't start pairing.",
+    };
+  }
+
+  // Surface the approval URL to the user's default browser. We don't
+  // wait on this — if the user has a browser handler issue, the poll
+  // loop will still observe an approval if they navigate to the URL
+  // manually from a different machine (the URL is in the IPC return
+  // value for the UI to show).
+  try {
+    await shell.openExternal(pending.approvalUrl);
+  } catch (err) {
+    console.warn(
+      "[pair] failed to open approval URL — user can paste manually:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  currentPolling = new AbortController();
+  try {
+    const approved = await pollForApproval(base, pending, currentPolling);
+    persistToken(approved.token, approved.deviceId, approved.deviceName);
+    return {
+      ok: true,
+      deviceId: approved.deviceId,
+      deviceName: approved.deviceName,
+      message: `Paired as “${approved.deviceName}.”`,
+    };
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { ok: false, message: "Pairing cancelled." };
+    }
+    return {
+      ok: false,
+      message:
+        err instanceof Error
+          ? err.message
+          : "Pairing failed for an unknown reason.",
+    };
+  } finally {
+    currentPolling = null;
+  }
+}
+
+/** Drop the local token. Does NOT call the server's /devices/:id
+ *  revoke endpoint — that's a Phase 3e UI affordance ("Revoke from
+ *  all my devices"). This is local-only forget so the user can re-pair
+ *  a different account. */
+export function unpair(): void {
+  keychain.clear(TOKEN_KEY);
+  keychain.clear(DEVICE_META_KEY);
+}
+
+// ─── private ─────────────────────────────────────────────────────────
+
+async function startPairing(base: string): Promise<PendingPairing> {
+  const res = await fetch(`${base}/api/v1/companion/pair/start`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ deviceName: defaultDeviceName() }),
+  });
+  if (!res.ok) {
+    throw new Error(`pair/start returned ${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as {
+    code: string;
+    expiresAt: string;
+    approvalUrl: string;
+  };
+  if (!data.code || !data.approvalUrl) {
+    throw new Error("pair/start response was missing code/approvalUrl");
+  }
+  return {
+    code: data.code,
+    expiresAt: new Date(data.expiresAt).getTime(),
+    approvalUrl: data.approvalUrl,
+  };
+}
+
+interface ApprovedPairing {
+  token: string;
+  deviceId: string;
+  deviceName: string;
+}
+
+async function pollForApproval(
+  base: string,
+  pending: PendingPairing,
+  ctrl: AbortController,
+): Promise<ApprovedPairing> {
+  const deadline = Math.min(
+    Date.now() + POLL_TIMEOUT_MS,
+    pending.expiresAt - 5_000,
+  );
+
+  while (Date.now() < deadline) {
+    if (ctrl.signal.aborted) {
+      throw aborted();
+    }
+
+    let body: {
+      status: string;
+      token?: string;
+      deviceId?: string;
+      deviceName?: string;
+    };
+    try {
+      const res = await fetch(
+        `${base}/api/v1/companion/pair/poll?code=${encodeURIComponent(
+          pending.code,
+        )}`,
+        { signal: ctrl.signal },
+      );
+      body = (await res.json()) as typeof body;
+    } catch (err) {
+      if (ctrl.signal.aborted) throw aborted();
+      // Network blip — log + keep polling. Don't bail; the user could
+      // be reconnecting Wi-Fi between calls.
+      console.warn(
+        "[pair] poll fetch failed (will retry):",
+        err instanceof Error ? err.message : String(err),
+      );
+      await sleep(POLL_INTERVAL_MS, ctrl.signal);
+      continue;
+    }
+
+    if (body.status === "approved") {
+      if (!body.token || !body.deviceId) {
+        throw new Error(
+          "approved response missing token or deviceId — server bug?",
+        );
+      }
+      return {
+        token: body.token,
+        deviceId: body.deviceId,
+        deviceName: body.deviceName ?? defaultDeviceName(),
+      };
+    }
+    if (body.status === "expired") {
+      throw new Error(
+        "Pairing code expired before you approved. Try pairing again.",
+      );
+    }
+    if (body.status === "not_found") {
+      throw new Error(
+        "Pairing code disappeared on the server. Try pairing again.",
+      );
+    }
+    if (body.status === "consumed") {
+      // Another companion (or the same one on a prior run) already
+      // fetched this token. Treat as expired from this caller's POV.
+      throw new Error(
+        "Pairing was already used by another device. Try pairing again.",
+      );
+    }
+    // status === "pending" — fall through.
+    await sleep(POLL_INTERVAL_MS, ctrl.signal);
+  }
+  throw new Error(
+    "Timed out waiting for browser approval. Restart pairing and click Approve faster next time.",
+  );
+}
+
+function persistToken(token: string, deviceId: string, deviceName: string): void {
+  keychain.set(TOKEN_KEY, token);
+  keychain.set(
+    DEVICE_META_KEY,
+    JSON.stringify({ deviceId, deviceName }),
+  );
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) return reject(aborted());
+    const t = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(t);
+        reject(aborted());
+      },
+      { once: true },
+    );
+  });
+}
+
+function aborted(): Error {
+  const e = new Error("Pairing aborted.");
+  e.name = "AbortError";
+  return e;
+}

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -52,6 +52,22 @@ interface CompanionSchema {
   /** When true, clicking "Start backend" pre-flights the VPN — brings
    * it up first if it's down. */
   vpnAutoConnectOnStart?: boolean;
+  // ── Phase 3d: companion-tunnel routing ──────────────────────────
+  /** Public URL of the eSpace Dev Hub frontend the companion talks
+   *  to (for /api/v1/companion/* and /me/companion-tunnel). Defaults
+   *  to the production deployment; can be pointed at a preview /
+   *  localhost while developing. */
+  apiBaseUrl?: string;
+  /** The PUBLIC hostname the user's CF Tunnel exposes the local
+   *  backend at. Mirrors the tunnel's --hostname or the auto-assigned
+   *  trycloudflare.com value. The companion POSTs this to the
+   *  Vercel app on backend start so the catch-all knows where to
+   *  proxy this user's requests. */
+  tunnelHostname?: string;
+  /** When true, backend:start auto-registers tunnelHostname via the
+   *  paired bearer token AND backend:stop clears it. Defaults to true
+   *  on a fresh install. */
+  tunnelAutoRegister?: boolean;
 }
 
 const FILE_NAME = "config.json";

--- a/apps/desktop/src/main/tunnel-register.ts
+++ b/apps/desktop/src/main/tunnel-register.ts
@@ -1,0 +1,281 @@
+/**
+ * Per-user CF tunnel registration + heartbeat.
+ *
+ * The Vercel catch-all (apps/web/src/pages/api/v1/[...path].ts) looks
+ * up `user.companionTunnel` on every authenticated request. If it's
+ * fresh (lastSeenAt within COMPANION_STALE_AFTER_MS = 5 minutes), the
+ * request gets proxied to that hostname instead of the bundled
+ * Express app.
+ *
+ * This module is what keeps that row fresh while the companion is
+ * running:
+ *
+ *   start()    POSTs /me/companion-tunnel once (sets registeredAt
+ *              + lastSeenAt), then schedules heartbeat() on a 60s
+ *              interval.
+ *
+ *   heartbeat() re-POSTs (the server preserves registeredAt and just
+ *              bumps lastSeenAt). Each tick re-asserts our hostname so
+ *              if the user's tunnel hostname changed, the server
+ *              learns about it within a heartbeat window.
+ *
+ *   stop()     DELETE /me/companion-tunnel. Best-effort — we don't
+ *              block app quit on the network call succeeding.
+ *
+ * Auth: every request carries `Authorization: Bearer <token>` where
+ * `<token>` came out of the Phase 3c device-pairing flow (see
+ * apps/desktop/src/main/pair.ts). Without a paired token, start()
+ * returns `{ ok: false, reason: "not_paired" }` and never touches
+ * the network.
+ *
+ * Why the heartbeat at all
+ * ────────────────────────
+ * The catch-all decides "fresh enough to proxy?" by comparing
+ * `lastSeenAt` to a 5-minute stale threshold. If the companion
+ * crashed or the laptop sleeps, the row goes stale and the catch-all
+ * falls back to the bundled API — which is the right behaviour. The
+ * heartbeat is what keeps a healthy companion's row green; without
+ * it, requests would start failing after exactly 5 minutes of normal
+ * operation.
+ */
+
+import { getToken } from "./pair.js";
+import { settings } from "./settings.js";
+
+const DEFAULT_API_BASE_URL = "https://espace-hubs.vercel.app";
+const HEARTBEAT_INTERVAL_MS = 60_000;
+
+export interface TunnelState {
+  /** Whether the heartbeat loop is currently running. */
+  active: boolean;
+  /** The hostname we're keeping registered. Null when inactive. */
+  hostname: string | null;
+  /** ISO ts of the most recent successful POST/heartbeat. Null when
+   *  inactive OR when the first POST has not yet returned. */
+  lastSeenAt: string | null;
+  /** Last error from a register or heartbeat call, surfaced to the
+   *  renderer so the user can fix configuration. Null on success. */
+  lastError: string | null;
+}
+
+type StartResult =
+  | { ok: true; hostname: string }
+  | {
+      ok: false;
+      reason:
+        | "not_paired"
+        | "missing_hostname"
+        | "network_error"
+        | "server_error";
+      message: string;
+    };
+
+let state: TunnelState = {
+  active: false,
+  hostname: null,
+  lastSeenAt: null,
+  lastError: null,
+};
+let heartbeatTimer: NodeJS.Timeout | null = null;
+
+function apiBaseUrl(): string {
+  const explicit = settings.get<string>("apiBaseUrl", "");
+  return (explicit && explicit.trim() ? explicit : DEFAULT_API_BASE_URL).replace(
+    /\/$/,
+    "",
+  );
+}
+
+export function getState(): TunnelState {
+  return { ...state };
+}
+
+/**
+ * Register the configured tunnel hostname with the Dev Hub and start
+ * the heartbeat. Idempotent — calling while already active replaces
+ * the heartbeat schedule and re-fires an immediate POST so a hostname
+ * change propagates immediately.
+ */
+export async function start(): Promise<StartResult> {
+  const token = getToken();
+  if (!token) {
+    state = {
+      active: false,
+      hostname: null,
+      lastSeenAt: null,
+      lastError:
+        "Companion is not paired. Pair it in the companion settings before starting the backend.",
+    };
+    return {
+      ok: false,
+      reason: "not_paired",
+      message: state.lastError!,
+    };
+  }
+  const hostname = settings.get<string>("tunnelHostname", "").trim();
+  if (!hostname) {
+    state = {
+      active: false,
+      hostname: null,
+      lastSeenAt: null,
+      lastError:
+        "Tunnel hostname is empty. Set the public CF tunnel hostname in settings.",
+    };
+    return {
+      ok: false,
+      reason: "missing_hostname",
+      message: state.lastError!,
+    };
+  }
+
+  const post = await postRegister(token, hostname);
+  if (!post.ok) {
+    state = {
+      active: false,
+      hostname,
+      lastSeenAt: null,
+      lastError: post.message,
+    };
+    return post;
+  }
+
+  state = {
+    active: true,
+    hostname,
+    lastSeenAt: new Date().toISOString(),
+    lastError: null,
+  };
+  scheduleHeartbeat();
+  return { ok: true, hostname };
+}
+
+/** Stop the heartbeat and clear the server-side registration. */
+export async function stop(): Promise<void> {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+  const wasActive = state.active;
+  state = {
+    active: false,
+    hostname: null,
+    lastSeenAt: null,
+    lastError: null,
+  };
+  if (!wasActive) return;
+
+  const token = getToken();
+  if (!token) return; // nothing to do server-side without auth
+
+  try {
+    const res = await fetch(
+      `${apiBaseUrl()}/api/v1/auth/me/companion-tunnel`,
+      {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${token}` },
+      },
+    );
+    if (!res.ok && res.status !== 401) {
+      // 401 just means our token was revoked — there's nothing to
+      // unregister anyway. Other failures are best-effort; log and
+      // move on so we don't block shutdown.
+      console.warn(
+        "[tunnel-register] DELETE failed",
+        res.status,
+        await res.text().catch(() => ""),
+      );
+    }
+  } catch (err) {
+    console.warn(
+      "[tunnel-register] DELETE threw:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+function scheduleHeartbeat(): void {
+  if (heartbeatTimer) clearInterval(heartbeatTimer);
+  heartbeatTimer = setInterval(() => {
+    void heartbeat();
+  }, HEARTBEAT_INTERVAL_MS);
+}
+
+async function heartbeat(): Promise<void> {
+  if (!state.active || !state.hostname) return;
+  const token = getToken();
+  if (!token) {
+    // Token was revoked while we were running. Stop trying.
+    state = {
+      active: false,
+      hostname: state.hostname,
+      lastSeenAt: state.lastSeenAt,
+      lastError: "Companion token was revoked — re-pair to reconnect.",
+    };
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+    return;
+  }
+  const post = await postRegister(token, state.hostname);
+  if (post.ok) {
+    state = {
+      ...state,
+      lastSeenAt: new Date().toISOString(),
+      lastError: null,
+    };
+  } else {
+    // Keep the loop alive — a transient blip shouldn't unregister us
+    // (the server will fall back to the bundled API once lastSeenAt
+    // ages past 5 minutes, which gives us multiple recovery
+    // heartbeats). Surface the latest error to the UI.
+    state = { ...state, lastError: post.message };
+    // BUT: if the token's been revoked server-side, stop trying.
+    if (post.reason === "server_error" && post.message.includes("401")) {
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+        heartbeatTimer = null;
+      }
+      state = { ...state, active: false };
+    }
+  }
+}
+
+async function postRegister(
+  token: string,
+  hostname: string,
+): Promise<StartResult> {
+  try {
+    const res = await fetch(
+      `${apiBaseUrl()}/api/v1/auth/me/companion-tunnel`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ hostname }),
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return {
+        ok: false,
+        reason: "server_error",
+        message: `companion-tunnel register returned ${res.status}: ${
+          text || res.statusText
+        }`,
+      };
+    }
+    return { ok: true, hostname };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "network_error",
+      message:
+        err instanceof Error
+          ? `Couldn't reach the Dev Hub: ${err.message}`
+          : "Couldn't reach the Dev Hub.",
+    };
+  }
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -48,6 +48,20 @@ const api = {
     openExternal: (url: string) =>
       ipcRenderer.invoke("shell:open-external", url),
   },
+  // Phase 3d — device-pairing + tunnel-registration. The token NEVER
+  // crosses this bridge; `status` returns whether we hold one plus
+  // its label, and `start` runs the full pairing handshake in main
+  // and resolves with a success/failure summary.
+  pair: {
+    status: () => ipcRenderer.invoke("companion:status"),
+    start: () => ipcRenderer.invoke("companion:pair"),
+    cancel: () => ipcRenderer.invoke("companion:pair-cancel"),
+    forget: () => ipcRenderer.invoke("companion:unpair"),
+  },
+  tunnel: {
+    register: () => ipcRenderer.invoke("tunnel:register"),
+    clear: () => ipcRenderer.invoke("tunnel:clear"),
+  },
 } as const;
 
 contextBridge.exposeInMainWorld("companion", api);

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -63,10 +63,41 @@ type CompanionWindow = Window & {
         vpnProfile?: string;
         vpnGatedHost?: string;
         vpnAutoConnectOnStart?: boolean;
+        apiBaseUrl?: string;
+        tunnelHostname?: string;
+        tunnelAutoRegister?: boolean;
       }>;
       set: (patch: Record<string, unknown>) => Promise<unknown>;
     };
     shell: { openExternal: (url: string) => Promise<void> };
+    pair: {
+      status: () => Promise<{
+        paired: boolean;
+        deviceName: string | null;
+        deviceId: string | null;
+        tunnel: {
+          active: boolean;
+          hostname: string | null;
+          lastSeenAt: string | null;
+          lastError: string | null;
+        };
+      }>;
+      start: () => Promise<{
+        ok: boolean;
+        deviceId?: string;
+        deviceName?: string;
+        message: string;
+      }>;
+      cancel: () => Promise<{ ok: boolean }>;
+      forget: () => Promise<{ ok: boolean }>;
+    };
+    tunnel: {
+      register: () => Promise<
+        | { ok: true; hostname: string }
+        | { ok: false; reason: string; message: string }
+      >;
+      clear: () => Promise<{ ok: boolean }>;
+    };
   };
 };
 
@@ -78,6 +109,7 @@ type Settings = Awaited<ReturnType<typeof companion.settings.get>>;
 type VpnStatus = Awaited<ReturnType<typeof companion.vpn.status>>;
 type VpnClient = Awaited<ReturnType<typeof companion.vpn.discoverClient>>;
 type CredentialFlag = Awaited<ReturnType<typeof companion.credentials.has>>;
+type PairStatus = Awaited<ReturnType<typeof companion.pair.status>>;
 
 const POLL_INTERVAL_MS = 3000;
 const LOG_LINES = 50;
@@ -91,12 +123,21 @@ export function App() {
   const [vpnClient, setVpnClient] = useState<VpnClient | null>(null);
   const [vpnPwdFlag, setVpnPwdFlag] = useState<CredentialFlag | null>(null);
   const [vpnPwdDraft, setVpnPwdDraft] = useState("");
-  const [busy, setBusy] = useState<"" | "starting" | "stopping" | "vpn-connect" | "vpn-disconnect">("");
+  const [pairState, setPairState] = useState<PairStatus | null>(null);
+  const [busy, setBusy] = useState<
+    | ""
+    | "starting"
+    | "stopping"
+    | "vpn-connect"
+    | "vpn-disconnect"
+    | "pairing"
+    | "tunnel-register"
+  >("");
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     try {
-      const [s, p, ll, st, vs, vc, vp] = await Promise.all([
+      const [s, p, ll, st, vs, vc, vp, ps] = await Promise.all([
         companion.backend.status(),
         companion.api.ping(),
         companion.backend.logs(LOG_LINES),
@@ -104,6 +145,7 @@ export function App() {
         companion.vpn.status(),
         companion.vpn.discoverClient(),
         companion.credentials.has("vpnPassword"),
+        companion.pair.status(),
       ]);
       setStatus(s);
       setPing(p);
@@ -112,6 +154,7 @@ export function App() {
       setVpn(vs);
       setVpnClient(vc);
       setVpnPwdFlag(vp);
+      setPairState(ps);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -178,6 +221,46 @@ export function App() {
 
   const onClearPassword = async () => {
     await companion.credentials.clear("vpnPassword");
+    await refresh();
+  };
+
+  /* ── Pairing + tunnel actions ────────────────────────────────── */
+
+  const onPair = async () => {
+    setBusy("pairing");
+    setError(null);
+    // Pairing blocks up to ~4½ minutes while the user clicks Approve.
+    // We don't want the polling status-refresh interval to fire a
+    // duplicate pair attempt; the main process holds an internal
+    // single-flight guard, but we also avoid spamming the UI.
+    const r = await companion.pair.start();
+    if (!r.ok) setError(r.message);
+    setBusy("");
+    await refresh();
+  };
+
+  const onCancelPair = async () => {
+    await companion.pair.cancel();
+    setBusy("");
+    await refresh();
+  };
+
+  const onUnpair = async () => {
+    await companion.pair.forget();
+    await refresh();
+  };
+
+  const onTunnelRegister = async () => {
+    setBusy("tunnel-register");
+    setError(null);
+    const r = await companion.tunnel.register();
+    if (!r.ok) setError(r.message);
+    setBusy("");
+    await refresh();
+  };
+
+  const onTunnelClear = async () => {
+    await companion.tunnel.clear();
     await refresh();
   };
 
@@ -396,6 +479,135 @@ export function App() {
         </Field>
       </Section>
 
+      <Section title="Pairing & tunnel routing">
+        <div style={S.row}>
+          <Stat
+            label="Companion"
+            value={
+              pairState?.paired
+                ? `paired · ${pairState.deviceName || "(unnamed)"}`
+                : "not paired"
+            }
+            tone={pairState?.paired ? "good" : "warn"}
+          />
+          <Stat
+            label="Tunnel"
+            value={
+              pairState?.tunnel.active
+                ? `live · ${pairState.tunnel.hostname || ""}`
+                : pairState?.tunnel.hostname
+                ? "registered (stopped)"
+                : "off"
+            }
+            tone={pairState?.tunnel.active ? "good" : "muted"}
+          />
+          <Stat
+            label="Last seen"
+            value={
+              pairState?.tunnel.lastSeenAt
+                ? new Date(pairState.tunnel.lastSeenAt).toLocaleTimeString()
+                : "—"
+            }
+            tone="muted"
+          />
+        </div>
+        {pairState?.tunnel.lastError && (
+          <p style={S.helpInline}>{pairState.tunnel.lastError}</p>
+        )}
+        <div style={S.actions}>
+          {pairState?.paired ? (
+            <>
+              <button
+                type="button"
+                style={S.btnSecondary}
+                onClick={onUnpair}
+                disabled={!!busy}
+              >
+                Forget pairing
+              </button>
+              {pairState.tunnel.active ? (
+                <button
+                  type="button"
+                  style={S.btnSecondary}
+                  onClick={onTunnelClear}
+                  disabled={!!busy}
+                >
+                  Clear tunnel registration
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  style={S.btnPrimary}
+                  onClick={onTunnelRegister}
+                  disabled={!!busy}
+                >
+                  {busy === "tunnel-register" ? "Registering…" : "Register tunnel"}
+                </button>
+              )}
+            </>
+          ) : busy === "pairing" ? (
+            <>
+              <span style={S.helpInline}>
+                Approve the device in your browser — this window will update
+                as soon as the server sees the approval.
+              </span>
+              <button
+                type="button"
+                style={S.btnSecondary}
+                onClick={onCancelPair}
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              style={S.btnPrimary}
+              onClick={onPair}
+              disabled={!!busy}
+            >
+              Pair this device
+            </button>
+          )}
+        </div>
+        <Field
+          label="Tunnel hostname"
+          help="Public hostname your Cloudflare Tunnel exposes the local backend at (e.g. user-42.cf-tunnel.com). Used on backend start to register with the Dev Hub."
+        >
+          <input
+            type="text"
+            value={settings.tunnelHostname || ""}
+            placeholder="your-name.cf-tunnel.com"
+            onChange={(e) => onSettingChange("tunnelHostname", e.target.value.trim())}
+            style={S.input}
+          />
+        </Field>
+        <Field
+          label="Auto-register tunnel on backend start"
+          help="POST the hostname above when the backend comes up, DELETE when it goes down. Heartbeats every 60s while running."
+        >
+          <input
+            type="checkbox"
+            checked={settings.tunnelAutoRegister !== false}
+            onChange={(e) =>
+              onSettingChange("tunnelAutoRegister", e.target.checked)
+            }
+          />
+        </Field>
+        <Field
+          label="Dev Hub URL"
+          help="Where the companion talks to. Defaults to the production deployment; override to point at a preview or localhost for development."
+        >
+          <input
+            type="text"
+            value={settings.apiBaseUrl || ""}
+            placeholder="https://espace-hubs.vercel.app"
+            onChange={(e) => onSettingChange("apiBaseUrl", e.target.value.trim())}
+            style={S.input}
+          />
+        </Field>
+      </Section>
+
       <Section title="Settings">
         <Field
           label="Repo path"
@@ -438,7 +650,7 @@ export function App() {
 
       <footer style={S.footer}>
         <span>
-          Phase 2 · backend + VPN. Per-user tunnel routing lands in Phase 3.
+          Phase 3d · pairing + auto-register. Devices UI lands in Phase 3e.
         </span>
         <a
           href="#"


### PR DESCRIPTION
> Stacks on #107. Merge after that one.

## Summary

- Companion-side device pairing: opens the approval URL in the user's default browser, polls until they click Approve, persists the bearer token via `safeStorage` (DPAPI / macOS Keychain / libsecret).
- Auto-register the per-user CF tunnel hostname when `backend:start` brings Docker up; clear it on `backend:stop` and on app quit.
- 60s heartbeat keeps `lastSeenAt` inside the catch-all's 5-minute freshness window so a healthy companion stays continuously proxied to.
- New renderer section surfaces paired-device label, live/stopped tunnel state, last-seen time, and a Pair button.

## What changed

**New modules**
- `apps/desktop/src/main/pair.ts` — pairing handshake, token persistence, status read.
- `apps/desktop/src/main/tunnel-register.ts` — POST `/me/companion-tunnel` with bearer, scheduled heartbeat, DELETE on stop, clean shutdown on token-revoked.

**Wired up**
- `backend:start` IPC handler now: starts Docker → if paired AND `tunnelAutoRegister` → kicks off `tunnel.start()` in the background.
- `backend:stop` IPC handler: clears the tunnel first (so the catch-all stops routing to a hostname we're about to take down), then stops Docker.
- `before-quit` does the same.

**Settings additions**
- `apiBaseUrl` — Dev Hub URL the companion talks to (defaults to `https://espace-hubs.vercel.app`).
- `tunnelHostname` — public CF tunnel hostname this companion exposes.
- `tunnelAutoRegister` — toggle for the auto-register behavior (true by default).

**IPC surface** (preload)
- `window.companion.pair.{status, start, cancel, forget}`
- `window.companion.tunnel.{register, clear}`

The bearer token NEVER crosses the IPC bridge — `pair.status()` returns a boolean + the human-readable device label; renderer never sees the token bytes.

## Test plan

- [ ] Fresh install (no token in keychain): \"Pairing & tunnel routing\" section shows \"not paired\". Click Pair → browser opens to `/companion/pair?code=...` → approve → companion section updates to show \"paired · <hostname> (Companion)\".
- [ ] `tunnelHostname` empty + Pair → registering shows \"Tunnel hostname is empty\" error and doesn't crash.
- [ ] `tunnelHostname` set + click Start backend → tunnel:active flips true; \"Last seen\" updates every refresh; the Vercel app's `/me/api-origin` returns `{ source: \"companion\", origin: \"https://<hostname>\" }`.
- [ ] Wait 5+ minutes with the companion running → catch-all keeps proxying (heartbeat is doing its job). Verified via repeated browser requests landing on the local Express logs.
- [ ] Stop backend → DELETE `/me/companion-tunnel` fires; `/me/api-origin` flips back to `{ source: \"bundled\", origin: null }`.
- [ ] Quit companion → DELETE fires, then `docker compose down`. Container actually exits.
- [ ] Revoke device from a future Devices UI / direct `DELETE /companion/devices/:id` → next heartbeat 401s; loop stops; UI shows \"Companion token was revoked\".
- [ ] Forget pairing → keychain entries deleted; status drops to \"not paired\"; no server call (deliberate — Phase 3e Devices UI is where revoke happens).
- [ ] Pairing timeout (don't click Approve in 5 min) → companion shows \"Timed out waiting for browser approval.\"
- [ ] Cancel button during pairing aborts the poll cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)