### PR TITLE
fix(compose): make TUNNEL_TOKEN optional

### DIFF
--- a/apps/desktop/src/main/docker.ts
+++ b/apps/desktop/src/main/docker.ts
@@ -106,7 +106,7 @@ function pushLog(line: string): void {
 
 export async function startBackend(): Promise<{ ok: boolean; message: string }> {
   lastError = null;
-  pushLog("[companion] starting docker compose --profile tunnel up -d");
+  pushLog("[companion] starting docker compose up -d");
   const res = await run(dockerComposeArgs("up", "-d"));
   if (!res.ok) {
     running = false;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,19 @@ services:
     image: cloudflare/cloudflared:latest
     command: tunnel --no-autoupdate run
     environment:
-      TUNNEL_TOKEN: ${TUNNEL_TOKEN:?TUNNEL_TOKEN required when --profile tunnel is active. See docs/RUN_LOCALLY.md.}
+      # Default to empty so the compose file parses cleanly when the
+      # tunnel sidecar isn't activated. docker-compose interpolates
+      # EVERY service's env vars on load, even profile-gated ones —
+      # `${...:?error}` would block `docker compose up -d` (no tunnel
+      # profile) on users without TUNNEL_TOKEN set.
+      #
+      # The companion's auto-spawn cloudflared on the HOST (not in this
+      # sidecar) is the default path; this sidecar is only relevant
+      # for users running a named tunnel via `docker compose --profile
+      # tunnel up -d` directly. Those users set TUNNEL_TOKEN themselves;
+      # the sidecar would crash on launch with an empty value, which
+      # is the correct failure mode for the named-tunnel use case.
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:-}
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
## Issue

After #114 the companion's \`docker compose up -d\` was hitting:

\`\`\`
error while interpolating services.tunnel.environment.TUNNEL_TOKEN:
required variable TUNNEL_TOKEN is missing a value
\`\`\`

Even though #114 removed \`--profile tunnel\` from the spawn command, docker-compose **interpolates every service's env vars on file load** regardless of whether the service's profile is active. The \`\${TUNNEL_TOKEN:?error}\` form blocked load on every companion user (none of whom set the variable post-#114).

## Fix

- \`docker-compose.yml\`: switch \`\${TUNNEL_TOKEN:?...}\` → \`\${TUNNEL_TOKEN:-}\` (default empty). The sidecar still won't start without \`--profile tunnel\`; users running a named tunnel manually set the var themselves.
- \`apps/desktop/src/main/docker.ts\`: clean up a stale log line that still said \"starting docker compose --profile tunnel up -d\".

## After this merges

Existing companion installs need to \`git pull\` on the laptop's repo checkout (the companion reads docker-compose.yml from disk at runtime) — no companion rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)