### PR TITLE
Phase 3e — companion-routed UX (indicator, devices, setup)

### DIFF
--- a/apps/web/src/app/layout.jsx
+++ b/apps/web/src/app/layout.jsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import { Inter_Tight, JetBrains_Mono } from "next/font/google";
 import { Toaster } from "sonner";
 import { SessionProvider } from "@/features/auth";
+import { CompanionApiOriginProvider } from "@/features/companion";
 import { GradingSync } from "@/features/grading";
 import { SnapshotsSync } from "@/features/snapshots";
 import { ContextSync } from "@/features/goal-context";
@@ -44,6 +45,12 @@ export default function RootLayout({ children }) {
             the API once on session establishment, merging into
             localStorage. M7.2 mirror-mode rollout. */}
         <SessionProvider>
+          {/* Drives the api-origin store — fetches /me/api-origin on
+              session establishment, then refreshes every 60s and on
+              tab focus so the header chip flips within a heartbeat
+              window of the companion going up/down. Side-effect only;
+              doesn't gate children. */}
+          <CompanionApiOriginProvider />
           {/* MigrateOnce runs the first-session localStorage→API upload
               for devices that carry pre-M7 legacy data. It's silent
               on devices with no legacy data and idempotent on the

--- a/apps/web/src/components/shell/header.jsx
+++ b/apps/web/src/components/shell/header.jsx
@@ -6,6 +6,7 @@ import { LogoMark } from "./logo-mark";
 import { AnalystActivator } from "@/features/analyst";
 import { useIntegrations } from "@/features/integrations";
 import { UserChip } from "@/features/auth";
+import { CompanionIndicator } from "@/features/companion";
 import { useActiveHub, HubSwitcher } from "@/features/hubs";
 import { cn } from "@/lib/cn";
 
@@ -153,6 +154,9 @@ export function Header() {
         </div>
         {/* Inverse-themed activator — opens the accent-ground analyst page. */}
         <AnalystActivator />
+        {/* Companion-routing indicator — self-hides when the user has
+            no companion. Engagement-agnostic; espace devs see nothing. */}
+        <CompanionIndicator />
         {/* Session-aware chip with logout dropdown. */}
         <UserChip />
       </div>

--- a/apps/web/src/features/companion/api-origin-store.js
+++ b/apps/web/src/features/companion/api-origin-store.js
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * Reactive store for the user's `/me/api-origin` lookup.
+ *
+ * Backend contract (see apps/api/src/modules/auth/controller.ts):
+ *
+ *   GET /api/v1/auth/me/api-origin →
+ *     { origin: "https://<companion-hostname>",
+ *       source: "companion",
+ *       lastSeenAt: "<iso>" }                  // fresh tunnel
+ *
+ *     { origin: null,
+ *       source: "bundled",
+ *       lastSeenAt: "<iso>" | null,
+ *       staleHostname: "<hostname>" | null }   // no tunnel OR stale
+ *
+ * Why a store and not just a useEffect-per-component
+ * ──────────────────────────────────────────────────
+ * The header chip and any "companion offline" banner both want to
+ * react to the SAME state without duplicating fetches. The session
+ * store pattern (module-level state + dispatch event) keeps this
+ * cheap — one fetch per login, occasional refresh, and consumers
+ * subscribe via React's useSyncExternalStore.
+ *
+ * Refresh cadence:
+ *   - On session establishment (SessionProvider mount)
+ *   - On every 60s while the user is on the site, to catch a
+ *     just-started or just-stopped companion
+ *   - Manual via `refreshApiOrigin()` after the user finishes the
+ *     pairing flow
+ */
+
+const CHANGE_EVENT = "companion-api-origin:change";
+const INITIAL = {
+  /** "companion" | "bundled" | null (null = haven't fetched yet) */
+  source: null,
+  /** Companion hostname when source === "companion", null otherwise. */
+  hostname: null,
+  /** Last successful heartbeat ISO ts. May be stale OR null. */
+  lastSeenAt: null,
+  /** When the companion is stale, the server returns its last-known
+   *  hostname so the UI can show "Companion <hostname> went offline"
+   *  rather than a generic "no companion." */
+  staleHostname: null,
+  loading: false,
+  error: null,
+};
+
+let state = INITIAL;
+const listeners = new Set();
+
+function emit() {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+  for (const fn of listeners) fn();
+}
+
+export function getApiOrigin() {
+  return state;
+}
+
+export function setApiOrigin(next) {
+  state = { ...state, ...next };
+  emit();
+}
+
+export function subscribeApiOrigin(cb) {
+  if (typeof window === "undefined") return () => {};
+  listeners.add(cb);
+  const handler = () => cb();
+  window.addEventListener(CHANGE_EVENT, handler);
+  return () => {
+    listeners.delete(cb);
+    window.removeEventListener(CHANGE_EVENT, handler);
+  };
+}

