### PR TITLE
fix(companion): probe cloudflared local /ready (VPN-friendly)

### DIFF
--- a/apps/desktop/src/main/tunnel-register.ts
+++ b/apps/desktop/src/main/tunnel-register.ts
@@ -344,24 +344,40 @@ async function heartbeat(): Promise<void> {
 }
 
 /**
- * HEAD https://<hostname>/healthz with a hard timeout. Verifies the
- * entire request path (DNS → CF edge → tunnel → local Express)
- * actually works — cheaper + more honest than re-POSTing blindly.
+ * Probe cloudflared's LOCAL readiness endpoint instead of the public
+ * `https://<host>/healthz`. The earlier public-URL probe broke on
+ * laptops whose VPN-forced DNS couldn't resolve `*.trycloudflare.com`
+ * — even though the tunnel itself was working fine from Vercel's
+ * perspective. cloudflared exposes `/ready` on its metrics server
+ * (we pin the port via `--metrics 127.0.0.1:<port>` in tunnel-spawn);
+ * the response is 200 when the tunnel has an active edge connection
+ * and 5xx when it's disconnected.
  *
- * Treats any non-2xx as a failure, including the 502 / 530 envelope
- * CF returns when its edge can't reach the tunnel.
+ * Trade-off: this no longer verifies the FULL data path (DNS → CF
+ * edge → tunnel → local Express). It verifies "cloudflared has an
+ * active connection to CF edge," which is the part that can
+ * legitimately fail in steady state. Local backend liveness is
+ * already covered by the api-ping IPC; DNS-from-Vercel is verified
+ * by every actual user request through the catch-all. This is the
+ * narrowest honest check we can do without piggybacking on the
+ * laptop's broken DNS.
+ *
+ * `_hostname` is kept in the signature for back-compat with future
+ * callers that might want both probes; today's call site just passes
+ * spawn.hostname and we ignore it.
  */
-async function probeHostname(hostname: string): Promise<boolean> {
+async function probeHostname(_hostname: string): Promise<boolean> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
   try {
-    const res = await fetch(`https://${hostname}/healthz`, {
-      method: "HEAD",
-      signal: ctrl.signal,
-      // Avoid sending random cookies / referrers from the Electron
-      // main process. This call is purely a liveness probe.
-      headers: { "user-agent": "espace-devhub-companion/probe" },
-    });
+    const res = await fetch(
+      `http://127.0.0.1:${tunnelSpawn.METRICS_PORT}/ready`,
+      {
+        method: "GET",
+        signal: ctrl.signal,
+        headers: { "user-agent": "espace-devhub-companion/probe" },
+      },
+    );
     return res.ok;
   } catch {
     return false;

--- a/apps/desktop/src/main/tunnel-spawn.ts
+++ b/apps/desktop/src/main/tunnel-spawn.ts
@@ -48,6 +48,14 @@ const HOSTNAME_WAIT_MS = 30_000;
 
 const TRYCLOUDFLARE_RE = /https?:\/\/([a-z0-9-]+\.trycloudflare\.com)/i;
 
+/**
+ * Pinned port for cloudflared's metrics + readiness endpoint. Default
+ * cloudflared picks a free port; we pin so tunnel-register can probe
+ * `http://127.0.0.1:<port>/ready` deterministically. Exported so the
+ * register module can reach the same URL.
+ */
+export const METRICS_PORT = 20241;
+
 export interface TunnelSpawnState {
   /** Roughly tracks the lifecycle. */
   status: "idle" | "starting" | "running" | "crashed" | "stopped";
@@ -230,7 +238,7 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
     }, HOSTNAME_WAIT_MS);
 
     pushLog(
-      `[tunnel-spawn] starting: cloudflared tunnel --protocol http2 --url http://localhost:${port}`,
+      `[tunnel-spawn] starting: cloudflared tunnel --protocol http2 --metrics 127.0.0.1:${METRICS_PORT} --url http://localhost:${port}`,
     );
 
     try {
@@ -255,6 +263,14 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
           // reliability gain.
           "--protocol",
           "http2",
+          // Pin the metrics endpoint to a known port. By default
+          // cloudflared picks a free port and prints it; we'd have
+          // to parse stdout to find it. Pinning lets the heartbeat's
+          // probe target a deterministic `http://127.0.0.1:<port>/ready`
+          // URL. Picked 20241 because that's what cloudflared used
+          // for both observed sessions in testing.
+          "--metrics",
+          `127.0.0.1:${METRICS_PORT}`,
           "--url",
           `http://localhost:${port}`,
         ],


### PR DESCRIPTION
## Confirmed cause

User on Crealogix VPN. cloudflared connected fine (\`Registered tunnel connection ... protocol=http2\` — visible in logs). But probe failed because:

\`\`\`
C:\> curl -v https://population-albums-design-shoes.trycloudflare.com/healthz
* Could not resolve host: population-albums-design-shoes.trycloudflare.com
\`\`\`

VPN-forced DNS at \`10.2.40.132\` (Crealogix internal) can't resolve \`*.trycloudflare.com\`. The tunnel was working from **Vercel's** edge perspective — only the laptop's own DNS couldn't see the public hostname.

Our probe was answering the wrong question:
- **Wrong**: Can the laptop reach its own public hostname?
- **Right**: Is cloudflared connected to CF edge?

## Fix

Pin cloudflared's metrics server to \`127.0.0.1:20241\` and probe \`/ready\` locally.

| Aspect | Before | After |
|---|---|---|
| Probe target | \`https://<host>/healthz\` (round-trips through public DNS + CF edge) | \`http://127.0.0.1:20241/ready\` (loopback) |
| DNS required | Yes (laptop must resolve trycloudflare.com) | No |
| Signal | Full data path | cloudflared edge connection state |
| VPN-safe | No | Yes |

cloudflared's \`/ready\` returns 200 when connected, 5xx when disconnected — exactly the signal we need.

## What this changes architecturally

Probe was testing FULL request path; now it tests ONLY \"cloudflared has edge connection.\" The other parts of the path are covered:
- Local backend liveness — already covered by \`companion.api.ping()\`
- DNS-from-Vercel + Vercel→CF routing — implicitly verified by every actual user request

This is the narrowest honest check we can do without depending on the laptop's possibly-broken outbound DNS.

## Test plan

- [ ] Start backend on a VPN-restricted laptop → companion's Tunnel stat flips to \`live · <host>\` within ~60s (was failing indefinitely before).
- [ ] Kill cloudflared via Task Manager → next heartbeat sees /ready fail → after 3 fails clears registration → catch-all falls back to bundled.
- [ ] Restart cloudflared → next heartbeat re-probes /ready → success → re-registers.
- [ ] On a laptop without DNS restrictions: same outcome, same UX, no regression.

Desktop typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)