### PR TITLE
fix(companion): surface tunnel-spawn errors + cloudflared logs

### DIFF
--- a/apps/desktop/src/main/docker.ts
+++ b/apps/desktop/src/main/docker.ts
@@ -93,7 +93,12 @@ function run(args: string[]): Promise<RunResult> {
   });
 }
 
-function pushLog(line: string): void {
+// Exported so tunnel-spawn (and any future sibling subprocess module)
+// can pipe its own output into the same shared log buffer the renderer
+// reads via the `backend:logs` IPC. Centralising the buffer keeps the
+// Logs panel showing the complete picture: docker output + cloudflared
+// output + any other companion subprocess.
+export function pushLog(line: string): void {
   // Keep the most-recent LOG_TAIL_MAX lines in memory so the UI's
   // "tail logs" panel can show context after the fact, without the
   // app holding onto unbounded buffers.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -290,7 +290,14 @@ ipcMain.handle("tunnel:spawn-state", async () => {
 
 // ─── companion pairing IPC ───────────────────────────────────────────
 ipcMain.handle("companion:status", async () => {
-  return { ...pair.status(), tunnel: tunnel.getState() };
+  // Include tunnel-spawn state so the renderer can surface spawn-side
+  // errors (ENOENT on cloudflared, bad CF edge, etc.) instead of just
+  // showing "Tunnel: off" with no clue why.
+  return {
+    ...pair.status(),
+    tunnel: tunnel.getState(),
+    spawn: tunnelSpawn.getState(),
+  };
 });
 
 ipcMain.handle("companion:pair", async () => {

--- a/apps/desktop/src/main/tunnel-spawn.ts
+++ b/apps/desktop/src/main/tunnel-spawn.ts
@@ -39,6 +39,7 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
+import { pushLog } from "./docker.js";
 
 const RESTART_BASE_MS = 2_000;
 const RESTART_MAX_MS = 60_000;
@@ -228,16 +229,29 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
       reject(new Error(msg));
     }, HOSTNAME_WAIT_MS);
 
+    pushLog(`[tunnel-spawn] starting: cloudflared tunnel --url http://localhost:${port}`);
+
     try {
       child = spawn(
         "cloudflared",
         ["tunnel", "--no-autoupdate", "--url", `http://localhost:${port}`],
-        { shell: false, windowsHide: true },
+        {
+          // shell:true on Windows so cmd.exe resolves cloudflared's
+          // location via PATHEXT — Electron's main process PATH can
+          // drift from the user's interactive shell PATH (especially
+          // when cloudflared was installed via winget after Electron
+          // launched), and shell:false won't find a bare `cloudflared`
+          // without explicit `.exe`. shell:true is safe here because
+          // none of our args contain spaces or shell meta-characters.
+          shell: process.platform === "win32",
+          windowsHide: true,
+        },
       );
     } catch (err) {
       clearTimeout(waitTimer);
       resolved = true;
       const msg = err instanceof Error ? err.message : String(err);
+      pushLog(`[tunnel-spawn] spawn threw: ${msg}`);
       setState({ status: "crashed", lastError: msg });
       reject(new Error(msg));
       return;
@@ -268,17 +282,24 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
       }
     };
 
+    // Pipe EVERY line from cloudflared into the shared log buffer so
+    // the renderer's Logs panel can show what's happening. Previously
+    // these lines were swallowed by the closure handler and the user
+    // had no way to see why spawn failed.
+    //
     // cloudflared writes the banner to STDERR (zerolog default). We
     // listen on both streams defensively in case a future version
     // changes that.
-    child.stderr?.on("data", (chunk) => {
+    const consume = (stream: "out" | "err") => (chunk: Buffer) => {
       const text = chunk.toString();
-      for (const line of text.split(/\r?\n/)) handleLine(line);
-    });
-    child.stdout?.on("data", (chunk) => {
-      const text = chunk.toString();
-      for (const line of text.split(/\r?\n/)) handleLine(line);
-    });
+      for (const line of text.split(/\r?\n/)) {
+        if (!line) continue;
+        pushLog(`[cloudflared${stream === "err" ? "/err" : ""}] ${line}`);
+        handleLine(line);
+      }
+    };
+    child.stderr?.on("data", consume("err"));
+    child.stdout?.on("data", consume("out"));
 
     child.on("error", (err) => {
       clearTimeout(waitTimer);
@@ -288,6 +309,7 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
       const msg = isMissing
         ? "cloudflared not found on PATH. Install via: winget install --id Cloudflare.cloudflared (Windows), brew install cloudflared (macOS)."
         : err.message;
+      pushLog(`[tunnel-spawn] child error: ${msg}`);
       setState({ status: "crashed", lastError: msg });
       if (!resolved) {
         resolved = true;
@@ -298,6 +320,9 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
     child.on("close", (code) => {
       const wasRunning = state.status === "running";
       child = null;
+      pushLog(
+        `[tunnel-spawn] cloudflared exited (code=${code}, wasRunning=${wasRunning}, hostnameSeen=${hostnameSeen})`,
+      );
       if (stopping) {
         setState({ status: "stopped", hostname: null });
         return;
@@ -309,13 +334,15 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
           RESTART_BASE_MS * 2 ** state.restarts,
           RESTART_MAX_MS,
         );
+        const msg = `cloudflared exited with code ${code} — restarting in ${
+          delay / 1000
+        }s (attempt ${state.restarts + 1}/${MAX_RESTARTS})…`;
+        pushLog(`[tunnel-spawn] ${msg}`);
         setState({
           status: "crashed",
           hostname: null,
           restarts: state.restarts + 1,
-          lastError: `cloudflared exited with code ${code} — restarting in ${
-            delay / 1000
-          }s (attempt ${state.restarts + 1}/${MAX_RESTARTS})…`,
+          lastError: msg,
         });
         restartTimer = setTimeout(() => {
           restartTimer = null;
@@ -324,12 +351,14 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
           });
         }, delay);
       } else {
+        const msg = wasRunning
+          ? `cloudflared restart budget exhausted (${MAX_RESTARTS} attempts). Stop + start backend to retry.`
+          : `cloudflared exited with code ${code} before allocating a hostname.`;
+        pushLog(`[tunnel-spawn] ${msg}`);
         setState({
           status: "crashed",
           hostname: null,
-          lastError: wasRunning
-            ? `cloudflared restart budget exhausted (${MAX_RESTARTS} attempts). Stop + start backend to retry.`
-            : `cloudflared exited with code ${code} before allocating a hostname.`,
+          lastError: msg,
         });
       }
     });

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -94,6 +94,13 @@ type CompanionWindow = Window & {
           lastSeenAt: string | null;
           lastError: string | null;
         };
+        spawn: {
+          status: "idle" | "starting" | "running" | "crashed" | "stopped";
+          hostname: string | null;
+          port: number | null;
+          restarts: number;
+          lastError: string | null;
+        };
       }>;
       start: () => Promise<{
         ok: boolean;
@@ -521,14 +528,29 @@ export function App() {
           />
           <Stat
             label="Tunnel"
+            value={tunnelStatusValue(pairState)}
+            tone={tunnelStatusTone(pairState)}
+          />
+          <Stat
+            label="Cloudflared"
             value={
-              pairState?.tunnel.active
-                ? `live · ${pairState.tunnel.hostname || ""}`
-                : pairState?.tunnel.hostname
-                ? "registered (stopped)"
-                : "off"
+              pairState?.spawn
+                ? `${pairState.spawn.status}${
+                    pairState.spawn.restarts > 0
+                      ? ` · restarts: ${pairState.spawn.restarts}`
+                      : ""
+                  }`
+                : "—"
             }
-            tone={pairState?.tunnel.active ? "good" : "muted"}
+            tone={
+              pairState?.spawn?.status === "running"
+                ? "good"
+                : pairState?.spawn?.status === "starting"
+                ? "muted"
+                : pairState?.spawn?.status === "crashed"
+                ? "bad"
+                : "muted"
+            }
           />
           <Stat
             label="Last seen"
@@ -540,6 +562,11 @@ export function App() {
             tone="muted"
           />
         </div>
+        {pairState?.spawn?.lastError && (
+          <p style={{ ...S.helpInline, color: "var(--bad)" }}>
+            cloudflared: {pairState.spawn.lastError}
+          </p>
+        )}
         {pairState?.tunnel.lastError && (
           <p style={S.helpInline}>{pairState.tunnel.lastError}</p>
         )}
@@ -698,6 +725,41 @@ export function App() {
 }
 
 /* ─────────────────── primitives ─────────────────── */
+
+/**
+ * Disambiguate the tunnel display across three independent states:
+ *   - spawn is running but register is mid-handshake (was misleadingly
+ *     "live · " with empty hostname pre-fix)
+ *   - register is live with a confirmed hostname
+ *   - register has gone offline / stopped
+ * Reads from spawn AND register because the renderer can only safely
+ * say "live · hostname" when the register has actually confirmed a
+ * working probe + POST.
+ */
+function tunnelStatusValue(s: PairStatus | null): string {
+  if (!s) return "off";
+  if (s.tunnel.active && s.tunnel.hostname) {
+    return `live · ${s.tunnel.hostname}`;
+  }
+  if (s.tunnel.active) {
+    return "registering…";
+  }
+  if (s.spawn?.status === "running" && s.spawn.hostname) {
+    return `spawn up · awaiting probe`;
+  }
+  if (s.tunnel.hostname) return "registered (stopped)";
+  return "off";
+}
+
+function tunnelStatusTone(
+  s: PairStatus | null,
+): "good" | "bad" | "muted" | "warn" {
+  if (!s) return "muted";
+  if (s.tunnel.active && s.tunnel.hostname) return "good";
+  if (s.spawn?.status === "crashed") return "bad";
+  if (s.tunnel.active || s.spawn?.status === "running") return "warn";
+  return "muted";
+}
 
 function Badge({
   ping,


### PR DESCRIPTION
## Symptom

User confirmed: cloudflared runs fine from cmd.exe (gets a quick-tunnel URL, connects to CF edge, no errors), but the companion's auto-spawn produces no cloudflared.exe in Task Manager. Companion UI just shows \"Tunnel: off\" with no clue why. Spawn errors were going to Electron's main-process console (invisible) and the Logs panel only showed Docker output.

## Fix — four parts

### 1. Pipe cloudflared output into the visible Logs panel
\`pushLog\` exported from \`docker.ts\`. \`tunnel-spawn.ts\` now pipes every stdout/stderr line through it, prefixed \`[cloudflared/err]\` or \`[cloudflared]\`. Lifecycle events (start, child error, close, restart, budget exhaustion) also go through pushLog. Next failure: the user sees what cloudflared is actually saying.

### 2. \`shell: true\` on Windows for spawn
Electron's main-process PATH can drift from the user's interactive shell PATH (especially when cloudflared was installed via winget AFTER Electron launched). \`shell: false\` with a bare binary name can fail PATHEXT lookup in some Node versions. Switch to \`shell: true\` on Windows so cmd.exe does the resolution — safe because none of our args contain shell meta-characters.

### 3. Spawn state in \`companion:status\` IPC
Renderer can now read \`tunnelSpawn.getState()\` alongside the existing register state. Surfaces:
- \`status\`: idle / starting / running / crashed / stopped
- \`restarts\`: how many auto-restart attempts have fired
- \`lastError\`: the actual reason for the most recent failure
- \`hostname\`: the spawn's view (vs register's view)

### 4. Renderer shows the spawn state honestly
- New \"Cloudflared\" stat alongside \"Tunnel\"
- Spawn lastError surfaced in red below the stats row
- Tunnel display gains intermediate states:
  - \"registering…\" — spawn up, register handshake mid-flight
  - \"spawn up · awaiting probe\" — cloudflared has a hostname, register hasn't kicked yet
  - The misleading \"live · \" (empty hostname) display is gone

## Net effect

Next time the spawn silently fails, the user sees the cause **in the UI** without us asking for Task Manager forensics. Same pattern we used in #122 for the proxy errors — make the diagnostic loop short.

## Test plan

- [ ] Start backend with cloudflared on PATH → \"Cloudflared: running\", then \"Tunnel: live · <host>\".
- [ ] Start backend with cloudflared NOT on PATH (rename the .exe temporarily) → \"Cloudflared: crashed\", lastError shows \"cloudflared not found on PATH. Install via: winget install...\"
- [ ] Stop backend mid-run → \"Cloudflared: stopped\".
- [ ] Logs panel shows \`[cloudflared] INF Your quick Tunnel has been created...\` etc. during a healthy session.
- [ ] Logs panel shows \`[tunnel-spawn] child error: ...\` on a failed spawn.
- [ ] Desktop typecheck + build clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)