--- a/apps/web/src/features/companion/companion-api-origin-provider.jsx
+++ b/apps/web/src/features/companion/companion-api-origin-provider.jsx
@@ -1,0 +1,52 @@
+"use client";
+
+/**
+ * Mounts once at the root layout (alongside SessionProvider). Drives
+ * the api-origin store:
+ *
+ *   1. Fetches /me/api-origin on session establishment.
+ *   2. Re-fetches every 60s while the tab is in foreground so the
+ *      header chip flips from "companion" → "bundled" within a
+ *      heartbeat window of the companion going offline.
+ *   3. Bumps an immediate refresh on tab focus (catches the case
+ *      where the user paused the companion in another window).
+ *
+ * No children render gating — this is a side-effect-only component.
+ */
+
+import { useEffect } from "react";
+import { useSession } from "@/features/auth";
+import { refreshApiOrigin } from "./use-api-origin.js";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+export function CompanionApiOriginProvider({ children }) {
+  const { user } = useSession();
+
+  useEffect(() => {
+    if (!user) return;
+    // Initial fetch right after the session lands.
+    void refreshApiOrigin();
+    const t = setInterval(() => {
+      // Skip the tick if the tab is backgrounded — there's no UI to
+      // update, and we'd rather pay the round-trip when the user
+      // returns focus.
+      if (typeof document !== "undefined" && document.hidden) return;
+      void refreshApiOrigin();
+    }, REFRESH_INTERVAL_MS);
+    const onFocus = () => {
+      void refreshApiOrigin();
+    };
+    if (typeof window !== "undefined") {
+      window.addEventListener("focus", onFocus);
+    }
+    return () => {
+      clearInterval(t);
+      if (typeof window !== "undefined") {
+        window.removeEventListener("focus", onFocus);
+      }
+    };
+  }, [user]);
+
+  return children;
+}

--- a/apps/web/src/features/companion/companion-indicator.jsx
+++ b/apps/web/src/features/companion/companion-indicator.jsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Tiny header indicator showing where /api/v1/* calls are going:
+ *
+ *   • source === "companion":  green pill "via companion · <host>"
+ *   • source === "bundled" with `staleHostname` set:  amber pill
+ *     "companion offline" (the user's heartbeat went stale; the
+ *     catch-all fell back to the bundled API. Once the user reopens
+ *     their companion app the chip flips back to green within a
+ *     heartbeat window).
+ *   • source === "bundled" with no stale host: render nothing —
+ *     espace devs without a companion shouldn't see UI for it.
+ *
+ * Mounted next to UserChip in the layout header.
+ */
+
+import { useApiOrigin } from "./use-api-origin.js";
+
+export function CompanionIndicator() {
+  const { source, hostname, staleHostname, lastSeenAt } = useApiOrigin();
+
+  if (source === "companion" && hostname) {
+    return (
+      <span
+        title={
+          lastSeenAt
+            ? `Companion last seen ${new Date(lastSeenAt).toLocaleTimeString()}.`
+            : "Companion connected."
+        }
+        style={pill("good")}
+      >
+        <Dot color="var(--good, #2da44e)" />
+        via companion · {hostname}
+      </span>
+    );
+  }
+
+  if (source === "bundled" && staleHostname) {
+    return (
+      <span
+        title={
+          lastSeenAt
+            ? `Last heartbeat ${new Date(lastSeenAt).toLocaleTimeString()}. Open your companion app to resume routing.`
+            : "Open your companion app to resume routing."
+        }
+        style={pill("warn")}
+      >
+        <Dot color="var(--warn, #bf8700)" />
+        companion offline
+      </span>
+    );
+  }
+
+  return null;
+}
+
+function Dot({ color }) {
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        width: 6,
+        height: 6,
+        borderRadius: "50%",
+        background: color,
+      }}
+    />
+  );
+}
+
+function pill(tone) {
+  return {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    padding: "3px 8px",
+    fontFamily: "var(--font-mono)",
+    fontSize: 10,
+    letterSpacing: "0.4px",
+    textTransform: "uppercase",
+    border: "1px solid var(--border-strong)",
+    borderRadius: 999,
+    color: "var(--fg)",
+    background: "var(--card)",
+    // Tone hints the dot colour; the pill itself stays neutral so it
+    // doesn't compete with the user chip.
+    opacity: tone === "warn" ? 0.95 : 1,
+  };
+}

