### PR TITLE
fix(integrations): trim creds + surface err.cause on upstream fetch

### DIFF
--- a/apps/api/src/modules/integrations/controller.ts
+++ b/apps/api/src/modules/integrations/controller.ts
@@ -36,7 +36,17 @@ import { HttpError } from "../../middleware/error-handler.js";
 
 // ─── input schema ────────────────────────────────────────────────────
 
-const tokenString = z.string().min(1).max(2_048);
+// Trim whitespace BEFORE the min-length check so a token that's
+// "just whitespace" rejects, and a token with trailing newline /
+// space (the standard copy-paste mistake) is normalised to the
+// clean string. Without this, the bytes flow through encryption,
+// decryption, and into the upstream Authorization header — where
+// undici rejects newlines as invalid header values and the proxy
+// surfaces a useless "fetch failed".
+const tokenString = z
+  .string()
+  .transform((s) => s.trim())
+  .pipe(z.string().min(1).max(2_048));
 
 const upsertSchema = z.object({
   providerId: z.string().min(1).max(64),

--- a/apps/api/src/modules/integrations/proxy.ts
+++ b/apps/api/src/modules/integrations/proxy.ts
@@ -323,17 +323,45 @@ async function runProxy(
         ...(body !== undefined ? { body } : {}),
       });
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      // Node's undici-backed fetch throws a generic `TypeError: fetch
+      // failed` for every network-layer failure — the actual cause
+      // (ENOTFOUND, ECONNREFUSED, UND_ERR_CONNECT_TIMEOUT, TLS chain
+      // errors, etc.) lives on `err.cause`. We pull it out so the
+      // error envelope and the integration's `lastError` field show
+      // something operators can act on instead of the useless
+      // "fetch failed" string.
+      const baseMsg = err instanceof Error ? err.message : String(err);
+      const cause = (err as { cause?: unknown }).cause;
+      const causeMsg =
+        cause instanceof Error
+          ? cause.message
+          : cause && typeof cause === "object"
+          ? // Undici causes are typically `{ code, message }` shaped.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ((cause as any).code ?? (cause as any).message ?? "")
+          : "";
+      const detail = causeMsg ? `${baseMsg} (${causeMsg})` : baseMsg;
+      // Log the FULL exception for ops — the response message keeps
+      // it concise but Pino captures the structured error.
+      logger.warn(
+        {
+          err,
+          providerId: ctx.providerId,
+          targetUrl,
+          reqId: req.id,
+        },
+        "[proxy] upstream fetch failed",
+      );
       void markIntegrationError({
         orgId: session.orgId,
         userId: session.userId,
         providerId: ctx.providerId,
-        message: `Network: ${msg}`,
+        message: `Network: ${detail}`,
       });
       throw new HttpError(
         502,
         "integration_unreachable",
-        `Network error reaching ${ctx.providerId}: ${msg}`,
+        `Network error reaching ${ctx.providerId}: ${detail}`,
       );
     }
 

