### PR TITLE
fix(serverless): await bootstrap before serving requests (schema race)

### DIFF
--- a/apps/web/src/pages/api/v1/[...path].ts
+++ b/apps/web/src/pages/api/v1/[...path].ts
@@ -201,22 +201,38 @@ async function getApp(): Promise<Application> {
       // Phase 3: capture the companion-routing resolver so we can
       // ask it on every request whether to proxy instead.
       resolveCompanionOrigin = mod.resolveCompanionOrigin;
-      // Kick off the Mongo + bootstrap pipeline in the background.
-      // We don't `await` it here so the first request can start
-      // processing immediately — any handler that needs the DB
-      // awaits the same in-flight `connect()` singleton via
-      // `getDb()` (see apps/api/src/db/client.ts).
-      void mod
-        .connect()
-        .then(() => mod.bootstrap())
-        .then(() => mod.seedDefaultOrg())
-        .catch((err: unknown) => {
-          // eslint-disable-next-line no-console
-          console.warn(
-            "[boot] serverless mongo bootstrap failed:",
-            err instanceof Error ? err.message : String(err),
-          );
-        });
+
+      // Await the Mongo + bootstrap pipeline BEFORE returning the
+      // app. Earlier this was fire-and-forget so the first request
+      // could start immediately — but that races schema-changing
+      // deploys: any deploy that removes a `required` field from a
+      // validator (e.g. the demo-mode removal) leaves Mongo still
+      // requiring the old field until `bootstrap()` runs
+      // `collMod`. Requests that landed in that window failed
+      // validation on insert ("missingProperties: [demo]").
+      //
+      // Cost of awaiting: cold-start latency goes up by the
+      // duration of bootstrap (~1-2s on Atlas — validator alignment
+      // + index ensure + boot-time migrations). Warm invocations
+      // still hit the cached appPromise and pay nothing. Worth it
+      // for correctness.
+      try {
+        await mod.connect();
+        await mod.bootstrap();
+        await mod.seedDefaultOrg();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "[boot] serverless mongo bootstrap failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+        // We DON'T reset appPromise on failure — the next request
+        // would just retry the failing path. Better: serve the app
+        // so handlers can surface a clean 500 with a logged cause.
+        // The retry happens on the next cold start (new container)
+        // which is the right scope.
+      }
+
       return app;
     })();
   }


### PR DESCRIPTION
## Bug

\`\`\`
{
  \"err\": {
    \"type\": \"MongoServerError\",
    \"message\": \"Document failed validation\",
    \"errInfo\": {
      \"details\": {
        \"schemaRulesNotSatisfied\": [{
          \"operatorName\": \"required\",
          \"specifiedAs\": { \"required\": [..., \"demo\", \"totpVerified\"] },
          \"missingProperties\": [\"demo\"]
        }]
      }
    }
  },
  \"path\": \"/api/v1/auth/login\"
}
\`\`\`

The deployed code no longer writes \`demo\` to new sessions (since #117), but Mongo's stored validator on the sessions collection STILL required it. Login \`insertOne\` failed → 500.

## Root cause

The Vercel catch-all kicks off the boot pipeline fire-and-forget:

\`\`\`ts
void mod.connect()
  .then(() => mod.bootstrap())       // ← updates Mongo validator via collMod
  .then(() => mod.seedDefaultOrg())
  .catch(...)
\`\`\`

Comment says \"so the first request can start processing immediately.\"

That works fine for additive schema changes (new optional fields). But the demo-mode removal in #117 was the first deploy in this codebase to REMOVE a required field — and the FIRST cold-start request landed before \`applyValidators()\` finished aligning Mongo's validator. The still-old validator required \`demo\`, the new code didn't write it, insert failed.

## Fix

Await the boot pipeline inside \`getApp()\` instead of voiding it. The Express app isn't returned until \`connect → bootstrap → seedDefaultOrg\` completes (or fails — failures still log but don't block serving).

## Trade-off

| | Before | After |
|---|---|---|
| Cold-start latency | App returns immediately; first DB-touching request races bootstrap | App returns after bootstrap (~1-2s on Atlas) |
| Warm-invocation latency | Same as cold (cached) | Same as cold (cached) |
| Schema-changing deploys | Race; first request after deploy can fail | Safe; validator aligned before any handler runs |
| Bootstrap failure | Silently logged; future requests retry | Silently logged; app still serves so handlers can return clean 500s |

The +1-2s cold-start cost lands on the first request after each new function container spins up. Vercel reuses containers for several minutes between cold starts, so per-user latency impact is minimal.

## Why this race didn't bite us before

Every previous schema migration was additive:
- adding \`totpEnrolled\` (optional)
- adding \`engagement\` (optional)
- adding \`companionTunnel\` (optional)
- adding \`signupCodes\` (optional)
- adding \`onboardingCompletedAt\` (optional)

The demo-mode removal in #117 was the first deploy that made the OLD validator REJECT writes the NEW code performs. Hence the first to expose the race.

## Going forward

The general lesson: schema-removing migrations are deploy-unsafe unless either (a) bootstrap is awaited before serving, OR (b) the validator stays permissive (field in \`properties\` but not in \`required[]\`) across two deploys so the old code can write without the field AND the new code can write without it.

Today's fix is (a) — the simpler and more robust answer.

## Test plan

- [ ] Cold-start the serverless function (e.g. retry login after Vercel function has been idle): no more validation errors on login.
- [ ] Warm invocations still fast (no per-request bootstrap overhead).
- [ ] Boot log shows \`[db] bootstrap complete (validators + indexes)\` BEFORE the first request log.
- [ ] If Mongo is unreachable, app still returns and clean 500s start surfacing (no infinite hang on getApp()).

🤖 Generated with [Claude Code](https://claude.com/claude-code)