--- a/apps/web/src/features/companion/companion-pair-form.jsx
+++ b/apps/web/src/features/companion/companion-pair-form.jsx
@@ -29,6 +29,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { apiPost } from "@/lib/api-client";
 import { useSession } from "@/features/auth";
+import { refreshApiOrigin } from "./use-api-origin.js";
 
 export function CompanionPairForm() {
   const params = useSearchParams();
@@ -98,6 +99,10 @@ export function CompanionPairForm() {
     }
     setDevice(r.data?.device || null);
     setPhase("approved");
+    // The companion will heartbeat the tunnel within seconds; pre-empt
+    // the next 60s store refresh so the header chip / setup guide
+    // update immediately when the user navigates back to the app.
+    void refreshApiOrigin();
   }
 
   return (

--- a/apps/web/src/features/companion/companion-setup-guide.jsx
+++ b/apps/web/src/features/companion/companion-setup-guide.jsx
@@ -1,0 +1,208 @@
+"use client";
+
+/**
+ * Setup-guide explainer for the Companion settings tab.
+ *
+ * Audience: any user whose engagement requires routing API calls
+ * through a local backend (today: Crealogix, because Vercel can't
+ * reach git.bcn.crealogix.net). Espace devs don't need it.
+ *
+ * Decisions baked into the copy:
+ *   - We don't auto-download the companion installer from here yet.
+ *     Phase 4 ships the installer + auto-update; until then the user
+ *     pulls a tagged release from GitHub.
+ *   - The CF tunnel hostname is user-provided. Phase 4 wraps the
+ *     `cloudflared` CLI so the companion mints the hostname itself,
+ *     but for v1 we let the user paste their existing one.
+ */
+
+import { useApiOrigin } from "./use-api-origin.js";
+
+export function CompanionSetupGuide() {
+  const { source, hostname, staleHostname } = useApiOrigin();
+  const live = source === "companion";
+  const stale = source === "bundled" && !!staleHostname;
+
+  return (
+    <section
+      style={{
+        border: "1px solid var(--border-strong)",
+        borderRadius: "var(--radius-sub, 3px)",
+        background: "var(--card)",
+        padding: 16,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        marginBottom: 16,
+      }}
+    >
+      <StatusLine live={live} stale={stale} hostname={hostname || staleHostname} />
+
+      <Step
+        num={1}
+        title="Install the companion app"
+        body={
+          <>
+            Grab the latest release for your OS from the eSpace Dev Hub
+            GitHub releases page and run the installer. The companion
+            runs in your system tray; it starts a local copy of the
+            backend and forwards requests through a Cloudflare Tunnel.
+          </>
+        }
+      />
+
+      <Step
+        num={2}
+        title="Set up a Cloudflare Tunnel"
+        body={
+          <>
+            From the Cloudflare Zero Trust dashboard, create a tunnel
+            and copy its <Code>token</Code>. In the companion's Settings
+            section, paste the token AND the public hostname you bound
+            to the tunnel (e.g. <Code>your-name.cf-tunnel.com</Code>).
+            Phase 4 will mint a named tunnel for you automatically; for
+            now you provide the hostname yourself.
+          </>
+        }
+      />
+
+      <Step
+        num={3}
+        title="Pair this browser with your companion"
+        body={
+          <>
+            In the companion, click <strong>Pair this device</strong>.
+            Your browser opens to <Code>/companion/pair?code=…</Code>,
+            shows the pairing code and the IP that initiated it, and
+            asks you to confirm. Approve only pairings you started.
+          </>
+        }
+      />
+
+      <Step
+        num={4}
+        title="Start the backend"
+        body={
+          <>
+            Click <strong>Start backend</strong> in the companion. The
+            Docker stack comes up, the tunnel hostname is registered
+            with the Dev Hub, and a heartbeat keeps it fresh every 60
+            seconds. The chip in the top-right of this page flips green
+            once routing is live.
+          </>
+        }
+      />
+
+      <p
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10.5,
+          color: "var(--muted-fg)",
+          lineHeight: 1.6,
+          margin: 0,
+        }}
+      >
+        Auth model: the companion holds a per-device bearer token
+        encrypted by your OS keychain (DPAPI on Windows, Keychain on
+        macOS). The token never leaves your machine; revoking from the
+        list below makes it useless on the next request.
+      </p>
+    </section>
+  );
+}
+
+function StatusLine({ live, stale, hostname }) {
+  if (live) {
+    return (
+      <p
+        style={{
+          margin: 0,
+          fontSize: 12.5,
+          color: "var(--good)",
+          fontFamily: "var(--font-mono)",
+        }}
+      >
+        ● Routing live via <strong>{hostname}</strong>. Your /api/v1/*
+        calls are reaching your laptop's backend.
+      </p>
+    );
+  }
+  if (stale) {
+    return (
+      <p
+        style={{
+          margin: 0,
+          fontSize: 12.5,
+          color: "var(--warn)",
+          fontFamily: "var(--font-mono)",
+        }}
+      >
+        ● Companion offline — last heartbeat from <strong>{hostname}</strong>{" "}
+        went stale. Open the desktop app to resume routing; we're
+        falling back to the bundled API in the meantime.
+      </p>
+    );
+  }
+  return (
+    <p
+      style={{
+        margin: 0,
+        fontSize: 12.5,
+        color: "var(--muted-fg)",
+        fontFamily: "var(--font-mono)",
+      }}
+    >
+      No companion registered. Follow the steps below if your engagement
+      requires routing through your local laptop (Crealogix, etc.).
+    </p>
+  );
+}
+
+function Step({ num, title, body }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "28px 1fr",
+        gap: 12,
+        alignItems: "start",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: "0.5px",
+          color: "var(--accent)",
+          paddingTop: 2,
+        }}
+      >
+        {String(num).padStart(2, "0")}
+      </span>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <span style={{ fontSize: 13.5, fontWeight: 600 }}>{title}</span>
+        <span style={{ fontSize: 12.5, lineHeight: 1.6, color: "var(--fg)" }}>
+          {body}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function Code({ children }) {
+  return (
+    <code
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        background: "var(--bg)",
+        border: "1px solid var(--border-strong)",
+        borderRadius: 2,
+        padding: "1px 5px",
+      }}
+    >
+      {children}
+    </code>
+  );
+}

--- a/apps/web/src/features/companion/devices-list.jsx
+++ b/apps/web/src/features/companion/devices-list.jsx
@@ -1,0 +1,213 @@
+"use client";
+
+/**
+ * Lists the user's paired companion devices.
+ *
+ *   GET    /api/v1/companion/devices         — list (excludes revoked)
+ *   DELETE /api/v1/companion/devices/:id     — soft-revoke
+ *
+ * Used inside the CompanionTab (Settings → Companion). Read-only
+ * surface for the user to audit "what laptops have my Dev Hub token?"
+ * and pull the plug if a device walks off.
+ *
+ * The bearer token is NEVER returned by either endpoint — `devices`
+ * surfaces only the name + IP + ua + timestamps so revocation never
+ * exposes the secret material to the browser.
+ */
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { apiDelete, apiGet } from "@/lib/api-client";
+
+export function DevicesList() {
+  const [devices, setDevices] = useState(null); // null = loading
+  const [error, setError] = useState(null);
+  const [revokingId, setRevokingId] = useState(null);
+
+  const refresh = async () => {
+    setError(null);
+    const r = await apiGet("/companion/devices");
+    if (!r.ok) {
+      setError(r.error?.message || "Couldn't load devices.");
+      setDevices([]);
+      return;
+    }
+    setDevices(r.data?.devices ?? []);
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  async function handleRevoke(d) {
+    const ok = window.confirm(
+      `Revoke ${d.name}? The companion app on that machine will need to be re-paired before it can route traffic again.`,
+    );
+    if (!ok) return;
+    setRevokingId(d.id);
+    const r = await apiDelete(`/companion/devices/${d.id}`);
+    setRevokingId(null);
+    if (!r.ok) {
+      toast.error(r.error?.message || "Couldn't revoke that device.");
+      return;
+    }
+    toast.success(`${d.name} revoked.`);
+    await refresh();
+  }
+
+  if (devices === null) {
+    return (
+      <p
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11.5,
+          color: "var(--muted-fg)",
+        }}
+      >
+        Loading devices…
+      </p>
+    );
+  }
+
+  if (error) {
+    return (
+      <p
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11.5,
+          color: "var(--bad)",
+        }}
+      >
+        {error}
+      </p>
+    );
+  }
+
+  if (devices.length === 0) {
+    return (
+      <p
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 11.5,
+          color: "var(--muted-fg)",
+          lineHeight: 1.6,
+        }}
+      >
+        No paired devices. Install the companion app on a laptop, click
+        “Pair this device,” then approve the prompt that opens in this
+        browser.
+      </p>
+    );
+  }
+
+  return (
+    <ul
+      style={{
+        listStyle: "none",
+        margin: 0,
+        padding: 0,
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+      }}
+    >
+      {devices.map((d) => (
+        <li
+          key={d.id}
+          style={{
+            border: "1px solid var(--border-strong)",
+            borderRadius: "var(--radius-sub, 3px)",
+            background: "var(--card)",
+            padding: 14,
+            display: "grid",
+            gridTemplateColumns: "1fr auto",
+            gap: 12,
+          }}
+        >
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <span style={{ fontWeight: 600, fontSize: 13.5 }}>{d.name}</span>
+            <DevicesMeta device={d} />
+          </div>
+          <button
+            type="button"
+            onClick={() => handleRevoke(d)}
+            disabled={revokingId === d.id}
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10.5,
+              fontWeight: 700,
+              letterSpacing: "0.5px",
+              textTransform: "uppercase",
+              background: "transparent",
+              color: "var(--bad)",
+              border: "1px solid var(--bad)",
+              borderRadius: "var(--radius-sub, 3px)",
+              padding: "6px 12px",
+              cursor: revokingId === d.id ? "wait" : "pointer",
+              opacity: revokingId === d.id ? 0.5 : 1,
+              alignSelf: "start",
+            }}
+          >
+            {revokingId === d.id ? "Revoking…" : "Revoke"}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function DevicesMeta({ device }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "max-content 1fr",
+        rowGap: 2,
+        columnGap: 10,
+        fontFamily: "var(--font-mono)",
+        fontSize: 10.5,
+        color: "var(--muted-fg)",
+      }}
+    >
+      <Row
+        label="Paired"
+        value={
+          device.createdAt
+            ? new Date(device.createdAt).toLocaleString()
+            : "—"
+        }
+      />
+      <Row
+        label="Last used"
+        value={
+          device.lastUsedAt
+            ? new Date(device.lastUsedAt).toLocaleString()
+            : "—"
+        }
+      />
+      {device.createdByIp ? (
+        <Row label="From IP" value={device.createdByIp} />
+      ) : null}
+      {device.createdByUa ? (
+        <Row label="User agent" value={device.createdByUa} />
+      ) : null}
+    </div>
+  );
+}
+
+function Row({ label, value }) {
+  return (
+    <>
+      <span
+        style={{
+          textTransform: "uppercase",
+          letterSpacing: "0.4px",
+          fontSize: 9.5,
+        }}
+      >
+        {label}
+      </span>
+      <span style={{ overflowWrap: "anywhere" }}>{value}</span>
+    </>
+  );
+}

