### PR TITLE
feat(desktop): auto-spawn TryCloudflare — drop the typed-hostname step

### DIFF
--- a/apps/desktop/src/main/docker.ts
+++ b/apps/desktop/src/main/docker.ts
@@ -50,11 +50,15 @@ function repoPath(): string {
 }
 
 function dockerComposeArgs(...extra: string[]): string[] {
-  // `--profile tunnel` brings up the optional CF tunnel sidecar
-  // alongside mongo + api. The companion's whole job is to expose
-  // the api to a Vercel frontend through CF Tunnel, so we want the
-  // tunnel container running by default.
-  return ["compose", "--profile", "tunnel", ...extra];
+  // TEMP (TryCloudflare path): the `--profile tunnel` flag was
+  // dropped so docker compose doesn't try to start the cloudflared
+  // sidecar that requires TUNNEL_TOKEN. Run
+  // `cloudflared tunnel --url http://localhost:4000` on the host
+  // instead and paste the printed *.trycloudflare.com hostname into
+  // the companion's tunnel-hostname field.
+  // TODO: make the flag conditional on TUNNEL_TOKEN presence so a
+  // named-tunnel user gets the sidecar back automatically.
+  return ["compose", ...extra];
 }
 
 function run(args: string[]): Promise<RunResult> {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -31,6 +31,7 @@ import * as vpn from "./vpn";
 import * as keychain from "./keychain";
 import * as pair from "./pair";
 import * as tunnel from "./tunnel-register";
+import * as tunnelSpawn from "./tunnel-spawn";
 import { checkDocker } from "./docker-check";
 import { initAutoUpdater } from "./auto-update";
 
@@ -203,17 +204,29 @@ ipcMain.handle("backend:start", async () => {
   }
   const result = await startBackend();
 
-  // Phase 3d — after Docker is up, register the tunnel hostname with
-  // the Dev Hub so its catch-all proxies this user's API calls here
-  // instead of running the bundled Express app. Best-effort: if
-  // pairing isn't done or the hostname isn't configured we surface
-  // the reason in tunnel.getState() but don't fail the start.
+  // Phase 3d + auto-tunnel — after Docker is up:
+  //   1. spawn cloudflared (TryCloudflare); when it allocates the
+  //      *.trycloudflare.com hostname, the onHostname callback wired
+  //      below auto-fires tunnel.start(hostname) to register with the
+  //      Dev Hub.
+  //   2. tunnel.start runs the heartbeat that keeps lastSeenAt fresh.
+  //
+  // Best-effort end-to-end: a missing cloudflared binary or unpaired
+  // companion is surfaced via tunnel-spawn.getState() / tunnel.getState()
+  // — but the backend itself still starts cleanly so the user can
+  // pair / install cloudflared and retry.
   if (
     result.ok &&
     settings.get<boolean>("tunnelAutoRegister", true) &&
     pair.status().paired
   ) {
-    void tunnel.start();
+    void tunnelSpawn.start({ port: 4000 }).catch((err: unknown) => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[main] tunnel-spawn failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
   }
 
   return result;
@@ -258,13 +271,21 @@ ipcMain.handle("credentials:clear", async (_event, key: string) => {
 });
 
 ipcMain.handle("backend:stop", async () => {
-  // Phase 3d — clear the tunnel registration BEFORE tearing down
-  // Docker. Order matters: if we stop Docker first, the catch-all
-  // could route an in-flight request to a hostname that no longer
-  // resolves, surfacing "companion_unreachable" instead of a clean
-  // bundled-API fallback.
+  // Phase 3d + auto-tunnel — teardown order matters:
+  //   1. clear the tunnel registration (so the Dev Hub catch-all stops
+  //      routing to a hostname we're about to take down)
+  //   2. kill the cloudflared subprocess (severs the public hostname)
+  //   3. stop Docker
+  // Reversing 1-2 would leave the Dev Hub briefly routing to a dead
+  // cloudflared, surfacing "companion_unreachable" toasts to anyone
+  // mid-request.
   await tunnel.stop();
+  await tunnelSpawn.stop();
   return stopBackend();
+});
+
+ipcMain.handle("tunnel:spawn-state", async () => {
+  return tunnelSpawn.getState();
 });
 
 // ─── companion pairing IPC ───────────────────────────────────────────
@@ -291,7 +312,18 @@ ipcMain.handle("companion:unpair", async () => {
 });
 
 ipcMain.handle("tunnel:register", async () => {
-  return tunnel.start();
+  // Manual register from the main UI. Use whatever hostname cloudflared
+  // has currently allocated; if spawn isn't running, surface that.
+  const spawnState = tunnelSpawn.getState();
+  if (!spawnState.hostname) {
+    return {
+      ok: false as const,
+      reason: "missing_hostname" as const,
+      message:
+        "No tunnel hostname allocated yet. Start the backend first — cloudflared launches and assigns a hostname automatically.",
+    };
+  }
+  return tunnel.start(spawnState.hostname);
 });
 
 ipcMain.handle("tunnel:clear", async () => {
@@ -340,6 +372,10 @@ ipcMain.handle("docker:check", async () => {
   return checkDocker();
 });
 
+ipcMain.handle("cloudflared:check", async () => {
+  return tunnelSpawn.check();
+});
+
 ipcMain.handle("dialog:choose-directory", async (_event, title?: string) => {
   // returnFocus is the only place we care about the window-handle
   // origin — falls back to undefined cleanly if no window is open.
@@ -373,6 +409,20 @@ app.whenReady().then(() => {
   // Phase 4 — auto-update polling. Background; no-op in dev / when
   // unpackaged. See apps/desktop/src/main/auto-update.ts.
   initAutoUpdater();
+
+  // Wire tunnel-spawn → tunnel-register: every time cloudflared
+  // allocates (or re-allocates after a respawn) a hostname, register
+  // it with the Dev Hub. tunnel.start() is idempotent, so calling it
+  // with a fresh hostname cleanly replaces the prior registration.
+  tunnelSpawn.onHostname((hostname) => {
+    void tunnel.start(hostname).catch((err: unknown) => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[main] tunnel.start failed after hostname allocation:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+  });
 });
 
 app.on("activate", () => {
@@ -392,11 +442,13 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
-  // Best-effort: clear the tunnel registration so the Vercel
-  // catch-all stops proxying to a hostname we're about to take down,
-  // then stop the backend container. Without this, `docker compose
-  // up -d` would leave a container running in the background even
-  // after the companion is gone — surprising for the user.
+  // Best-effort cleanup, ordered like backend:stop:
+  //   1. clear Dev Hub registration
+  //   2. kill cloudflared
+  //   3. stop Docker
+  // We don't await any of these — quit shouldn't stall waiting on
+  // network calls or subprocess teardown.
   void tunnel.stop();
+  void tunnelSpawn.stop();
   void stopBackend({ silent: true });
 });

--- a/apps/desktop/src/main/tunnel-register.ts
+++ b/apps/desktop/src/main/tunnel-register.ts
@@ -42,6 +42,14 @@
 import { getToken } from "./pair.js";
 import { settings } from "./settings.js";
 
+/**
+ * Phase 4-followup: the hostname now comes from tunnel-spawn (the
+ * managed `cloudflared tunnel --url` subprocess) rather than from a
+ * user-typed setting. Calling start() before spawn has a hostname is
+ * a no-op (returns reason="missing_hostname"); the spawn module's
+ * onHostname callback wires the two together in main/index.ts.
+ */
+
 const DEFAULT_API_BASE_URL = "https://espace-hubs.vercel.app";
 const HEARTBEAT_INTERVAL_MS = 60_000;
 
@@ -96,7 +104,7 @@ export function getState(): TunnelState {
  * the heartbeat schedule and re-fires an immediate POST so a hostname
  * change propagates immediately.
  */
-export async function start(): Promise<StartResult> {
+export async function start(hostname: string): Promise<StartResult> {
   const token = getToken();
   if (!token) {
     state = {
@@ -112,14 +120,14 @@ export async function start(): Promise<StartResult> {
       message: state.lastError!,
     };
   }
-  const hostname = settings.get<string>("tunnelHostname", "").trim();
-  if (!hostname) {
+  const trimmed = hostname.trim();
+  if (!trimmed) {
     state = {
       active: false,
       hostname: null,
       lastSeenAt: null,
       lastError:
-        "Tunnel hostname is empty. Set the public CF tunnel hostname in settings.",
+        "No tunnel hostname allocated yet. Wait for cloudflared to come up.",
     };
     return {
       ok: false,
@@ -128,11 +136,11 @@ export async function start(): Promise<StartResult> {
     };
   }
 
-  const post = await postRegister(token, hostname);
+  const post = await postRegister(token, trimmed);
   if (!post.ok) {
     state = {
       active: false,
-      hostname,
+      hostname: trimmed,
       lastSeenAt: null,
       lastError: post.message,
     };
@@ -141,12 +149,12 @@ export async function start(): Promise<StartResult> {
 
   state = {
     active: true,
-    hostname,
+    hostname: trimmed,
     lastSeenAt: new Date().toISOString(),
     lastError: null,
   };
   scheduleHeartbeat();
-  return { ok: true, hostname };
+  return { ok: true, hostname: trimmed };
 }
 
 /** Stop the heartbeat and clear the server-side registration. */

--- a/apps/desktop/src/main/tunnel-spawn.ts
+++ b/apps/desktop/src/main/tunnel-spawn.ts
@@ -1,0 +1,389 @@
+/**
+ * Managed `cloudflared tunnel --url …` subprocess.
+ *
+ * Why this exists: named CF tunnels need a domain on the user's
+ * Cloudflare account; TryCloudflare doesn't. By spawning cloudflared
+ * directly with `--url`, the companion gets a free, ephemeral
+ * `*.trycloudflare.com` hostname per session without ANY user
+ * configuration (no token, no domain, no CF account).
+ *
+ * Lifecycle:
+ *   start({ port })   spawns cloudflared, parses the hostname out of
+ *                     its stderr log, resolves once we have it. The
+ *                     process stays alive until stop() is called.
+ *
+ *   stop()            SIGTERMs the process; on Windows kills via
+ *                     taskkill /T to also reap any helper processes
+ *                     cloudflared spawned.
+ *
+ *   getState()        synchronous snapshot for the renderer.
+ *
+ *   subscribe(cb)     fired on state transitions so the renderer can
+ *                     re-render without polling.
+ *
+ * Crash recovery: cloudflared occasionally dies after long sessions
+ * (network blip, CF edge restart). On unexpected exit we transition
+ * to "crashed" and auto-respawn up to MAX_RESTARTS times with
+ * exponential backoff. The hostname WILL change after a respawn —
+ * the caller (tunnel-register.ts) re-registers automatically when
+ * `onHostname` fires.
+ *
+ * stdout vs stderr: cloudflared uses zerolog → all output goes to
+ * stderr by default, INCLUDING the "Your quick Tunnel has been
+ * created at …" banner. We listen on stderr.
+ *
+ * Detection: looks for cloudflared on PATH. We don't bundle the
+ * binary yet (Phase 4-followup; see DISTRIBUTING.md TODO). For now
+ * the install message in `check()` tells the user how to get it
+ * (winget on Windows, brew on macOS, apt-get on Linux).
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+
+const RESTART_BASE_MS = 2_000;
+const RESTART_MAX_MS = 60_000;
+const MAX_RESTARTS = 5;
+const HOSTNAME_WAIT_MS = 30_000;
+
+const TRYCLOUDFLARE_RE = /https?:\/\/([a-z0-9-]+\.trycloudflare\.com)/i;
+
+export interface TunnelSpawnState {
+  /** Roughly tracks the lifecycle. */
+  status: "idle" | "starting" | "running" | "crashed" | "stopped";
+  /** The trycloudflare.com hostname (without scheme). Null until the
+   *  process prints the banner; reassigned on respawn. */
+  hostname: string | null;
+  /** Local port being forwarded. */
+  port: number | null;
+  /** Number of times we've restarted after a crash. Reset on a
+   *  successful start. */
+  restarts: number;
+  /** Surface for the UI when something's off. */
+  lastError: string | null;
+}
+
+const INITIAL: TunnelSpawnState = {
+  status: "idle",
+  hostname: null,
+  port: null,
+  restarts: 0,
+  lastError: null,
+};
+
+let state: TunnelSpawnState = INITIAL;
+let child: ChildProcess | null = null;
+let stopping = false;
+let restartTimer: NodeJS.Timeout | null = null;
+const listeners = new Set<() => void>();
+let onHostnameChange: ((hostname: string) => void) | null = null;
+
+function setState(patch: Partial<TunnelSpawnState>): void {
+  state = { ...state, ...patch };
+  for (const cb of listeners) {
+    try {
+      cb();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export function getState(): TunnelSpawnState {
+  return { ...state };
+}
+
+export function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+/**
+ * Register a callback fired EVERY time the hostname is (re)allocated.
+ * The tunnel-register module sets this so a respawn after a CF edge
+ * restart triggers a fresh /me/companion-tunnel POST automatically —
+ * the user never has to touch the UI.
+ */
+export function onHostname(cb: (hostname: string) => void): void {
+  onHostnameChange = cb;
+}
+
+/**
+ * Probe for `cloudflared` on PATH. Mirrors docker-check.ts's shape so
+ * the wizard can show a uniform "missing-tool" panel for either.
+ */
+export function check(): Promise<{
+  installed: boolean;
+  version: string | null;
+  message: string;
+}> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let resolved = false;
+
+    const settle = (r: {
+      installed: boolean;
+      version: string | null;
+      message: string;
+    }) => {
+      if (resolved) return;
+      resolved = true;
+      resolve(r);
+    };
+
+    const proc = spawn("cloudflared", ["--version"], {
+      shell: false,
+      windowsHide: true,
+    });
+    proc.stdout?.on("data", (d) => {
+      stdout += d.toString();
+    });
+    proc.stderr?.on("data", (d) => {
+      stderr += d.toString();
+    });
+    proc.on("error", (err) => {
+      const isMissing =
+        err.message.includes("ENOENT") ||
+        (err as NodeJS.ErrnoException).code === "ENOENT";
+      settle({
+        installed: false,
+        version: null,
+        message: isMissing
+          ? "cloudflared not found on PATH. Install via: winget install --id Cloudflare.cloudflared (Windows), brew install cloudflared (macOS), or apt install cloudflared (Linux)."
+          : err.message,
+      });
+    });
+    proc.on("close", (code) => {
+      const out = stdout.trim() || stderr.trim();
+      if (code === 0 && out) {
+        settle({ installed: true, version: out.split("\n")[0]!, message: "" });
+      } else {
+        settle({
+          installed: false,
+          version: null,
+          message:
+            out ||
+            `cloudflared --version exited with code ${code}.`,
+        });
+      }
+    });
+    setTimeout(() => {
+      if (resolved) return;
+      try {
+        proc.kill();
+      } catch {
+        /* ignore */
+      }
+      settle({
+        installed: false,
+        version: null,
+        message: "cloudflared --version timed out.",
+      });
+    }, 5_000);
+  });
+}
+
+interface StartOptions {
+  port: number;
+}
+
+/**
+ * Start cloudflared and resolve once we've parsed the trycloudflare
+ * hostname from its log output. Rejects if the hostname doesn't
+ * appear within HOSTNAME_WAIT_MS (network issue / bad cloudflared
+ * version / firewall blocking outbound).
+ *
+ * Idempotent — calling start() while running stop()s first, then
+ * starts fresh on the (possibly different) port.
+ */
+export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
+  if (child) {
+    await stop();
+  }
+  stopping = false;
+
+  setState({
+    status: "starting",
+    hostname: null,
+    port,
+    lastError: null,
+    // Don't reset `restarts` here — that's done after we observe a
+    // successful "running" transition below.
+  });
+
+  return new Promise<TunnelSpawnState>((resolve, reject) => {
+    let resolved = false;
+    let hostnameSeen = false;
+
+    // The hostname-wait timer rejects start() if cloudflared never
+    // prints the banner. We DON'T kill the process on this path
+    // because the user might want logs for debugging.
+    const waitTimer = setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      const msg = `cloudflared didn't allocate a hostname within ${
+        HOSTNAME_WAIT_MS / 1000
+      }s. Network blocked? Try running it manually: cloudflared tunnel --url http://localhost:${port}`;
+      setState({ status: "crashed", lastError: msg });
+      reject(new Error(msg));
+    }, HOSTNAME_WAIT_MS);
+
+    try {
+      child = spawn(
+        "cloudflared",
+        ["tunnel", "--no-autoupdate", "--url", `http://localhost:${port}`],
+        { shell: false, windowsHide: true },
+      );
+    } catch (err) {
+      clearTimeout(waitTimer);
+      resolved = true;
+      const msg = err instanceof Error ? err.message : String(err);
+      setState({ status: "crashed", lastError: msg });
+      reject(new Error(msg));
+      return;
+    }
+
+    const handleLine = (line: string) => {
+      const m = TRYCLOUDFLARE_RE.exec(line);
+      if (!m) return;
+      const hostname = m[1]!.toLowerCase();
+      if (state.hostname === hostname) return;
+      hostnameSeen = true;
+      clearTimeout(waitTimer);
+      setState({
+        status: "running",
+        hostname,
+        restarts: 0,
+        lastError: null,
+      });
+      // Fire the registered hostname callback (tunnel-register hook).
+      try {
+        onHostnameChange?.(hostname);
+      } catch {
+        /* ignore */
+      }
+      if (!resolved) {
+        resolved = true;
+        resolve({ ...state });
+      }
+    };
+
+    // cloudflared writes the banner to STDERR (zerolog default). We
+    // listen on both streams defensively in case a future version
+    // changes that.
+    child.stderr?.on("data", (chunk) => {
+      const text = chunk.toString();
+      for (const line of text.split(/\r?\n/)) handleLine(line);
+    });
+    child.stdout?.on("data", (chunk) => {
+      const text = chunk.toString();
+      for (const line of text.split(/\r?\n/)) handleLine(line);
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(waitTimer);
+      const isMissing =
+        err.message.includes("ENOENT") ||
+        (err as NodeJS.ErrnoException).code === "ENOENT";
+      const msg = isMissing
+        ? "cloudflared not found on PATH. Install via: winget install --id Cloudflare.cloudflared (Windows), brew install cloudflared (macOS)."
+        : err.message;
+      setState({ status: "crashed", lastError: msg });
+      if (!resolved) {
+        resolved = true;
+        reject(new Error(msg));
+      }
+    });
+
+    child.on("close", (code) => {
+      const wasRunning = state.status === "running";
+      child = null;
+      if (stopping) {
+        setState({ status: "stopped", hostname: null });
+        return;
+      }
+      // Unexpected exit. Auto-respawn if we've seen at least one
+      // successful run and we haven't exhausted restart attempts.
+      if (wasRunning && hostnameSeen && state.restarts < MAX_RESTARTS) {
+        const delay = Math.min(
+          RESTART_BASE_MS * 2 ** state.restarts,
+          RESTART_MAX_MS,
+        );
+        setState({
+          status: "crashed",
+          hostname: null,
+          restarts: state.restarts + 1,
+          lastError: `cloudflared exited with code ${code} — restarting in ${
+            delay / 1000
+          }s (attempt ${state.restarts + 1}/${MAX_RESTARTS})…`,
+        });
+        restartTimer = setTimeout(() => {
+          restartTimer = null;
+          void start({ port }).catch(() => {
+            /* state already reflects the error */
+          });
+        }, delay);
+      } else {
+        setState({
+          status: "crashed",
+          hostname: null,
+          lastError: wasRunning
+            ? `cloudflared restart budget exhausted (${MAX_RESTARTS} attempts). Stop + start backend to retry.`
+            : `cloudflared exited with code ${code} before allocating a hostname.`,
+        });
+      }
+    });
+  });
+}
+
+/** Cleanly stop the subprocess. Idempotent. */
+export async function stop(): Promise<void> {
+  stopping = true;
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+  if (!child) {
+    setState({ status: "stopped", hostname: null });
+    return;
+  }
+  const proc = child;
+  child = null;
+  await new Promise<void>((resolve) => {
+    const cleanup = () => resolve();
+    proc.once("close", cleanup);
+    try {
+      if (process.platform === "win32") {
+        // SIGTERM doesn't propagate cleanly on Windows for subprocesses
+        // that spawn helpers (cloudflared sometimes does). Use
+        // taskkill /T to reap the whole tree.
+        spawn("taskkill", ["/F", "/T", "/PID", String(proc.pid)], {
+          shell: false,
+          windowsHide: true,
+        }).on("close", () => {
+          /* close event on `proc` settles the promise */
+        });
+      } else {
+        proc.kill("SIGTERM");
+        // Hard-kill after 5s if SIGTERM didn't take.
+        setTimeout(() => {
+          try {
+            proc.kill("SIGKILL");
+          } catch {
+            /* already dead */
+          }
+        }, 5_000);
+      }
+    } catch (err) {
+      // If the kill itself throws, fall back to just resolving;
+      // process is presumably already dead.
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[tunnel-spawn] kill failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      cleanup();
+    }
+  });
+  setState({ status: "stopped", hostname: null });
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -56,6 +56,12 @@ const api = {
         version: string | null;
         message: string;
       }>,
+    checkCloudflared: () =>
+      ipcRenderer.invoke("cloudflared:check") as Promise<{
+        installed: boolean;
+        version: string | null;
+        message: string;
+      }>,
     chooseDirectory: (title?: string) =>
       ipcRenderer.invoke("dialog:choose-directory", title) as Promise<{
         canceled: boolean;
@@ -75,6 +81,14 @@ const api = {
   tunnel: {
     register: () => ipcRenderer.invoke("tunnel:register"),
     clear: () => ipcRenderer.invoke("tunnel:clear"),
+    spawnState: () =>
+      ipcRenderer.invoke("tunnel:spawn-state") as Promise<{
+        status: "idle" | "starting" | "running" | "crashed" | "stopped";
+        hostname: string | null;
+        port: number | null;
+        restarts: number;
+        lastError: string | null;
+      }>,
   },
 } as const;
 

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -601,19 +601,18 @@ export function App() {
         </div>
         <Field
           label="Tunnel hostname"
-          help="Public hostname your Cloudflare Tunnel exposes the local backend at (e.g. user-42.cf-tunnel.com). Used on backend start to register with the Dev Hub."
+          help="Auto-allocated by cloudflared on backend start. Read-only — TryCloudflare assigns a new hostname per session; the companion re-registers it automatically."
         >
           <input
             type="text"
-            value={settings.tunnelHostname || ""}
-            placeholder="your-name.cf-tunnel.com"
-            onChange={(e) => onSettingChange("tunnelHostname", e.target.value.trim())}
-            style={S.input}
+            readOnly
+            value={pairState?.tunnel.hostname || "(not running)"}
+            style={{ ...S.input, opacity: 0.75, cursor: "default" }}
           />
         </Field>
         <Field
           label="Auto-register tunnel on backend start"
-          help="POST the hostname above when the backend comes up, DELETE when it goes down. Heartbeats every 60s while running."
+          help="Spawn cloudflared + POST the hostname when the backend comes up, DELETE when it goes down. Heartbeats every 60s while running."
         >
           <input
             type="checkbox"

--- a/apps/desktop/src/renderer/Onboarding.tsx
+++ b/apps/desktop/src/renderer/Onboarding.tsx
@@ -8,10 +8,14 @@
  * on next refresh and unmounts this component.
  *
  * Steps (linear, can't skip ahead):
- *   1. Docker check
- *   2. Repo path (native folder picker)
- *   3. Tunnel hostname
- *   4. Pair this device
+ *   1. System requirements (Docker + cloudflared)
+ *   2. Repo folder (native folder picker)
+ *   3. Pair this device
+ *
+ * The tunnel hostname is no longer a step — the companion auto-spawns
+ * `cloudflared tunnel --url http://localhost:4000` when the user
+ * clicks Start backend, parses the *.trycloudflare.com hostname from
+ * its log output, and auto-registers with the Dev Hub. Zero typing.
  *
  * Why not a multi-page router
  * ───────────────────────────
@@ -31,6 +35,11 @@ type CompanionApi = (Window & {
         version: string | null;
         message: string;
       }>;
+      checkCloudflared: () => Promise<{
+        installed: boolean;
+        version: string | null;
+        message: string;
+      }>;
       chooseDirectory: (title?: string) => Promise<{
         canceled: boolean;
         path: string | null;
@@ -45,6 +54,7 @@ type CompanionApi = (Window & {
       start: () => Promise<{ ok: boolean; message: string }>;
       cancel: () => Promise<{ ok: boolean }>;
     };
+    shell: { openExternal: (url: string) => Promise<void> };
   };
 })["companion"];
 
@@ -56,16 +66,22 @@ interface OnboardingProps {
   onComplete: (completedAt: string) => void;
 }
 
-type DockerState =
+type ToolState =
   | { phase: "idle" }
   | { phase: "checking" }
   | { phase: "ok"; version: string }
   | { phase: "missing"; message: string };
 
+const cfInstallHint = {
+  win: "winget install --id Cloudflare.cloudflared",
+  mac: "brew install cloudflared",
+  linux: "apt install cloudflared  # or your distro's equivalent",
+};
+
 export function Onboarding({ onComplete }: OnboardingProps) {
-  const [dockerState, setDockerState] = useState<DockerState>({ phase: "idle" });
+  const [dockerState, setDockerState] = useState<ToolState>({ phase: "idle" });
+  const [cfState, setCfState] = useState<ToolState>({ phase: "idle" });
   const [repoPath, setRepoPath] = useState("");
-  const [tunnelHostname, setTunnelHostname] = useState("");
   const [apiBaseUrl, setApiBaseUrl] = useState("");
   const [paired, setPaired] = useState(false);
   const [pairBusy, setPairBusy] = useState(false);
@@ -74,12 +90,11 @@ export function Onboarding({ onComplete }: OnboardingProps) {
 
   // Hydrate any pre-existing settings — useful when the user
   // partially configured the app from the main UI before triggering
-  // the wizard, OR when "Restart onboarding" is added later.
+  // the wizard.
   useEffect(() => {
     void (async () => {
       const s = await companion.settings.get();
       if (typeof s.repoPath === "string") setRepoPath(s.repoPath);
-      if (typeof s.tunnelHostname === "string") setTunnelHostname(s.tunnelHostname);
       if (typeof s.apiBaseUrl === "string") setApiBaseUrl(s.apiBaseUrl);
       const p = await companion.pair.status();
       setPaired(p.paired);
@@ -87,18 +102,29 @@ export function Onboarding({ onComplete }: OnboardingProps) {
   }, []);
 
   const dockerOk = dockerState.phase === "ok";
+  const cfOk = cfState.phase === "ok";
+  const sysOk = dockerOk && cfOk;
   const repoOk = !!repoPath.trim();
-  const tunnelOk = !!tunnelHostname.trim() && tunnelHostname.includes(".");
-  const canFinish = dockerOk && repoOk && tunnelOk && paired;
+  const canFinish = sysOk && repoOk && paired;
 
   async function runDockerCheck() {
     setDockerState({ phase: "checking" });
     const r = await companion.onboarding.checkDocker();
-    if (r.installed) {
-      setDockerState({ phase: "ok", version: r.version || "Docker found." });
-    } else {
-      setDockerState({ phase: "missing", message: r.message });
-    }
+    setDockerState(
+      r.installed
+        ? { phase: "ok", version: r.version || "Docker found." }
+        : { phase: "missing", message: r.message },
+    );
+  }
+
+  async function runCfCheck() {
+    setCfState({ phase: "checking" });
+    const r = await companion.onboarding.checkCloudflared();
+    setCfState(
+      r.installed
+        ? { phase: "ok", version: r.version || "cloudflared found." }
+        : { phase: "missing", message: r.message },
+    );
   }
 
   async function chooseRepo() {
@@ -114,11 +140,9 @@ export function Onboarding({ onComplete }: OnboardingProps) {
   async function startPair() {
     setPairBusy(true);
     setPairMessage(null);
-    // Persist current hostname/url BEFORE pairing so the user doesn't
-    // have to remember to save them — the next backend:start can
-    // immediately register.
+    // Persist any advanced override BEFORE pairing so the pair flow
+    // hits the right Dev Hub.
     await companion.settings.set({
-      tunnelHostname: tunnelHostname.trim(),
       apiBaseUrl: apiBaseUrl.trim() || undefined,
     });
     const r = await companion.pair.start();
@@ -146,44 +170,81 @@ export function Onboarding({ onComplete }: OnboardingProps) {
         <header style={S.header}>
           <h1 style={S.title}>Welcome to the Companion.</h1>
           <p style={S.subtitle}>
-            Four steps to route the eSpace Dev Hub through your laptop.
+            Three quick steps to route the eSpace Dev Hub through your laptop.
             You only do this once.
           </p>
         </header>
 
         <Step
           n={1}
-          title="Docker Desktop"
-          done={dockerOk}
+          title="System requirements"
+          done={sysOk}
           locked={false}
-          help="The companion runs the backend as a Docker compose stack. We just need to know the CLI is on PATH; the daemon itself starts on demand."
+          help="The companion runs the backend in Docker and exposes it via Cloudflare Tunnel. Both tools just need to be on PATH; the companion starts and stops them for you."
         >
-          {dockerState.phase === "idle" && (
-            <Button onClick={runDockerCheck} variant="primary">
-              Check for Docker
-            </Button>
-          )}
-          {dockerState.phase === "checking" && (
-            <span style={S.muted}>Checking…</span>
-          )}
-          {dockerState.phase === "ok" && (
-            <span style={S.good}>✓ {dockerState.version}</span>
-          )}
-          {dockerState.phase === "missing" && (
-            <div style={S.errorBlock}>
-              <span style={S.bad}>{dockerState.message}</span>
-              <Button onClick={runDockerCheck} variant="secondary">
-                Recheck
+          {/* Docker */}
+          <div style={S.toolRow}>
+            <span style={S.toolLabel}>Docker</span>
+            {dockerState.phase === "idle" && (
+              <Button onClick={runDockerCheck} variant="primary">
+                Check
               </Button>
-            </div>
-          )}
+            )}
+            {dockerState.phase === "checking" && (
+              <span style={S.muted}>Checking…</span>
+            )}
+            {dockerState.phase === "ok" && (
+              <span style={S.good}>✓ {dockerState.version}</span>
+            )}
+            {dockerState.phase === "missing" && (
+              <div style={S.errorBlock}>
+                <span style={S.bad}>{dockerState.message}</span>
+                <Button onClick={runDockerCheck} variant="secondary">
+                  Recheck
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {/* cloudflared */}
+          <div style={S.toolRow}>
+            <span style={S.toolLabel}>cloudflared</span>
+            {cfState.phase === "idle" && (
+              <Button onClick={runCfCheck} variant="primary">
+                Check
+              </Button>
+            )}
+            {cfState.phase === "checking" && (
+              <span style={S.muted}>Checking…</span>
+            )}
+            {cfState.phase === "ok" && (
+              <span style={S.good}>✓ {cfState.version}</span>
+            )}
+            {cfState.phase === "missing" && (
+              <div style={S.errorBlock}>
+                <span style={S.bad}>{cfState.message}</span>
+                <p style={S.installHint}>
+                  Install with:{" "}
+                  <code style={S.code}>{cfInstallHint.win}</code>{" "}
+                  (Windows),{" "}
+                  <code style={S.code}>{cfInstallHint.mac}</code>{" "}
+                  (macOS), or{" "}
+                  <code style={S.code}>{cfInstallHint.linux}</code>{" "}
+                  (Linux). Restart this wizard after install.
+                </p>
+                <Button onClick={runCfCheck} variant="secondary">
+                  Recheck
+                </Button>
+              </div>
+            )}
+          </div>
         </Step>
 
         <Step
           n={2}
           title="Repository folder"
           done={repoOk}
-          locked={!dockerOk}
+          locked={!sysOk}
           help="Absolute path to your espace-devhub checkout. The companion runs `docker compose` from there."
         >
           <div style={S.row}>
@@ -194,7 +255,7 @@ export function Onboarding({ onComplete }: OnboardingProps) {
               placeholder="No folder selected"
               style={{ ...S.input, flex: 1 }}
             />
-            <Button onClick={chooseRepo} variant="primary" disabled={!dockerOk}>
+            <Button onClick={chooseRepo} variant="primary" disabled={!sysOk}>
               Pick folder
             </Button>
           </div>
@@ -202,43 +263,9 @@ export function Onboarding({ onComplete }: OnboardingProps) {
 
         <Step
           n={3}
-          title="Tunnel hostname"
-          done={tunnelOk}
-          locked={!repoOk}
-          help="Public hostname your Cloudflare Tunnel exposes the local backend at (e.g. user-42.cf-tunnel.com). The Dev Hub website asks this hostname for /api/v1/* once you click Start backend."
-        >
-          <input
-            type="text"
-            value={tunnelHostname}
-            onChange={(e) => setTunnelHostname(e.target.value.trim())}
-            placeholder="your-name.cf-tunnel.com"
-            style={S.input}
-            disabled={!repoOk}
-          />
-          <details style={S.details}>
-            <summary style={S.detailsSummary}>
-              Advanced: override Dev Hub URL
-            </summary>
-            <input
-              type="text"
-              value={apiBaseUrl}
-              onChange={(e) => setApiBaseUrl(e.target.value.trim())}
-              placeholder="https://espace-hubs.vercel.app"
-              style={{ ...S.input, marginTop: 8 }}
-              disabled={!repoOk}
-            />
-            <p style={S.help}>
-              Leave blank to use production. Override only when developing
-              against a preview deploy or localhost.
-            </p>
-          </details>
-        </Step>
-
-        <Step
-          n={4}
           title="Pair this device"
           done={paired}
-          locked={!tunnelOk}
+          locked={!repoOk}
           help="Opens your default browser to the eSpace Dev Hub approval page. You'll see the pairing code and the IP that initiated it before approving."
         >
           {paired ? (
@@ -254,13 +281,30 @@ export function Onboarding({ onComplete }: OnboardingProps) {
               </Button>
             </div>
           ) : (
-            <Button onClick={startPair} variant="primary" disabled={!tunnelOk}>
+            <Button onClick={startPair} variant="primary" disabled={!repoOk}>
               Pair this device
             </Button>
           )}
           {pairMessage && !paired && (
             <span style={S.muted}>{pairMessage}</span>
           )}
+
+          <details style={S.details}>
+            <summary style={S.detailsSummary}>
+              Advanced: override Dev Hub URL
+            </summary>
+            <input
+              type="text"
+              value={apiBaseUrl}
+              onChange={(e) => setApiBaseUrl(e.target.value.trim())}
+              placeholder="https://espace-hubs.vercel.app"
+              style={{ ...S.input, marginTop: 8 }}
+            />
+            <p style={S.help}>
+              Leave blank to use production. Override only when developing
+              against a preview deploy or localhost.
+            </p>
+          </details>
         </Step>
 
         <footer style={S.footer}>
@@ -397,12 +441,40 @@ const S: Record<string, React.CSSProperties> = {
     fontWeight: 700,
   },
   stepTitle: { margin: 0, fontSize: 15 },
-  stepBody: { display: "flex", flexDirection: "column", gap: 8 },
+  stepBody: { display: "flex", flexDirection: "column", gap: 12 },
+  toolRow: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 6,
+    paddingBottom: 8,
+    borderBottom: "1px solid var(--border)",
+  },
+  toolLabel: {
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 11,
+    color: "var(--muted)",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+  },
   help: {
     margin: 0,
     fontSize: 12,
     color: "var(--muted)",
     lineHeight: 1.5,
+  },
+  installHint: {
+    margin: 0,
+    fontSize: 12,
+    color: "var(--muted)",
+    lineHeight: 1.6,
+  },
+  code: {
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: 11,
+    background: "var(--bg)",
+    border: "1px solid var(--border)",
+    borderRadius: 3,
+    padding: "1px 4px",
   },
   row: { display: "flex", gap: 8, alignItems: "center" },
   input: {


### PR DESCRIPTION
## Why

Named CF tunnels need a domain on the user's Cloudflare account. TryCloudflare doesn't — it's free, anonymous, and starts in one command. Switching to TryCloudflare under the hood means users never type a hostname.

## What this changes

### New module: \`apps/desktop/src/main/tunnel-spawn.ts\`

Managed \`cloudflared tunnel --url http://localhost:4000\` subprocess:
- \`start({ port })\` spawns cloudflared, resolves when the \`*.trycloudflare.com\` URL appears in stderr (30s timeout).
- \`stop()\` SIGTERMs cleanly (Windows: \`taskkill /F /T /PID\` for tree reap).
- \`onHostname(cb)\` fires every allocation — covers respawn after crash.
- \`check()\` pre-flight probe (\`cloudflared --version\`) for the wizard.
- Auto-respawn on unexpected exit, exponential backoff, max 5 attempts.

### Wiring (\`main/index.ts\`)

- \`backend:start\` → \`startBackend()\` → \`tunnelSpawn.start({ port: 4000 })\`
- \`onHostname\` callback → \`tunnel.start(hostname)\` registers / re-registers with the Dev Hub
- \`backend:stop\` → \`tunnel.stop()\` → \`tunnelSpawn.stop()\` → \`stopBackend()\` (order matters — registration cleared BEFORE the public hostname dies)
- \`before-quit\` does the same

### \`tunnel-register.ts\`

\`start()\` now takes the hostname as a parameter (was reading \`settings.tunnelHostname\`). Idempotent — calling on a respawn cleanly re-registers + restarts the heartbeat with the new hostname.

### Wizard — 3 steps instead of 4

1. **System requirements** — Docker check + cloudflared check, both inline. Missing-tool path surfaces install hints (\`winget install --id Cloudflare.cloudflared\` etc.).
2. **Repository folder**
3. **Pair this device**

The \"Tunnel hostname\" step is gone entirely.

### Main UI

- The Tunnel hostname input is now a read-only display showing the live \`*.trycloudflare.com\` hostname.
- Auto-register checkbox stays as the off-switch.

### \`docker.ts\`

Removed the \`--profile tunnel\` flag from \`docker compose\` invocations (the sidecar needed \`TUNNEL_TOKEN\`, which is only relevant for named tunnels). The compose stack now starts mongo + api only; cloudflared runs on the host as a managed Electron subprocess.

## Trade-offs / known follow-ups

- **Cloudflared as a runtime dep** — for dev/test, users install via winget/brew/apt; the wizard surfaces a clear hint when missing. For released installers, bundle the binary via \`electron-builder.extraResources\` (~50MB). Left as a follow-up; lets us validate the PATH-installed flow first.
- **TryCloudflare hostname rotates** — every cloudflared restart picks a fresh subdomain. Our \`onHostname\` callback re-registers automatically; the user doesn't notice. Trade-off: heartbeat-window during the swap (~5s) might briefly show \"companion offline\" on the Dev Hub chip.
- **TryCloudflare rate limits** — fine for a handful of users; for hundreds we'd need named tunnels. Adding a \"Use named tunnel\" advanced option later is a small additive change.

## Test plan

- [ ] Fresh install with \`cloudflared\` on PATH: wizard step 1 → \"Check\" buttons → both ✓.
- [ ] Fresh install WITHOUT \`cloudflared\`: step 1 cloudflared check shows the red error + install hint with winget/brew/apt commands.
- [ ] Complete wizard, click Start backend → Docker comes up → within ~10s the \"Tunnel hostname\" readonly field shows a \`*.trycloudflare.com\` value → tunnel.active flips true.
- [ ] Dev Hub website: header chip flips to green \`via companion · <hostname>\` within ~5s of registration.
- [ ] Force cloudflared to crash (kill it manually from Task Manager) → companion auto-respawns, gets new hostname, re-registers, chip on Dev Hub stays green (or briefly goes amber during the swap).
- [ ] Stop backend → tunnel registration cleared, cloudflared killed, Docker stopped (in that order — verify via Task Manager + Dev Hub chip).
- [ ] Quit companion → same teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)