--- a/apps/web/src/features/settings/token-forms.jsx
+++ b/apps/web/src/features/settings/token-forms.jsx
@@ -42,7 +42,12 @@ export function GitLabTokenForm() {
 
   async function handleSubmit(e) {
     e.preventDefault();
-    if (!token) return toast.error("Access token is required.");
+    // Trim before everything — copy-paste from password managers and
+    // GitLab's UI commonly drags a trailing space/newline that breaks
+    // the upstream Authorization header. We don't want to lose that
+    // to undici's "fetch failed" black hole.
+    const cleanToken = token.trim();
+    if (!cleanToken) return toast.error("Access token is required.");
     if (!gitlabUrl) {
       return toast.error(
         "GitLab base URL not configured for your engagement. Ask an admin to set <ENGAGEMENT>_GITLAB_URL in the API env.",
@@ -53,12 +58,12 @@ export function GitLabTokenForm() {
       // Save + await the mirror — the API needs the encrypted token on
       // disk before the proxy call below can use it.
       await saveConnection("gitlab", {
-        accessToken: token,
+        accessToken: cleanToken,
         endpointUrl: gitlabUrl,
       });
       const me = await proxyFetch("gitlab", "user");
       await saveConnection("gitlab", {
-        accessToken: token,
+        accessToken: cleanToken,
         endpointUrl: gitlabUrl,
         username: me.username,
         displayName: me.name,
@@ -136,7 +141,11 @@ export function JiraTokenForm() {
 
   async function handleSubmit(e) {
     e.preventDefault();
-    if (!identity || !secret) {
+    // Trim both — copy-paste of either field commonly drags whitespace
+    // that breaks the upstream Basic-auth header encoding.
+    const cleanIdentity = identity.trim();
+    const cleanSecret = secret.trim();
+    if (!cleanIdentity || !cleanSecret) {
       return toast.error(
         isEspace
           ? "Username and password are required."
@@ -153,22 +162,24 @@ export function JiraTokenForm() {
       // Persist into the SAME columns either way — server-side proxy
       // reads engagement at request time and decides v2 vs v3.
       await saveConnection("jira", {
-        email: identity,
-        apiToken: secret,
+        email: cleanIdentity,
+        apiToken: cleanSecret,
         endpointUrl: jiraUrl,
       });
       const me = await proxyFetch("jira", "myself");
       await saveConnection("jira", {
-        email: identity,
-        apiToken: secret,
+        email: cleanIdentity,
+        apiToken: cleanSecret,
         endpointUrl: jiraUrl,
         // Jira Server's /myself returns `name` (the login id) + may not
         // expose `emailAddress` depending on user-privacy settings.
         // Cloud reliably has `emailAddress`. Fall through gracefully.
-        username: me.name || me.emailAddress || identity,
+        username: me.name || me.emailAddress || cleanIdentity,
         displayName: me.displayName,
       });
-      toast.success(`Connected to Jira as ${me.displayName || identity}`);
+      toast.success(
+        `Connected to Jira as ${me.displayName || cleanIdentity}`,
+      );
     } catch (err) {
       disconnectProvider("jira");
       toast.error(err.message);
@@ -267,7 +278,13 @@ export function JenkinsTokenForm() {
 
   async function handleSubmit(e) {
     e.preventDefault();
-    if (!url || !username || !apiToken) {
+    // Trim all three — copy-paste artifacts of any field break the
+    // upstream Basic-auth header. We don't want a stray newline to
+    // surface as "fetch failed" with no diagnostic.
+    const cleanUrl = url.trim().replace(/\/$/, "");
+    const cleanUsername = username.trim();
+    const cleanApiToken = apiToken.trim();
+    if (!cleanUrl || !cleanUsername || !cleanApiToken) {
       return toast.error("URL, username, and API token are all required.");
     }
     setLoading(true);
@@ -276,21 +293,21 @@ export function JenkinsTokenForm() {
       // reuse the same field for any "second auth identity" — see
       // Jira). The proxy reads it as the Basic-auth username.
       await saveConnection("jenkins", {
-        email: username,
-        apiToken,
-        endpointUrl: url.replace(/\/$/, ""),
+        email: cleanUsername,
+        apiToken: cleanApiToken,
+        endpointUrl: cleanUrl,
       });
       // /api/json on the Jenkins root returns instance metadata
       // when auth is valid (no specific job needed).
       const root = await proxyFetch("jenkins", "api/json");
       await saveConnection("jenkins", {
-        email: username,
-        apiToken,
-        endpointUrl: url.replace(/\/$/, ""),
-        username,
-        displayName: root?.nodeDescription || username,
+        email: cleanUsername,
+        apiToken: cleanApiToken,
+        endpointUrl: cleanUrl,
+        username: cleanUsername,
+        displayName: root?.nodeDescription || cleanUsername,
       });
-      toast.success(`Connected to Jenkins as ${username}`);
+      toast.success(`Connected to Jenkins as ${cleanUsername}`);
     } catch (err) {
       disconnectProvider("jenkins");
       toast.error(err.message);


### PR DESCRIPTION
## Context

User reported GitLab \"Save & verify\" failing with:

\`\`\`
{ \"error\": { \"code\": \"integration_unreachable\",
              \"message\": \"Network error reaching gitlab: fetch failed\" }}
\`\`\`

Bare \`fetch\` from inside the same container with the same token returned 200. So not network, not DNS, not TLS, not the token value. The difference: the proxy loads the token through encrypt → Mongo → decrypt → \`Authorization: Bearer <token>\` header. Whitespace artifacts from paste (trailing newline / space, very common with password managers + the GitLab \"Copy token\" button) survive the round-trip and make undici reject the header as **Invalid header value** — surfacing as the useless generic \"fetch failed\".

## Three fixes, one PR

### 1. Frontend forms trim credentials
\`apps/web/src/features/settings/token-forms.jsx\` — \`GitLabTokenForm\`, \`JiraTokenForm\`, \`JenkinsTokenForm\` now \`.trim()\` token / username / URL before sending. User's typical entry point.

### 2. Backend schema normalises
\`apps/api/src/modules/integrations/controller.ts\` — \`tokenString\` runs \`.transform(s => s.trim())\` before the min-length check. Defence in depth for any caller (CLI tools, future admin endpoints).

### 3. Proxy surfaces err.cause
\`apps/api/src/modules/integrations/proxy.ts\` — the upstream-fetch catch block extracts \`err.cause\` (where undici puts the real reason) and includes it in both the response envelope AND the integration's \`lastError\` field. Future incidents read like:

\`\`\`
\"Network error reaching gitlab: fetch failed (Invalid header value)\"
\`\`\`

…instead of the silent black hole. Also adds a structured \`logger.warn\` with \`{err, providerId, targetUrl}\` so ops have the full record in the API logs.

## Why three at once

They're the same diagnostic loop. Trim alone fixes today's incident. err.cause alone fixes diagnostic latency. Together they give us \"this never happens, AND if it ever does we know within one error message instead of an hour of \`docker exec node -e ...\`.\"

## Test plan

- [ ] Connect GitLab with a token that has trailing whitespace (\` glpat-xyz \n\`). Saves cleanly, verify call returns 200.
- [ ] Connect Jira (both engagement modes) — trims username + password / email + token.
- [ ] Connect Jenkins — trims URL + username + apiToken.
- [ ] Force a real \"fetch failed\" (e.g. add a fake host like \`https://nonexistent.example/api/v4\` in endpointUrl). The error message now includes the cause (\`ENOTFOUND\`, \`UND_ERR_CONNECT_TIMEOUT\`, etc.).
- [ ] Both apps typecheck clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)