--- a/apps/web/src/features/companion/index.js
+++ b/apps/web/src/features/companion/index.js
@@ -1,11 +1,21 @@
 /**
  * @espace-devhub/web — companion feature barrel.
  *
- * UI for the desktop companion-app pairing flow:
- *   - CompanionPairForm  → /companion/pair approval page contents
+ * UI for the desktop companion-app pairing flow + per-user
+ * tunnel-routing surfacing:
  *
- * Phase 3e will add the active-device list + "Using companion: …"
- * indicator; those exports land here when they do.
+ *   CompanionPairForm           /companion/pair approval page contents
+ *   CompanionIndicator          header chip showing where /api/v1/* is going
+ *   CompanionApiOriginProvider  mount-once driver of the api-origin store
+ *   useApiOrigin                reactive hook over the store
+ *   refreshApiOrigin            imperative refresh (after pair/unpair)
+ *   DevicesList                 /settings/devices contents (Phase 3e)
+ *   CompanionSetupGuide         /settings/companion explainer (Phase 3e)
  */
 
 export { CompanionPairForm } from "./companion-pair-form.jsx";
+export { CompanionIndicator } from "./companion-indicator.jsx";
+export { CompanionApiOriginProvider } from "./companion-api-origin-provider.jsx";
+export { useApiOrigin, refreshApiOrigin } from "./use-api-origin.js";
+export { DevicesList } from "./devices-list.jsx";
+export { CompanionSetupGuide } from "./companion-setup-guide.jsx";

