### PR TITLE
feat(admin): wipe-dashboard-data button to clean mirror-bug pollution

### DIFF
--- a/apps/api/src/modules/admin/controller.ts
+++ b/apps/api/src/modules/admin/controller.ts
@@ -28,8 +28,14 @@ import { ObjectId } from "mongodb";
 import { findHubById, HUB_ORDER } from "@espace-devhub/shared/hubs";
 import {
   getAuditLogCollection,
+  getGoalContextCollection,
+  getGoalInputsCollection,
+  getGoalSpecsCollection,
+  getGoalsCollection,
+  getGradingVerdictsCollection,
   getOrgsCollection,
   getSessionsCollection,
+  getSnapshotsCollection,
   getUsersCollection,
 } from "../../db/collections.js";
 import type {
@@ -523,6 +529,119 @@ export async function resetUserTotpHandler(
     });
 
     res.json({ user: toPublicUser(updated), reset: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── DELETE /api/v1/admin/users/:id/personal-data ────────────────────
+//
+// Wipe a target user's accumulated dashboard data across the
+// collections that used to mirror localStorage (and so were susceptible
+// to the cross-user upload bug fixed in PR #117). Cleans up:
+//
+//   - goals             (one row per user)
+//   - snapshots         (many)
+//   - grading_verdicts  (many — verdict cache)
+//   - goal_specs        (many — AI classifier output)
+//   - goal_context      (many — per-goal answers)
+//   - goal_inputs       (many — time-series entries)
+//
+// Deliberately NOT touched:
+//   - users             (the account itself — admin uses PATCH /users/:id
+//                        for that)
+//   - integrations      (OAuth tokens — never written by the mirror bug)
+//   - sessions          (kicking users out is a separate admin action)
+//   - audit_log         (history is preserved)
+//
+// Idempotent + admin-only + cross-org-safe (every filter pins orgId).
+// Audited.
+
+export async function resetUserPersonalDataHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const targetId = requireUserId(req);
+
+    // Verify target exists in this org before deleting anything.
+    const users = await getUsersCollection();
+    const target = await users.findOne({
+      _id: targetId,
+      orgId: session.orgId,
+    });
+    if (!target) {
+      throw new HttpError(404, "not_found", "User not found in this org.");
+    }
+
+    // Collect every affected collection up front so we can audit
+    // exact delete counts. Parallel deletes — the collections are
+    // independent and the bottleneck would otherwise be the round
+    // trips.
+    const [
+      goals,
+      snapshots,
+      grading,
+      specs,
+      context,
+      inputs,
+    ] = await Promise.all([
+      getGoalsCollection(),
+      getSnapshotsCollection(),
+      getGradingVerdictsCollection(),
+      getGoalSpecsCollection(),
+      getGoalContextCollection(),
+      getGoalInputsCollection(),
+    ]);
+
+    const filter = { orgId: session.orgId, userId: targetId };
+
+    const [
+      goalsRes,
+      snapshotsRes,
+      gradingRes,
+      specsRes,
+      contextRes,
+      inputsRes,
+    ] = await Promise.all([
+      goals.deleteMany(filter),
+      snapshots.deleteMany(filter),
+      grading.deleteMany(filter),
+      specs.deleteMany(filter),
+      context.deleteMany(filter),
+      inputs.deleteMany(filter),
+    ]);
+
+    const deleted = {
+      goals: goalsRes.deletedCount,
+      snapshots: snapshotsRes.deletedCount,
+      gradingVerdicts: gradingRes.deletedCount,
+      goalSpecs: specsRes.deletedCount,
+      goalContext: contextRes.deletedCount,
+      goalInputs: inputsRes.deletedCount,
+    };
+
+    await writeAudit({
+      orgId: session.orgId,
+      actorUserId: session.userId,
+      actorRole: session.role,
+      action: "user.personal_data_reset_by_admin",
+      targetType: "user",
+      targetId: targetId.toHexString(),
+      after: { deleted },
+      ...networkMeta(req),
+    });
+
+    res.json({
+      ok: true,
+      user: toPublicUser(target),
+      deleted,
+    });
   } catch (err) {
     next(err);
   }

--- a/apps/api/src/modules/admin/routes.ts
+++ b/apps/api/src/modules/admin/routes.ts
@@ -29,6 +29,7 @@ import {
   listAuditHandler,
   listSignupCodesHandler,
   listUsersHandler,
+  resetUserPersonalDataHandler,
   resetUserTotpHandler,
   updateSignupCodeHandler,
   updateUserHandler,
@@ -53,6 +54,16 @@ adminRouter.post(
   requireAuth(),
   requireRole("admin"),
   resetUserTotpHandler,
+);
+// Wipes the user's dashboard data (goals + snapshots + verdicts +
+// specs + context + inputs) across the collections that were polluted
+// by the pre-#117 localStorage-mirror upload bug. Does NOT delete the
+// user account, integrations, sessions, or audit history.
+adminRouter.delete(
+  "/users/:id/personal-data",
+  requireAuth(),
+  requireRole("admin"),
+  resetUserPersonalDataHandler,
 );
 
 adminRouter.get(

--- a/apps/web/src/hubs/admin/admin-users.jsx
+++ b/apps/web/src/hubs/admin/admin-users.jsx
@@ -29,7 +29,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import { apiGet, apiPatch, apiPost } from "@/lib/api-client";
+import { apiDelete, apiGet, apiPatch, apiPost } from "@/lib/api-client";
 import { useSession } from "@/features/auth";
 import { CAPABILITIES } from "@espace-devhub/shared/capabilities";
 import { HUB_ORDER } from "@espace-devhub/shared/hubs";
@@ -662,6 +662,47 @@ function UserEditor({ user, isSelf, onUpdate }) {
     }
   }
 
+  // Wipe the user's dashboard data (goals, snapshots, grading verdicts,
+  // goal specs/context/inputs). Useful when the pre-#117 localStorage-
+  // mirror bug uploaded another user's data under this user's account
+  // and you want to start them with a clean slate.
+  async function handleResetPersonalData() {
+    if (
+      !window.confirm(
+        `Wipe all dashboard data for ${user.displayName}?\n\nDeletes their goals, snapshots, AI verdicts, goal specs/context/inputs. Does NOT touch their account, integrations, or sessions. Use this to clean up data left over from the cross-user mirror bug. Irreversible.`,
+      )
+    ) {
+      return;
+    }
+    setSaving(true);
+    const r = await apiDelete(`/admin/users/${user.id}/personal-data`);
+    setSaving(false);
+    if (!r.ok) {
+      toast.error(r.error?.message || "Couldn't reset personal data.");
+      return;
+    }
+    const d = r.data?.deleted || {};
+    const total =
+      (d.goals || 0) +
+      (d.snapshots || 0) +
+      (d.gradingVerdicts || 0) +
+      (d.goalSpecs || 0) +
+      (d.goalContext || 0) +
+      (d.goalInputs || 0);
+    if (total === 0) {
+      toast.info(`${user.displayName} had nothing to clean up.`);
+    } else {
+      toast.success(
+        `Wiped ${total} row${total === 1 ? "" : "s"} for ${user.displayName} ` +
+          `(goals:${d.goals || 0} · snapshots:${d.snapshots || 0} · verdicts:${
+            d.gradingVerdicts || 0
+          } · specs:${d.goalSpecs || 0} · context:${d.goalContext || 0} · inputs:${
+            d.goalInputs || 0
+          }).`,
+      );
+    }
+  }
+
   return (
     <div
       className="border-t px-5 py-5"
@@ -804,6 +845,22 @@ function UserEditor({ user, isSelf, onUpdate }) {
               Reset TOTP
             </button>
           ) : null}
+          {/* Wipe accumulated dashboard data — useful for cleaning up
+              pre-#117 mirror-bug pollution. Always available (idempotent
+              if there's nothing to delete). */}
+          <button
+            type="button"
+            onClick={handleResetPersonalData}
+            disabled={saving}
+            style={{
+              ...dangerButtonStyle,
+              opacity: saving ? 0.55 : 1,
+              cursor: saving ? "wait" : "pointer",
+            }}
+            title="Wipes goals/snapshots/verdicts/specs/context/inputs. Does NOT touch the account itself, integrations, or sessions."
+          >
+            Wipe dashboard data
+          </button>
           <button
             type="button"
             onClick={handleSave}


### PR DESCRIPTION
## Context

After #117 landed (goals → API-direct), the user reported the cross-user goals leak still showed in their test session. Diagnosis: the leak is gone going forward, but pre-#117 buggy uploads via \`mirrorPutTree\` already wrote one user's data into another user's Mongo row. The data is server-side pollution; the new code reads it correctly because as far as the DB is concerned, those goals belong to that user.

## Fix

New admin tool to clean it up per-user.

**Endpoint**: \`DELETE /api/v1/admin/users/:id/personal-data\`
- Wipes the target user's rows in: goals, snapshots, grading_verdicts, goal_specs, goal_context, goal_inputs
- Does NOT touch: the user row, integrations, sessions, audit history
- Cross-org safe (every filter pins \`orgId: session.orgId\`)
- Idempotent + admin-only + audited (\`user.personal_data_reset_by_admin\`)

**UI**: \"Wipe dashboard data\" button in the admin user editor next to the existing \"Reset TOTP\". Confirm dialog + success toast showing the per-collection delete counts.

## Why this set of collections specifically

These are the six collections that had localStorage mirrors writing into them. All vulnerable to the same upload pattern. Cleaning them as a unit means an admin click resets a user to \"as if they just signed up\" without nuking the account or integrations.

## Test plan

- [ ] Log in as admin → /admin/users → expand abdelrahman.kamel@crealogix.com → click \"Wipe dashboard data\" → confirm.
- [ ] Toast shows \"Wiped N rows for ...\" with per-collection counts.
- [ ] Log in as abdelrahman.kamel → dashboard goals tab is empty.
- [ ] GET /api/v1/goals returns \`{ schemaVersion: 2, l1s: [], cycleId: null, updatedAt: null }\`.
- [ ] Add a new goal as that user → still works, doesn't leak.
- [ ] Audit log shows \`user.personal_data_reset_by_admin\` with the counts under \`after.deleted\`.
- [ ] Endpoint is admin-only (call as non-admin → 403).
- [ ] Calling on a user with no data is idempotent — second call returns \`total: 0\` toast.

Web + API both typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)