### PR TITLE
fix(auth): wipe user-scoped localStorage on every auth transition

### DIFF
--- a/apps/web/src/features/auth/accept-invite-form.jsx
+++ b/apps/web/src/features/auth/accept-invite-form.jsx
@@ -23,6 +23,7 @@ import { useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { apiPost } from "@/lib/api-client";
 import { useSession } from "./use-session.js";
+import { clearAllUserScopedStorage } from "./clear-user-storage.js";
 
 const MIN_PASSWORD_LENGTH = 12;
 
@@ -69,8 +70,14 @@ export function AcceptInviteForm({ onSuccess }) {
       return;
     }
 
-    // Cookie's already set by the API. Refresh the session store so
-    // useSession() sees the new user, then bubble up.
+    // Cookie's already set by the API. Wipe any localStorage left by
+    // a prior user on this browser (cross-user data leak fix) BEFORE
+    // refreshing the session — `refresh()` flips `user` and the
+    // *Sync effects mount; if localStorage still has the prior user's
+    // data they'd race / upload it via MigrateOnce.
+    clearAllUserScopedStorage();
+    // Refresh the session store so useSession() sees the new user,
+    // then bubble up.
     await refresh();
     onSuccess?.(r.data?.user);
     // Default destination: /onboarding. AuthGuard would route here

--- a/apps/web/src/features/auth/clear-user-storage.js
+++ b/apps/web/src/features/auth/clear-user-storage.js
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Wipe every user-scoped localStorage key in one call.
+ *
+ * Why this exists
+ * ───────────────
+ * The pre-M7 design mirrored user data to localStorage so the dashboard
+ * stayed responsive on slow networks. That design predates the multi-
+ * user reality of the deployed app — and `logout()` never cleared the
+ * mirror. The consequence was a real cross-user leak: a fresh signup
+ * on the same browser hydrated from the prior user's localStorage
+ * BEFORE the new user's `*Sync` components pulled their own data,
+ * AND `MigrateOnce` then UPLOADED the prior user's data under the new
+ * user's account (apps/web/src/features/migrate/migrate-once.jsx).
+ *
+ * Fix: clear all user-scoped keys synchronously at every auth-state
+ * transition (login, logout, signup, accept-invite, TOTP verify). The
+ * keys are listed here as an explicit allowlist rather than a
+ * `localStorage:*` prefix sweep so anyone adding a new store
+ * deliberately considers whether the value is user-scoped.
+ *
+ * NEVER add anything to this list that isn't user-scoped (themes,
+ * dismissed banners, etc.) — those are intentionally preserved across
+ * users on the same machine.
+ *
+ * Cross-tab note: `localStorage.removeItem` fires the `storage` event
+ * in OTHER tabs but not the one calling it. The stores that subscribe
+ * via the custom-event pattern (e.g. goals-store) won't auto-re-render
+ * in the same tab — but that's fine here because the call sites flip
+ * `user` immediately afterwards, which triggers the *Sync remount path
+ * that does its own re-render.
+ */
+
+/**
+ * Allowlist of user-scoped localStorage keys to clear on auth
+ * transitions. Mirrors the inventory in apps/web/src/features/*.
+ * When adding a new store with user-scoped data, ADD ITS KEY HERE.
+ */
+const USER_SCOPED_KEYS = Object.freeze([
+  "espace-devhub:goals",
+  "espace-devhub:snapshots",
+  "espace-devhub:evidence",
+  "espace-devhub:grading",
+  "espace-devhub:goal-specs",
+  "espace-devhub:goal-context",
+  "espace-devhub:goal-inputs",
+  "espace-devhub:integrations",
+  "espace-devhub:ai-provider",
+  "espace-devhub:chat",
+  "espace-devhub:last-seen",
+  "espace-devhub:last-review-date",
+  "espace-devhub:active-hub-pick",
+  "espace-devhub:migrate-completed-by-user",
+  "eshub:qa:config:v1",
+]);
+
+/**
+ * Synchronous wipe. Idempotent. SSR-safe (no-op when window is
+ * undefined). Catches per-key errors so a single locked / corrupt
+ * value can't block the rest of the wipe.
+ */
+export function clearAllUserScopedStorage() {
+  if (typeof window === "undefined") return;
+  for (const key of USER_SCOPED_KEYS) {
+    try {
+      window.localStorage.removeItem(key);
+    } catch (err) {
+      // localStorage can throw on quota / private mode / disabled
+      // storage. Log + continue so a misbehaving key doesn't trap us.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[auth] failed to clear ${key}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+  // Broadcast for any subscriber that wants to react (e.g. tests).
+  // Same-tab listeners on `storage` don't fire from setItem/removeItem
+  // calls in this tab — use the custom event for in-tab awareness.
+  try {
+    window.dispatchEvent(new Event("auth:user-storage-cleared"));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Exported for tests + the danger-tab "reset everything" button so
+ *  there's a single source of truth for what counts as user-scoped. */
+export const USER_SCOPED_LOCAL_STORAGE_KEYS = USER_SCOPED_KEYS;

--- a/apps/web/src/features/auth/index.js
+++ b/apps/web/src/features/auth/index.js
@@ -15,6 +15,10 @@
  */
 
 export { useSession } from "./use-session.js";
+export {
+  clearAllUserScopedStorage,
+  USER_SCOPED_LOCAL_STORAGE_KEYS,
+} from "./clear-user-storage.js";
 export { useMyEngagementConfig } from "./use-engagement-config.js";
 export { SessionProvider } from "./session-provider.jsx";
 export { LoginForm } from "./login-form.jsx";

--- a/apps/web/src/features/auth/session-provider.jsx
+++ b/apps/web/src/features/auth/session-provider.jsx
@@ -1,22 +1,55 @@
 "use client";
 
 /**
- * Mounts once at the root layout. Triggers the initial `/auth/me`
- * lookup so every consumer of useSession() reads from a populated
- * store on first render.
+ * Mounts once at the root layout. Two jobs:
+ *
+ *   1. Trigger the initial `/auth/me` lookup so every consumer of
+ *      useSession() reads from a populated store on first render.
+ *
+ *   2. Cross-user data-leak backstop: detect when the resolved user
+ *      ID changes from one value to a DIFFERENT non-null value and
+ *      wipe localStorage. The primary fix is in the explicit auth
+ *      mutation paths (login / verifyTotp / signup / accept-invite /
+ *      logout) — see clear-user-storage.js. This effect is a belt-
+ *      and-suspenders backstop catching transitions that bypass those
+ *      paths (e.g. a future SSO callback that flips `user` via
+ *      `setSession` directly).
+ *
+ *      The race vs. *Sync components: this effect fires AFTER the
+ *      user-state change, so Sync effects depending on `user.id`
+ *      might already have started. That's why we wipe in the
+ *      mutation paths FIRST (synchronously, before setSession). This
+ *      is just defense-in-depth.
  *
  * No React context — the session store is module-level so children
  * import `useSession` directly. The provider is just the lifecycle
  * hook that kicks off the first fetch.
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSession } from "./use-session.js";
+import { clearAllUserScopedStorage } from "./clear-user-storage.js";
 
 export function SessionProvider({ children }) {
-  const { refresh } = useSession();
+  const { refresh, user } = useSession();
+  const lastUserIdRef = useRef(null);
+
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    const currentId = user?.id ?? null;
+    const lastId = lastUserIdRef.current;
+    // Only act on a transition between two different non-null ids.
+    // null → user (fresh sign-in on a clean browser) and user → null
+    // (logout) are handled by the explicit auth-mutation wipes; we
+    // don't want to double-wipe here.
+    if (lastId && currentId && lastId !== currentId) {
+      clearAllUserScopedStorage();
+    }
+    lastUserIdRef.current = currentId;
+  }, [user?.id]);
+
   return children;
 }

--- a/apps/web/src/features/auth/signup-form.jsx
+++ b/apps/web/src/features/auth/signup-form.jsx
@@ -19,6 +19,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { apiPost } from "@/lib/api-client";
 import { setSession } from "./session-store.js";
+import { clearAllUserScopedStorage } from "./clear-user-storage.js";
 
 const INPUT_STYLE = {
   fontFamily: "var(--font-mono)",
@@ -61,6 +62,12 @@ export function SignupForm({ onSuccess }) {
       setError(result.error);
       return;
     }
+    // Cross-user data leak fix: wipe any localStorage the previous
+    // user left on this machine BEFORE handing the new user a session.
+    // Without this, the new user inherits the prior user's goals /
+    // snapshots / evidence / integrations etc., AND MigrateOnce
+    // uploads that stale payload under the new user's account.
+    clearAllUserScopedStorage();
     // Push the new user into the session store so AuthGuard /
     // useSession reflect the auth state without a /me round-trip.
     setSession({

--- a/apps/web/src/features/auth/use-session.js
+++ b/apps/web/src/features/auth/use-session.js
@@ -7,6 +7,7 @@ import {
   setSession,
   subscribeSession,
 } from "./session-store.js";
+import { clearAllUserScopedStorage } from "./clear-user-storage.js";
 
 // React's useSyncExternalStore compares snapshot return values by
 // reference (Object.is). If getServerSnapshot allocates a new object on
@@ -107,6 +108,12 @@ export function useSession() {
       return { ok: false, error: result.error };
     }
     const { user, needsTotp } = result.data;
+    // Cross-user data leak fix: wipe prior user's localStorage BEFORE
+    // promoting the new user into the session store. The *Sync
+    // components react to `user.id` change and will pull the new
+    // user's real data from the API; wiping first ensures they don't
+    // race against (or upload via MigrateOnce) the prior user's data.
+    clearAllUserScopedStorage();
     setSession({
       user: needsTotp ? null : user,
       loading: false,
@@ -128,6 +135,11 @@ export function useSession() {
       });
       return { ok: false, error: result.error };
     }
+    // Same reasoning as in login() — wipe before promoting the user.
+    // This branch matters for the two-step-login path: step 1 sets
+    // `needsTotp:true` and leaves user=null, then step 2 here flips
+    // user to the real user. The flip is the dangerous transition.
+    clearAllUserScopedStorage();
     setSession({
       user: result.data?.user ?? null,
       loading: false,
@@ -139,6 +151,11 @@ export function useSession() {
 
   const logout = useCallback(async () => {
     const result = await apiPost("/auth/logout");
+    // Wipe localStorage so the next user on this browser doesn't
+    // inherit anything from the session that just ended. Order
+    // doesn't matter here — there's no new user about to mount, just
+    // the bare /login screen.
+    clearAllUserScopedStorage();
     setSession({
       user: null,
       loading: false,


### PR DESCRIPTION
## Issue

A fresh signup (or new-user login) on a browser previously used by another user inherited the prior user's data — **and** \`MigrateOnce\` actively UPLOADED that stale payload under the new user's account. This is a real cross-user data leak (read AND write side).

Reproduced exactly per the test report: signed up a new account, saw the prior user's goals.

## Root cause

Each \`*Sync\` component in the root layout (\`GoalsSync\`, \`SnapshotsSync\`, \`ContextSync\`, \`InputsSync\`, \`SpecsSync\`, \`GradingSync\`, plus \`MigrateOnce\`) reacts to \`user.id\` changes by pulling from the API. But:

1. They **merge** server state into existing localStorage, not replace.
2. **No** auth-mutation path (login / logout / signup / accept-invite / verifyTotp) wiped localStorage at the transition.
3. The new user's \`user.id\` lands in the session store; the *Sync effects fire WITH the old localStorage already present; \`MigrateOnce\` reads that localStorage and POSTs it to \`/migrate/import\` under the new user's id.

## Fix

**New helper** — \`apps/web/src/features/auth/clear-user-storage.js\` — exports \`clearAllUserScopedStorage()\` over an explicit allowlist of 15 keys. Allowlist (not pattern sweep) so anyone adding a new store deliberately considers whether to wipe.

| Cleared on transition | Preserved across users |
| --- | --- |
| goals, snapshots, evidence, grading, goal-specs, goal-context, goal-inputs, integrations, ai-provider, chat, last-seen, last-review-date, active-hub-pick, migrate-completed-by-user, qa-hub-config | theme prefs, dismissed banners, demo-mode toggle |

**Wired synchronously** into every transition path **BEFORE** \`setSession({ user })\`:
- \`use-session.js\` → \`login\`, \`verifyTotp\`, \`logout\`
- \`signup-form.jsx\` → \`handleSubmit\`
- \`accept-invite-form.jsx\` → \`handleSubmit\`

**Defensive backstop** in \`session-provider.jsx\`: a \`useEffect\` that wipes on any non-null → different-non-null \`user.id\` transition, catching future auth paths that bypass the helpers.

## Side effects / trade-offs

- The danger-tab \"Reset everything\" still does \`localStorage.clear()\` — explicit user-initiated, different semantics, intentionally kept.
- A returning user with un-migrated pre-M7 legacy data on their device loses that data on next sign-in. Migrate window is ~6 months old at this point, and the cross-user leak is the bigger problem.

## Test plan

- [ ] Sign in as user A → make changes (add a goal, save a snapshot)
- [ ] Sign out → localStorage inspector shows all 15 keys gone
- [ ] Sign up as user B in the same browser → dashboard is empty, NOT showing user A's goals
- [ ] Check Mongo (or admin → /admin/users → click user B) — user B's goal tree is empty (NOT inheriting user A's tree via MigrateOnce upload)
- [ ] Sign in as user A again → re-pulls their data via *Sync; original tree intact
- [ ] Invite path: admin invites user C → user C accepts invite on user A's browser → no leak
- [ ] TOTP path: sign in to TOTP-enrolled user → step 1 sets needsTotp:true → step 2 wipes + sets user. No leak on the step-2 flip either.

Web typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)