--- a/apps/web/src/features/companion/use-api-origin.js
+++ b/apps/web/src/features/companion/use-api-origin.js
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * Reactive hook over the api-origin store. Mirrors useSession's
+ * shape: returns the current state + a `refresh()` you can call after
+ * the companion app reports a change.
+ *
+ * The auto-refresh ticker lives in `CompanionApiOriginProvider`, NOT
+ * here — multiple components calling this hook shouldn't multiply
+ * the fetch rate.
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+import { apiGet } from "@/lib/api-client";
+import {
+  getApiOrigin,
+  setApiOrigin,
+  subscribeApiOrigin,
+} from "./api-origin-store.js";
+
+const SERVER_SNAPSHOT = Object.freeze({
+  source: null,
+  hostname: null,
+  lastSeenAt: null,
+  staleHostname: null,
+  loading: false,
+  error: null,
+});
+
+function serverSnapshot() {
+  return SERVER_SNAPSHOT;
+}
+
+export async function refreshApiOrigin() {
+  setApiOrigin({ loading: true, error: null });
+  const result = await apiGet("/auth/me/api-origin");
+  if (!result.ok) {
+    // 401 unauthenticated is normal (logged-out users) — just clear
+    // state without surfacing an error.
+    if (result.error.code === "unauthenticated") {
+      setApiOrigin({
+        source: null,
+        hostname: null,
+        lastSeenAt: null,
+        staleHostname: null,
+        loading: false,
+        error: null,
+      });
+      return;
+    }
+    setApiOrigin({ loading: false, error: result.error });
+    return;
+  }
+  const d = result.data || {};
+  setApiOrigin({
+    source: d.source ?? "bundled",
+    hostname:
+      d.source === "companion" && typeof d.origin === "string"
+        ? d.origin.replace(/^https?:\/\//, "")
+        : null,
+    lastSeenAt: d.lastSeenAt ?? null,
+    staleHostname: d.staleHostname ?? null,
+    loading: false,
+    error: null,
+  });
+}
+
+export function useApiOrigin() {
+  const state = useSyncExternalStore(
+    subscribeApiOrigin,
+    getApiOrigin,
+    serverSnapshot,
+  );
+  const refresh = useCallback(() => refreshApiOrigin(), []);
+  return { ...state, refresh };
+}

--- a/apps/web/src/features/settings/settings-page.jsx
+++ b/apps/web/src/features/settings/settings-page.jsx
@@ -3,10 +3,12 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { Button, PageHeader } from "@/components/ui";
+import { useSession } from "@/features/auth";
 import { useActiveHub, useHubLink } from "@/features/hubs";
 import { cn } from "@/lib/cn";
 import {
   AccountTab,
+  CompanionTab,
   DangerTab,
   IntegrationsTab,
   OnboardingTab,
@@ -15,10 +17,9 @@ import {
 } from "./tabs";
 
 // `hubFilter` makes a tab hub-scoped — only shown when the active
-// hub's id matches. Tabs without `hubFilter` show for every hub.
-// This is how per-hub configuration (e.g. QA's project keys, future
-// Manager Hub roster picks) lives inside the shared SettingsPage
-// without sprouting per-hub conditional branches inside each tab.
+// hub's id matches. `engagementFilter` is analogous: a tab opt-in for
+// users whose `engagement` matches (e.g. Crealogix-only Companion
+// tab). Tabs without either filter show universally.
 const ALL_TABS = [
   { id: "onboarding", label: "Onboarding", Component: OnboardingTab },
   { id: "integrations", label: "Integrations", Component: IntegrationsTab },
@@ -28,6 +29,12 @@ const ALL_TABS = [
     Component: QaConfigTab,
     hubFilter: "qa",
   },
+  {
+    id: "companion",
+    label: "Companion",
+    Component: CompanionTab,
+    engagementFilter: "crealogix",
+  },
   { id: "account", label: "Account", Component: AccountTab },
   { id: "snapshots", label: "Snapshots & privacy", Component: SnapshotsPrefsTab },
   { id: "danger", label: "Danger zone", Component: DangerTab },
@@ -35,12 +42,19 @@ const ALL_TABS = [
 
 export function SettingsPage() {
   const activeHub = useActiveHub();
+  const { user } = useSession();
   const tabs = useMemo(
     () =>
-      ALL_TABS.filter(
-        (t) => !t.hubFilter || (activeHub && t.hubFilter === activeHub.id),
-      ),
-    [activeHub],
+      ALL_TABS.filter((t) => {
+        if (t.hubFilter && !(activeHub && t.hubFilter === activeHub.id)) {
+          return false;
+        }
+        if (t.engagementFilter && t.engagementFilter !== (user?.engagement ?? "espace")) {
+          return false;
+        }
+        return true;
+      }),
+    [activeHub, user?.engagement],
   );
 
   const [tab, setTab] = useState("onboarding");

--- a/apps/web/src/features/settings/tabs/companion-tab.jsx
+++ b/apps/web/src/features/settings/tabs/companion-tab.jsx
@@ -1,0 +1,28 @@
+"use client";
+
+/**
+ * Settings → Companion tab. Two stacked surfaces:
+ *
+ *   01. Setup guide  — explains the Crealogix companion flow,
+ *                       shows current routing state inline.
+ *   02. Paired devices — lists active devices + revoke action.
+ *
+ * Hub-gated in settings-page.jsx so espace devs (who never need a
+ * companion) don't see the tab in their Settings nav.
+ */
+
+import { Section } from "@/components/ui";
+import { CompanionSetupGuide, DevicesList } from "@/features/companion";
+
+export function CompanionTab() {
+  return (
+    <>
+      <Section num="01 /" title="Setup">
+        <CompanionSetupGuide />
+      </Section>
+      <Section num="02 /" title="Paired devices">
+        <DevicesList />
+      </Section>
+    </>
+  );
+}

--- a/apps/web/src/features/settings/tabs/index.js
+++ b/apps/web/src/features/settings/tabs/index.js
@@ -4,3 +4,4 @@ export { QaConfigTab } from "./qa-config-tab";
 export { AccountTab } from "./account-tab";
 export { SnapshotsPrefsTab } from "./snapshots-prefs-tab";
 export { DangerTab } from "./danger-tab";
+export { CompanionTab } from "./companion-tab";

--- a/apps/web/src/lib/api-client.js
+++ b/apps/web/src/lib/api-client.js
@@ -20,7 +20,37 @@
  * is configured.
  */
 
+import { toast } from "sonner";
+
 const API_BASE = "/api/v1";
+
+/**
+ * Phase 3e — surface "companion_unreachable" 502s to the user as a
+ * one-shot toast. The catch-all (apps/web/src/pages/api/v1/[...path].ts)
+ * emits this code when the user's paired companion fails to answer a
+ * proxied request: the tunnel is registered fresh but the local backend
+ * is down, the laptop's asleep, the VPN dropped, etc.
+ *
+ * Throttling: every component that fires a /api/v1/* call would
+ * otherwise pile up a toast each. We coalesce inside a 30s window so
+ * the user sees one banner, not twenty.
+ */
+let lastCompanionUnreachableToastAt = 0;
+const COMPANION_UNREACHABLE_THROTTLE_MS = 30_000;
+function maybeToastCompanionUnreachable(message) {
+  if (typeof window === "undefined") return;
+  const now = Date.now();
+  if (now - lastCompanionUnreachableToastAt < COMPANION_UNREACHABLE_THROTTLE_MS) {
+    return;
+  }
+  lastCompanionUnreachableToastAt = now;
+  toast.error("Companion offline", {
+    description:
+      message ||
+      "Couldn't reach your companion. Open the desktop app to resume routing.",
+    duration: 8000,
+  });
+}
 
 /**
  * Pages where a 401 is normal and shouldn't bounce the user back to
@@ -176,6 +206,13 @@ async function request(method, path, body, init = {}) {
     // already on a public auth page. See PUBLIC_AUTH_PATHS above.
     if (res.status === 401) {
       maybeRedirectToLogin(apiError.code);
+    }
+    // Companion offline (Phase 3e). The catch-all returns 502 with
+    // this specific code when proxying to the user's paired
+    // companion-tunnel hostname fails. We don't want individual
+    // callers to each render their own error — one global toast.
+    if (res.status === 502 && apiError.code === "companion_unreachable") {
+      maybeToastCompanionUnreachable(apiError.message);
     }
     return { ok: false, status: res.status, error: apiError };
   }


### PR DESCRIPTION
## Summary

Surfaces the per-user companion-tunnel routing landed in Phases 3a–3d to the user. Four pieces:

### 1. Header indicator chip
`CompanionIndicator` lives next to `UserChip`. Reads `/me/api-origin` reactively via a new store/provider.
- **source === \"companion\"** → green pill, e.g. `via companion · user-42.cf-tunnel.com`
- **source === \"bundled\" + staleHostname set** → amber pill `companion offline`
- otherwise → renders nothing (espace devs see no UI)

### 2. Companion-unreachable toast
`apps/web/src/lib/api-client.js` detects `502 { code: \"companion_unreachable\" }` from the catch-all and fires a sonner toast. Coalesced inside a 30s window so a burst of failed widget calls doesn't pile up twenty banners.

### 3. Reactive api-origin store
- `api-origin-store.js` — module-level state + change event
- `use-api-origin.js` — useSyncExternalStore hook + `refreshApiOrigin()`
- `companion-api-origin-provider.jsx` — fetches on session establishment, refreshes every 60s + on window focus

### 4. Settings → Companion tab (Crealogix-only)
- `CompanionSetupGuide` — step-by-step walkthrough with inline routing-status banner (live / offline / not registered).
- `DevicesList` — `GET /companion/devices` listing, Revoke button hits `DELETE /companion/devices/:id`.

Settings tabs gain `engagementFilter` alongside `hubFilter` so espace devs never see the tab; future engagements just need to set the filter.

`CompanionPairForm` now bumps `refreshApiOrigin()` after successful approve so the indicator flips green within seconds of pairing rather than waiting for the next 60s tick.

## Test plan

- [ ] Espace user logged in: no chip in header, no Companion tab in /settings.
- [ ] Crealogix user with no companion: no chip, Settings → Companion tab is visible, setup guide shows \"No companion registered.\"
- [ ] Crealogix user mid-pairing: `/companion/pair?code=…` shows approval; after Approve, the indicator flips to green within seconds.
- [ ] Companion running + tunnel registered: green chip shows `via companion · <host>`. Tooltip shows last-seen time.
- [ ] Stop companion → wait ~6 min for staleness → chip flips to amber `companion offline` + setup guide updates.
- [ ] With companion offline, an API call that the catch-all tries to proxy → 502 → single sonner toast.
- [ ] /settings → Companion tab: device list shows the paired device with paired-at / last-used / IP / UA. Click Revoke → confirm → device disappears. Subsequent companion heartbeats from that token start failing.
- [ ] Header chip auto-refreshes when you alt-tab back to the browser (focus listener).
- [ ] No regressions on /admin or /qa settings tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)