### PR TITLE
fix(companion): force cloudflared --protocol http2 (VPN blocks QUIC)

### DIFF
--- a/apps/desktop/src/main/tunnel-spawn.ts
+++ b/apps/desktop/src/main/tunnel-spawn.ts
@@ -229,12 +229,35 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
       reject(new Error(msg));
     }, HOSTNAME_WAIT_MS);
 
-    pushLog(`[tunnel-spawn] starting: cloudflared tunnel --url http://localhost:${port}`);
+    pushLog(
+      `[tunnel-spawn] starting: cloudflared tunnel --protocol http2 --url http://localhost:${port}`,
+    );
 
     try {
       child = spawn(
         "cloudflared",
-        ["tunnel", "--no-autoupdate", "--url", `http://localhost:${port}`],
+        [
+          "tunnel",
+          "--no-autoupdate",
+          // Force HTTP/2 instead of cloudflared's default QUIC. QUIC
+          // (UDP-based) is routinely blocked by corporate VPNs —
+          // FortiClient in particular drops the handshake, resulting
+          // in `Failed to dial a quic connection error="failed to
+          // dial to edge with quic: timeout: handshake did not
+          // complete in time"` and indefinite retries that never
+          // fall back. HTTP/2 (TCP/443) goes through the same TLS
+          // pipes regular HTTPS uses, which corporate networks
+          // basically always allow.
+          //
+          // The trade-off: HTTP/2 is fractionally slower than QUIC
+          // for our use case (no 0-RTT, no multipath). Negligible
+          // for a low-volume management API; well worth the
+          // reliability gain.
+          "--protocol",
+          "http2",
+          "--url",
+          `http://localhost:${port}`,
+        ],
         {
           // shell:true on Windows so cmd.exe resolves cloudflared's
           // location via PATHEXT — Electron's main process PATH can


### PR DESCRIPTION
## Confirmed root cause

Per user logs from #123: cloudflared spawned, got a hostname, then **infinitely retried QUIC handshakes**:

\`\`\`
ERR Failed to dial a quic connection error=\"failed to dial to edge with quic: timeout: handshake did not complete in time\"
INF Retrying connection in up to 32s ...
\`\`\`

Verified manually: \`cloudflared tunnel --protocol http2 --url http://localhost:4000\` connects immediately:

\`\`\`
INF Initial protocol http2
INF Registered tunnel connection ... protocol=http2
\`\`\`

## Why this happens

Corporate VPNs — FortiClient in particular — routinely drop UDP or interfere with QUIC's handshake. cloudflared's default \`--protocol auto\` prefers QUIC (UDP-based, faster) and only falls back to HTTP/2 after many retries with exponential backoff. By the time fallback would have fired, our spawn module has long given up.

## Fix

One line in the spawn args: \`--protocol http2\`. HTTP/2 uses TCP/443 — same pipes as regular HTTPS, basically always allowed.

Trade-off: HTTP/2 is fractionally slower than QUIC (no 0-RTT, no multipath). For a low-volume management API this is irrelevant; the reliability win is overwhelming.

## Test plan

- [ ] On a network that was failing with QUIC: companion Stop → Start backend → Cloudflared status goes \"running\", Tunnel goes \"live · <host>\" within ~10s. (Most users.)
- [ ] On a network without VPN restrictions: same outcome, no perf regression observable.
- [ ] Logs panel shows \`[cloudflared] INF Initial protocol http2\` followed by \`Registered tunnel connection ... protocol=http2\`.

Desktop typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)