### PR TITLE
fix(catch-all): never proxy auth/admin/companion paths through tunnel

### DIFF
--- a/apps/web/src/pages/api/v1/[...path].ts
+++ b/apps/web/src/pages/api/v1/[...path].ts
@@ -231,6 +231,39 @@ export const config = {
   },
 };
 
+/**
+ * Path prefixes that MUST always hit Vercel's bundled API, never the
+ * companion tunnel — regardless of whether the user has a fresh
+ * registration. Two failure modes drove this list:
+ *
+ *   1. Dead tunnel masks core endpoints. If the user's cloudflared
+ *      stops sending heartbeats but the registration is still inside
+ *      the 5-minute freshness window, a POST /auth/login would 530
+ *      via CF Tunnel error 1033 — the user can't sign in to fix it
+ *      from the same browser.
+ *
+ *   2. Circular routing. The /companion/* pairing endpoints and
+ *      /auth/me/companion-tunnel + /auth/me/api-origin ARE the
+ *      routing-management surface. Proxying them to a companion is
+ *      either circular ("ask the companion where the companion is")
+ *      or pointless (the companion doesn't know about the pairing
+ *      flow because the pairing collection lives only in the
+ *      Vercel-side Mongo).
+ *
+ * The integration-proxy endpoints (/integrations/proxy/<provider>/*)
+ * stay proxied — those are the entire reason companions exist
+ * (upstream calls to private resources behind the user's VPN).
+ */
+function shouldBypassCompanion(rawUrl: string): boolean {
+  // Strip query string — we're only matching on the path.
+  const path = rawUrl.split("?", 1)[0] || "";
+  return (
+    path.startsWith("/api/v1/auth/") ||
+    path.startsWith("/api/v1/admin/") ||
+    path.startsWith("/api/v1/companion/")
+  );
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -243,7 +276,11 @@ export default async function handler(
   // lookup keyed by the user's session; on null we fall through to
   // the bundled path, preserving today's behavior for the 99% of
   // users (and 100% of unauthenticated requests).
-  if (resolveCompanionOrigin) {
+  //
+  // Hard-bypass for auth/admin/companion-pairing paths — see
+  // `shouldBypassCompanion` above for why. Even if the user has a
+  // fresh companion registration, these endpoints must hit Vercel.
+  if (resolveCompanionOrigin && !shouldBypassCompanion(req.url || "")) {
     try {
       const origin = await resolveCompanionOrigin(req);
       if (origin) {


### PR DESCRIPTION
## Bug

User reported \`POST /api/v1/auth/login\` returning Cloudflare Error 1033 (Tunnel error) with HTML body from a dead \`*.trycloudflare.com\` hostname. They're locked out of their own browser session.

## Root cause

When a user's companion is registered but cloudflared has died, the registration is still considered fresh by the 5-minute heartbeat window. The catch-all happily proxies EVERY request — including login — through the dead tunnel, which 530s.

Beyond the dead-tunnel case: even with a healthy tunnel, routing certain paths to the companion is **architecturally wrong**:
- \`/companion/*\` are the pairing endpoints. The pairings collection lives only on Vercel's side; routing to the companion means a 404.
- \`/auth/me/companion-tunnel\` is the REGISTRATION endpoint. Routing it through the registered tunnel is circular — the companion would be asked to update its own registration.
- \`/auth/me/api-origin\` is the \"where do I route?\" question. Routing the answer creates infinite-loop semantics.
- \`/admin/*\` modifies global state (signup codes, user roles) that lives on Vercel.

## Fix

Hard-bypass companion routing for three path prefixes:

| Prefix | Why |
|---|---|
| \`/api/v1/auth/*\` | session mgmt, \`/me\`, TOTP, password reset, etc. Must hit Vercel so login can never be blocked by a dead tunnel. |
| \`/api/v1/admin/*\` | admin tooling — global state. |
| \`/api/v1/companion/*\` | device-pairing endpoints — pairings collection lives only on Vercel. |

The integration-proxy endpoints (\`/integrations/proxy/<provider>/*\`) — the actual reason companions exist (upstream calls to private resources behind the user's VPN) — stay proxied to the companion as before.

Single-file change to \`apps/web/src/pages/api/v1/[...path].ts\`. Web typecheck clean.

## Immediate workaround for users already locked out

Until this deploys, clear cookies for \`espace-hubs.vercel.app\` in your browser. Without a session cookie, \`resolveCompanionOrigin\` returns null → login hits the bundled API → you're back in. Then call \`DELETE /api/v1/auth/me/companion-tunnel\` (admin → user editor → \"Reset TOTP\" pattern, or curl with cookies) to clear the stale registration. Or just wait 5 minutes after the companion died for natural staleness expiry.

## Test plan

- [ ] User with a dead companion registration + still-fresh \`lastSeenAt\` can POST \`/auth/login\` successfully (no 530).
- [ ] \`/api/v1/admin/users\` admin list returns from Vercel even when companion is registered + fresh.
- [ ] \`/api/v1/companion/pair/start\` returns from Vercel (pairing flow works).
- [ ] \`/api/v1/integrations/proxy/github/user\` still routes to the companion when registered + fresh (no regression on the actual VPN-routing use case).
- [ ] Unauthenticated requests still hit the bundled API (no cookie → resolver returns null → bundled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)