### PR TITLE
fix(companion): allocate cloudflared --metrics port dynamically

### DIFF
--- a/apps/desktop/src/main/tunnel-register.ts
+++ b/apps/desktop/src/main/tunnel-register.ts
@@ -367,17 +367,20 @@ async function heartbeat(): Promise<void> {
  * spawn.hostname and we ignore it.
  */
 async function probeHostname(_hostname: string): Promise<boolean> {
+  const port = tunnelSpawn.getMetricsPort();
+  if (!port) {
+    // Spawn hasn't allocated a port yet — treat as not-ready, the
+    // next tick will retry once spawn has populated it.
+    return false;
+  }
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
   try {
-    const res = await fetch(
-      `http://127.0.0.1:${tunnelSpawn.METRICS_PORT}/ready`,
-      {
-        method: "GET",
-        signal: ctrl.signal,
-        headers: { "user-agent": "espace-devhub-companion/probe" },
-      },
-    );
+    const res = await fetch(`http://127.0.0.1:${port}/ready`, {
+      method: "GET",
+      signal: ctrl.signal,
+      headers: { "user-agent": "espace-devhub-companion/probe" },
+    });
     return res.ok;
   } catch {
     return false;

--- a/apps/desktop/src/main/tunnel-spawn.ts
+++ b/apps/desktop/src/main/tunnel-spawn.ts
@@ -39,6 +39,7 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
+import net from "node:net";
 import { pushLog } from "./docker.js";
 
 const RESTART_BASE_MS = 2_000;
@@ -49,12 +50,43 @@ const HOSTNAME_WAIT_MS = 30_000;
 const TRYCLOUDFLARE_RE = /https?:\/\/([a-z0-9-]+\.trycloudflare\.com)/i;
 
 /**
- * Pinned port for cloudflared's metrics + readiness endpoint. Default
- * cloudflared picks a free port; we pin so tunnel-register can probe
- * `http://127.0.0.1:<port>/ready` deterministically. Exported so the
- * register module can reach the same URL.
+ * Ephemeral port for cloudflared's metrics + readiness endpoint. We
+ * grab a free port from the OS at spawn time (rather than hardcoding)
+ * so a stray cloudflared from a prior session — or any other dev
+ * tool — doesn't collide on the same port. The probe in
+ * tunnel-register reads this via `getMetricsPort()`.
  */
-export const METRICS_PORT = 20241;
+let metricsPort: number | null = null;
+export function getMetricsPort(): number | null {
+  return metricsPort;
+}
+
+/**
+ * Ask the OS for a free TCP port bound to 127.0.0.1. Returns the
+ * port number; the server is closed before resolving so cloudflared
+ * can bind to it.
+ *
+ * Tiny race window between us closing + cloudflared binding — if
+ * another process steals the port in that window, cloudflared will
+ * crash on EADDRINUSE and our auto-restart logic re-attempts with a
+ * fresh port. Acceptable.
+ */
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") {
+        const port = addr.port;
+        server.close(() => resolve(port));
+      } else {
+        reject(new Error("net.createServer().address() returned unexpected shape"));
+      }
+    });
+  });
+}
 
 export interface TunnelSpawnState {
   /** Roughly tracks the lifecycle. */
@@ -220,6 +252,25 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
     // successful "running" transition below.
   });
 
+  // Grab a free port for cloudflared's metrics/readiness endpoint
+  // BEFORE entering the Promise executor (which can't be async).
+  // Hardcoding (we tried 20241) collides with prior cloudflared
+  // sessions still holding the port + with any other dev tool that
+  // grabbed it. Pre-allocating via the OS is race-free except for a
+  // microscopic window before cloudflared binds — caught by our
+  // auto-restart loop if it ever matters.
+  try {
+    metricsPort = await findFreePort();
+  } catch (err) {
+    const msg =
+      err instanceof Error
+        ? `couldn't find a free metrics port: ${err.message}`
+        : "couldn't find a free metrics port";
+    pushLog(`[tunnel-spawn] ${msg}`);
+    setState({ status: "crashed", lastError: msg });
+    throw new Error(msg);
+  }
+
   return new Promise<TunnelSpawnState>((resolve, reject) => {
     let resolved = false;
     let hostnameSeen = false;
@@ -238,7 +289,7 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
     }, HOSTNAME_WAIT_MS);
 
     pushLog(
-      `[tunnel-spawn] starting: cloudflared tunnel --protocol http2 --metrics 127.0.0.1:${METRICS_PORT} --url http://localhost:${port}`,
+      `[tunnel-spawn] starting: cloudflared tunnel --protocol http2 --metrics 127.0.0.1:${metricsPort} --url http://localhost:${port}`,
     );
 
     try {
@@ -263,14 +314,11 @@ export async function start({ port }: StartOptions): Promise<TunnelSpawnState> {
           // reliability gain.
           "--protocol",
           "http2",
-          // Pin the metrics endpoint to a known port. By default
-          // cloudflared picks a free port and prints it; we'd have
-          // to parse stdout to find it. Pinning lets the heartbeat's
-          // probe target a deterministic `http://127.0.0.1:<port>/ready`
-          // URL. Picked 20241 because that's what cloudflared used
-          // for both observed sessions in testing.
+          // Bind cloudflared's metrics + readiness endpoint to the
+          // free port we just claimed. tunnel-register reads the same
+          // value via getMetricsPort() to know where to probe.
           "--metrics",
-          `127.0.0.1:${METRICS_PORT}`,
+          `127.0.0.1:${metricsPort}`,
           "--url",
           `http://localhost:${port}`,
         ],


### PR DESCRIPTION
## Bug

After #125 landed, cloudflared crashed on every spawn:

\`\`\`
ERR Error opening metrics server listener
    error=\"failed to bind to address (127.0.0.1:20241): bind: Only one
    usage of each socket address (protocol/network address/port) is
    normally permitted.\"
[tunnel-spawn] cloudflared exited with code 1 — restarting in 2s
\`\`\`

\`METRICS_PORT = 20241\` was a hardcoded constant from #125. Conflicts with:
- A stray cloudflared from a prior session still holding the port (user's exact case — they had one running in another terminal)
- Any other dev tool that grabbed 20241 first
- Windows TIME_WAIT lingering on the port after a previous spawn died

## Fix

Pre-allocate a free port via Node's \`net.createServer().listen(0, '127.0.0.1', ...)\` before spawning. Pass that port to cloudflared's \`--metrics\`. Export \`getMetricsPort()\` so tunnel-register's probe reads the same value.

Microscopic race window between closing our temp listener and cloudflared binding — another process could theoretically steal the port in that gap. The auto-restart loop catches it. In steady state there's no contention.

## Test plan

- [ ] Start backend with no other cloudflared running → cloudflared spawns successfully, picks a random high port, tunnel goes \`live\`.
- [ ] Start backend WHILE having a manual \`cloudflared tunnel --url ...\` open in another terminal → companion's cloudflared gets a different port, both succeed independently.
- [ ] Stop+Start the backend repeatedly → each session picks a fresh port, no TIME_WAIT collisions.
- [ ] Probe still works — tunnel-register's heartbeat hits the right port via getMetricsPort().

Desktop typechecks + builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)