### PR TITLE
fix(incidents): mode-aware count vs duration tracking

### DIFF
--- a/apps/web/src/features/checkin/editors.jsx
+++ b/apps/web/src/features/checkin/editors.jsx
@@ -340,7 +340,7 @@ const SEVERITIES = [
   { id: "P4", label: "P4 · low" },
 ];
 
-export function IncidentLogEditor({ goal, weekStart, weekEnd, activeLabel }) {
+export function IncidentLogEditor({ goal, spec, weekStart, weekEnd, activeLabel }) {
   const { entries, append, remove } = useGoalInputs(goal?.id);
   const inWindow = useMemo(
     () =>
@@ -359,22 +359,37 @@ export function IncidentLogEditor({ goal, weekStart, weekEnd, activeLabel }) {
     0,
   );
 
+  // Mode mirrors the dashboard widget: time-words → duration (minutes
+  // required), anything else → count (each Log = +1 event, minutes
+  // optional). Keeps the check-in UX honest with how the goal-spec
+  // wants the budget to be measured.
+  const unit = spec?.manual?.unit || "minutes";
+  const isCountMode = inferIncidentEditorMode(unit) === "count";
+  const noun = isCountMode ? singularUnit(unit) : "incident";
+
   const [severity, setSeverity] = useState("P2");
   const [downtime, setDowntime] = useState("");
   const [link, setLink] = useState("");
 
-  const canLog = downtime !== "" && Number.isFinite(Number(downtime));
+  const trimmedDowntime = downtime.trim();
+  const minutesValue =
+    trimmedDowntime === "" ? null : Number(trimmedDowntime);
+  // Count mode: blank duration is fine. Duration mode: blank is invalid.
+  const canLog =
+    trimmedDowntime === ""
+      ? isCountMode
+      : Number.isFinite(minutesValue) && minutesValue >= 0;
 
   const log = () => {
     if (!canLog) return;
     const ts = midWeekTs(activeLabel);
     if (ts == null) return;
-    const minutes = Number(downtime);
-    if (!Number.isFinite(minutes) || minutes < 0) return;
     append(
       {
         severity,
-        downtime: minutes,
+        ...(Number.isFinite(minutesValue) && minutesValue >= 0
+          ? { downtime: minutesValue }
+          : {}),
         ...(link.trim() ? { link: link.trim() } : {}),
       },
       undefined,
@@ -391,9 +406,10 @@ export function IncidentLogEditor({ goal, weekStart, weekEnd, activeLabel }) {
         style={{ fontFamily: "var(--font-mono)" }}
       >
         <span>
-          {inWindow.length} incident{inWindow.length === 1 ? "" : "s"} this week
+          {inWindow.length} {noun}
+          {inWindow.length === 1 ? "" : "s"} this week
         </span>
-        {inWindow.length > 0 && (
+        {totalDowntime > 0 && (
           <span>Σ {totalDowntime} min downtime</span>
         )}
       </div>
@@ -455,7 +471,12 @@ export function IncidentLogEditor({ goal, weekStart, weekEnd, activeLabel }) {
           min={0}
           value={downtime}
           onChange={(ev) => setDowntime(ev.target.value)}
-          placeholder="min"
+          placeholder={isCountMode ? "min (opt)" : "min"}
+          aria-label={
+            isCountMode
+              ? "Duration (optional, minutes)"
+              : "Downtime (minutes)"
+          }
           className="h-7 w-16 rounded-md border border-border bg-bg px-1.5 text-[11px]"
         />
         <input
@@ -772,4 +793,42 @@ function cadenceWord(cadence) {
     case "yearly":    return "year";
     default:          return "period";
   }
+}
+
+/**
+ * Mode inference for the IncidentLogEditor — mirrors `inferMode` in
+ * the dashboard widget. If you grow either set, sync both files (and
+ * the evidence resolver in features/evidence/goal-readings.js).
+ */
+const INCIDENT_EDITOR_DURATION_UNITS = new Set([
+  "minute",
+  "minutes",
+  "min",
+  "mins",
+  "m",
+  "hour",
+  "hours",
+  "hr",
+  "hrs",
+  "h",
+  "second",
+  "seconds",
+  "sec",
+  "secs",
+  "s",
+]);
+
+function inferIncidentEditorMode(unit) {
+  if (typeof unit !== "string") return "duration";
+  const u = unit.toLowerCase().trim();
+  if (INCIDENT_EDITOR_DURATION_UNITS.has(u)) return "duration";
+  return "count";
+}
+
+function singularUnit(unit) {
+  if (typeof unit !== "string" || !unit.trim()) return "incident";
+  const u = unit.trim();
+  if (/ies$/i.test(u)) return `${u.slice(0, -3)}y`;
+  if (/s$/i.test(u)) return u.slice(0, -1);
+  return u;
 }

--- a/apps/web/src/features/checkin/goal-row.jsx
+++ b/apps/web/src/features/checkin/goal-row.jsx
@@ -238,6 +238,7 @@ function EditorFor({
       return (
         <IncidentLogEditor
           goal={goal}
+          spec={spec}
           weekStart={weekStart}
           weekEnd={weekEnd}
           activeLabel={activeLabel}

--- a/apps/web/src/features/checkin/grid-cells.jsx
+++ b/apps/web/src/features/checkin/grid-cells.jsx
@@ -393,7 +393,7 @@ export function BeforeAfterCell({ goal, weekStart, weekEnd, weekLabel }) {
 
 /* ─────────────────────── Incident log (cell, popover) ─────────────────────── */
 
-export function IncidentLogCell({ goal, weekStart, weekEnd, weekLabel }) {
+export function IncidentLogCell({ goal, spec, weekStart, weekEnd, weekLabel }) {
   const { entries, append, remove } = useGoalInputs(goal?.id);
   const inWindow = useMemo(
     () =>
@@ -411,22 +411,34 @@ export function IncidentLogCell({ goal, weekStart, weekEnd, weekLabel }) {
     0,
   );
 
+  // Match the dashboard widget's mode inference so the grid cell shows
+  // "3" for a defect-count goal instead of "3 · 0m" (which reads as a
+  // downtime tally even when nothing was timed).
+  const unit = spec?.manual?.unit || "minutes";
+  const isCountMode = inferIncidentCellMode(unit) === "count";
+
   const [severity, setSeverity] = useState("P2");
   const [downtime, setDowntime] = useState("");
   const [link, setLink] = useState("");
 
-  const canLog = downtime !== "" && Number.isFinite(Number(downtime));
+  const trimmedDowntime = downtime.trim();
+  const minutesValue =
+    trimmedDowntime === "" ? null : Number(trimmedDowntime);
+  const canLog =
+    trimmedDowntime === ""
+      ? isCountMode
+      : Number.isFinite(minutesValue) && minutesValue >= 0;
 
   const log = () => {
     if (!canLog) return;
     const ts = midWeekTs(weekLabel);
     if (ts == null) return;
-    const minutes = Number(downtime);
-    if (!Number.isFinite(minutes) || minutes < 0) return;
     append(
       {
         severity,
-        downtime: minutes,
+        ...(Number.isFinite(minutesValue) && minutesValue >= 0
+          ? { downtime: minutesValue }
+          : {}),
         ...(link.trim() ? { link: link.trim() } : {}),
       },
       undefined,
@@ -436,10 +448,15 @@ export function IncidentLogCell({ goal, weekStart, weekEnd, weekLabel }) {
     setLink("");
   };
 
+  // Cell preview: count mode shows just the count (the budget is in
+  // events, so downtime is a side-detail); duration mode keeps the
+  // legacy "N · Tm" form because both numbers are meaningful.
   const preview =
     inWindow.length === 0
       ? "0"
-      : `${inWindow.length} · ${totalDowntime}m`;
+      : isCountMode
+        ? String(inWindow.length)
+        : `${inWindow.length} · ${totalDowntime}m`;
 
   return (
     <Popover.Root>
@@ -503,7 +520,12 @@ export function IncidentLogCell({ goal, weekStart, weekEnd, weekLabel }) {
               min={0}
               value={downtime}
               onChange={(ev) => setDowntime(ev.target.value)}
-              placeholder="min"
+              placeholder={isCountMode ? "min (opt)" : "min"}
+              aria-label={
+                isCountMode
+                  ? "Duration (optional, minutes)"
+                  : "Downtime (minutes)"
+              }
               className="h-7 w-14 rounded-md border border-border bg-bg px-1.5 text-[11px]"
             />
             <input
@@ -809,4 +831,34 @@ function sunWeekOf(d) {
     (d.getTime() - yearStart.getTime()) / (24 * 60 * 60 * 1000),
   );
   return Math.floor(daysSinceJan1 / 7) + 1;
+}
+
+/**
+ * Mode inference for the incident-log grid cell. Mirrors the helper
+ * in incident-log-widget.jsx and the check-in editor — keep the three
+ * DURATION_UNITS sets aligned.
+ */
+const INCIDENT_CELL_DURATION_UNITS = new Set([
+  "minute",
+  "minutes",
+  "min",
+  "mins",
+  "m",
+  "hour",
+  "hours",
+  "hr",
+  "hrs",
+  "h",
+  "second",
+  "seconds",
+  "sec",
+  "secs",
+  "s",
+]);
+
+function inferIncidentCellMode(unit) {
+  if (typeof unit !== "string") return "duration";
+  const u = unit.toLowerCase().trim();
+  if (INCIDENT_CELL_DURATION_UNITS.has(u)) return "duration";
+  return "count";
 }

--- a/apps/web/src/features/checkin/grid-row.jsx
+++ b/apps/web/src/features/checkin/grid-row.jsx
@@ -204,6 +204,7 @@ function CellFor({
       return (
         <IncidentLogCell
           goal={goal}
+          spec={spec}
           weekStart={weekStart}
           weekEnd={weekEnd}
           weekLabel={weekLabel}

--- a/apps/web/src/features/evidence/goal-readings.js
+++ b/apps/web/src/features/evidence/goal-readings.js
@@ -481,37 +481,82 @@ function readFirstPassRate(spec, ctx) {
 
 /**
  * INCIDENT_LOG — per-incident logger. Reads from goal-inputs entries
- * with `{ severity, downtime, link? }` shape. Headline = total
- * downtime + incident count, compared against the target's budget
- * value (e.g. ≤ 43 minutes / quarter).
+ * with `{ severity, downtime, link? }` shape.
+ *
+ * Two modes (matches the widget — `inferIncidentMode` mirrors the
+ * `inferMode` helper in incident-log-widget.jsx):
+ *   - **Duration** (unit = "minutes" / time-words): headline value is
+ *     Σ downtime, compared against `≤ N minutes / quarter` budgets.
+ *   - **Count** (unit = "defects" / "incidents" / …): headline value
+ *     is the entry count, compared against `≤ N defects / quarter`
+ *     budgets — the natural reading for defect-control goals.
  */
 function readIncidentLog(spec, goal, { allInputs }) {
   const entries = allInputs[goal.id] || [];
   if (entries.length === 0) return empty("No incidents logged");
-  let total = 0;
+  let totalDowntime = 0;
   for (const e of entries) {
     const d = Number(e?.value?.downtime);
-    if (Number.isFinite(d)) total += d;
+    if (Number.isFinite(d)) totalDowntime += d;
   }
   const target = spec.manual?.target;
   const unit = spec.manual?.unit || "minutes";
   const period = target?.period || spec.manual?.cadence;
   const periodSuffix = period ? ` / ${period}` : "";
+  const isCountMode = inferIncidentMode(unit) === "count";
+  // The headline value is what the target compares against. Count mode
+  // looks at entry count (so "Σ 10 defects · quarter" reads as
+  // "defects in window"); duration mode looks at downtime minutes.
+  const headlineValue = isCountMode ? entries.length : totalDowntime;
+  const summary = isCountMode
+    ? `${entries.length} ${unit}${
+        totalDowntime > 0 ? ` · Σ ${totalDowntime}m downtime` : ""
+      }`
+    : `${entries.length} incidents · Σ ${totalDowntime} ${unit}`;
   if (!target || target.value == null) {
     return {
-      value: `${entries.length} incidents · Σ ${total} ${unit}`,
+      value: summary,
       statusTone: TONES.ACCENT,
       statusLabel: "tracked",
     };
   }
-  // Target is "≤ N minutes per period" — under = good, over = warn.
-  // Use the same withTarget evaluator (lowerIsBetter for "<=").
+  // Target is "≤ N [units] per period" — under = good, over = warn.
   return withTarget(
-    total,
+    headlineValue,
     target,
-    `${entries.length} incidents · Σ ${total} ${unit}${periodSuffix}`,
+    `${summary}${periodSuffix}`,
     { lowerIsBetter: target.op === "<=" },
   );
+}
+
+/**
+ * Local copy of the widget's `inferMode` — kept here so the evidence
+ * resolver doesn't have to depend on the React widget bundle. If the
+ * DURATION_UNITS list ever grows, sync both files.
+ */
+const INCIDENT_DURATION_UNITS = new Set([
+  "minute",
+  "minutes",
+  "min",
+  "mins",
+  "m",
+  "hour",
+  "hours",
+  "hr",
+  "hrs",
+  "h",
+  "second",
+  "seconds",
+  "sec",
+  "secs",
+  "s",
+]);
+
+function inferIncidentMode(unit) {
+  if (typeof unit !== "string") return "duration";
+  const u = unit.toLowerCase().trim();
+  if (INCIDENT_DURATION_UNITS.has(u)) return "duration";
+  return "count";
 }
 
 /**

--- a/apps/web/src/features/goal-widgets/widgets/incident-log-widget.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/incident-log-widget.jsx
@@ -9,24 +9,34 @@ import { fullDate } from "@/lib/date";
  * Incident log — one entry per SLA-affecting event.
  *
  * Each entry stores `{ severity, downtime, link? }` as the input
- * `value`. The widget computes:
- *   - Total downtime over the goal's window (or all-time if no target.period).
- *   - MTTR (mean downtime per incident).
- *   - Count of incidents.
- *   - % of SLA budget consumed when `spec.manual.target.value` is set
- *     (target.value = the budget in minutes for the period).
+ * `value`. The widget runs in one of two modes, chosen by
+ * `spec.manual.unit`:
  *
- * UX: the headline is "<minutes consumed> / <budget>" when a budget
- * exists, else just total downtime. A small severity chip strip
- * shows distribution. Entries below are the raw log (newest first).
+ *   1. **Duration mode** (unit = "minutes" / "hours" / time-words):
+ *      the budget is in minutes of downtime ("≤ 43 minutes/quarter").
+ *      Headline shows `Σ downtime / budget`. The numeric input is
+ *      required so MTTR makes sense. This is the classic SLA case.
+ *
+ *   2. **Count mode** (unit = "defects" / "incidents" / "bugs" / …):
+ *      the budget is in events ("≤ 10 defects/quarter"). Headline
+ *      shows `count / budget`. The numeric input becomes an optional
+ *      duration field so users can still record how long each took
+ *      without it being required.
+ *
+ * Mode inference is conservative: unknown units fall into count mode,
+ * because saying "0 / 10 defects" but accumulating minutes is the
+ * surprising bug the widget was reported for. Time-words stay in
+ * duration mode for backward compatibility with existing reliability
+ * goals.
  *
  * Why a dedicated widget vs. COUNTER + DATE_LOG?
  *   - The structured `{ severity, downtime, link }` shape lets MTTR
  *     and severity-mix render without each user inventing their own
  *     convention.
  *   - "Budget consumed" framing matches how reliability goals are
- *     written in practice ("≤ 43 minutes/quarter") — a plain counter
- *     of incidents doesn't tell you whether you're inside the budget.
+ *     written in practice ("≤ 43 minutes/quarter", "≤ 10 defects/
+ *     quarter") — a plain counter of incidents doesn't tell you
+ *     whether you're inside the budget.
  */
 export function IncidentLogWidget({
   spec,
@@ -52,26 +62,56 @@ export function IncidentLogWidget({
 
   const totals = useMemo(() => computeTotals(windowed), [windowed]);
   const unit = spec.manual?.unit || "minutes";
+  const mode = inferMode(unit);
+  const isCountMode = mode === "count";
   const promptCopy =
-    spec.manual?.prompt || "Log this incident: severity, downtime, link.";
+    spec.manual?.prompt ||
+    (isCountMode
+      ? `Log this ${singularUnit(unit)}: severity, optional duration, link.`
+      : "Log this incident: severity, downtime, link.");
+
+  // Mode-aware "what's the big number" lookup. Count mode sums entries,
+  // duration mode sums their downtime field. Everything downstream of
+  // here (headline, progress bar, over-budget detection) uses this value.
+  const headlineValue = isCountMode ? totals.count : totals.totalDowntime;
+
+  // Parsed minutes value — drives both the disabled state and what gets
+  // persisted. In count mode an empty input is fine; in duration mode
+  // we still require a non-negative number.
+  const trimmedDowntime = downtime.trim();
+  const minutesValue =
+    trimmedDowntime === "" ? null : Number(trimmedDowntime);
+  const minutesValid =
+    trimmedDowntime === ""
+      ? isCountMode
+      : Number.isFinite(minutesValue) && minutesValue >= 0;
 
   function logIncident() {
-    const minutes = Number(downtime);
-    if (!Number.isFinite(minutes) || minutes < 0) return;
+    if (!minutesValid) return;
     append({
       severity,
-      downtime: minutes,
+      ...(Number.isFinite(minutesValue) && minutesValue >= 0
+        ? { downtime: minutesValue }
+        : {}),
       ...(link.trim() ? { link: link.trim() } : {}),
     });
     setDowntime("");
     setLink("");
   }
 
+  // Label shows the configured unit in count mode (so "Defects · 3"
+  // matches a goal titled "Post-Delivery Defect Control"); in duration
+  // mode the unit is "minutes" so we stick with the generic "Incidents"
+  // label since the count and the budgeted quantity differ.
+  const shellLabel = isCountMode
+    ? `${capitalize(pluralUnit(unit))} · ${totals.count}`
+    : `Incidents · ${totals.count}`;
+
   return (
     <WidgetShell
       spec={spec}
       variant={variant}
-      label={`Incidents · ${entries.length}`}
+      label={shellLabel}
       title={goal?.title || spec.title}
       onRetry={onRetry}
       className={className}
@@ -79,10 +119,12 @@ export function IncidentLogWidget({
       <div className="flex h-full flex-col gap-2">
         <Headline
           totals={totals}
+          headlineValue={headlineValue}
           budget={target?.value}
           unit={unit}
           period={period}
           variant={variant}
+          mode={mode}
         />
         <div
           style={{
@@ -137,7 +179,7 @@ export function IncidentLogWidget({
             min={0}
             value={downtime}
             onChange={(e) => setDowntime(e.target.value)}
-            placeholder="min"
+            placeholder={isCountMode ? "min (opt)" : "min"}
             className="w-16 min-w-0 rounded-[var(--radius-sub)] bg-transparent px-2 py-1.5 outline-none"
             style={{
               fontFamily: "var(--font-mono)",
@@ -148,6 +190,9 @@ export function IncidentLogWidget({
                   ? "1px solid rgba(255,255,255,0.22)"
                   : "1px solid var(--border)",
             }}
+            aria-label={
+              isCountMode ? "Duration (optional, minutes)" : "Downtime (minutes)"
+            }
           />
           <input
             value={link}
@@ -167,7 +212,7 @@ export function IncidentLogWidget({
           <button
             type="button"
             onClick={logIncident}
-            disabled={!Number.isFinite(Number(downtime))}
+            disabled={!minutesValid}
             className="shrink-0 rounded-[var(--radius-sub)] px-3 py-1.5 font-bold uppercase transition-opacity disabled:opacity-40"
             style={{
               fontFamily: "var(--font-mono)",
@@ -273,21 +318,30 @@ export function IncidentLogWidget({
 const SEVERITY_LEVELS = ["P1", "P2", "P3", "P4"];
 
 /**
- * Headline mode 1 — a budget is set:
+ * Headline — branches on mode AND on whether a budget is configured.
  *
- *     43 / 60 min consumed
- *     [████████░░░░░░] 71%
- *     · 4 incidents · MTTR 11m
+ *   Duration + budget:
+ *       43 / 60 minutes · quarter
+ *       [████████░░░░░░] 71%
+ *       4 incidents · MTTR 11m
  *
- * Mode 2 — no budget, no period:
+ *   Count + budget:
+ *       3 / 10 defects · quarter
+ *       [████░░░░░░] 30%
+ *       MTTR 11m · 33m total              (only if any downtime logged)
  *
- *     Σ 43m
- *     4 incidents · MTTR 11m
+ *   Duration, no budget:
+ *       Σ 43 minutes
+ *       4 incidents · MTTR 11m
  *
- * The MTTR rounds to the nearest minute — sub-minute precision is
- * noise for outage tracking.
+ *   Count, no budget:
+ *       3 defects
+ *       MTTR 11m · 33m total              (only if any downtime logged)
+ *
+ * MTTR rounds to the nearest minute — sub-minute precision is noise
+ * for outage tracking.
  */
-function Headline({ totals, budget, unit, period, variant }) {
+function Headline({ totals, headlineValue, budget, unit, period, variant, mode }) {
   const muted =
     variant === "light" ? "rgba(255,255,255,0.72)" : "var(--muted-fg)";
   const monoStyle = {
@@ -296,13 +350,24 @@ function Headline({ totals, budget, unit, period, variant }) {
     color: muted,
     lineHeight: 1.4,
   };
+  const isCountMode = mode === "count";
+  const hasDowntime = totals.totalDowntime > 0;
+  // Secondary stats line. Count mode shows MTTR + total minutes (only
+  // if anyone bothered to log durations); duration mode shows the
+  // incident count + MTTR (the original behaviour).
+  const secondary = isCountMode
+    ? hasDowntime
+      ? `MTTR ${Math.round(totals.mttr)}m · ${totals.totalDowntime}m total`
+      : ""
+    : `${totals.count} incident${totals.count === 1 ? "" : "s"}${
+        totals.count > 0
+          ? ` · MTTR ${Math.round(totals.mttr)}${unit === "minutes" ? "m" : ""}`
+          : ""
+      }`;
 
   if (Number.isFinite(budget) && budget > 0) {
-    const pct = Math.min(
-      100,
-      Math.round((totals.totalDowntime / budget) * 100),
-    );
-    const over = totals.totalDowntime > budget;
+    const pct = Math.min(100, Math.round((headlineValue / budget) * 100));
+    const over = headlineValue > budget;
     return (
       <div className="flex flex-col gap-1.5">
         <div className="flex items-baseline gap-2">
@@ -319,7 +384,7 @@ function Headline({ totals, budget, unit, period, variant }) {
                 : "inherit",
             }}
           >
-            {totals.totalDowntime}
+            {headlineValue}
           </div>
           <div style={monoStyle}>
             / {budget} {unit}
@@ -349,13 +414,12 @@ function Headline({ totals, budget, unit, period, variant }) {
             }}
           />
         </div>
-        <div style={monoStyle}>
-          {totals.count} incident{totals.count === 1 ? "" : "s"}
-          {totals.count > 0
-            ? ` · MTTR ${Math.round(totals.mttr)}${unit === "minutes" ? "m" : ""}`
-            : ""}
-          {over ? " · over budget" : ""}
-        </div>
+        {secondary || over ? (
+          <div style={monoStyle}>
+            {secondary}
+            {over ? `${secondary ? " · " : ""}over budget` : ""}
+          </div>
+        ) : null}
       </div>
     );
   }
@@ -372,16 +436,11 @@ function Headline({ totals, budget, unit, period, variant }) {
             letterSpacing: "-1.4px",
           }}
         >
-          Σ {totals.totalDowntime}
+          {isCountMode ? headlineValue : `Σ ${headlineValue}`}
         </div>
         <div style={monoStyle}>{unit}</div>
       </div>
-      <div style={monoStyle}>
-        {totals.count} incident{totals.count === 1 ? "" : "s"}
-        {totals.count > 0
-          ? ` · MTTR ${Math.round(totals.mttr)}${unit === "minutes" ? "m" : ""}`
-          : ""}
-      </div>
+      {secondary ? <div style={monoStyle}>{secondary}</div> : null}
     </div>
   );
 }
@@ -515,4 +574,61 @@ function periodToDays(period) {
     default:
       return 0;
   }
+}
+
+/**
+ * Pick the widget mode from the configured unit.
+ *
+ * Time-words → duration mode (downtime budget, current behaviour).
+ * Everything else (defects, incidents, bugs, tickets, …) → count mode.
+ *
+ * Falling unknown units into count mode is deliberate: the original
+ * bug was "0 / 10 defects · quarter" silently summing minutes, so the
+ * safer default for ambiguous units is to count events.
+ */
+const DURATION_UNITS = new Set([
+  "minute",
+  "minutes",
+  "min",
+  "mins",
+  "m",
+  "hour",
+  "hours",
+  "hr",
+  "hrs",
+  "h",
+  "second",
+  "seconds",
+  "sec",
+  "secs",
+  "s",
+]);
+
+function inferMode(unit) {
+  if (typeof unit !== "string") return "duration";
+  const u = unit.toLowerCase().trim();
+  if (DURATION_UNITS.has(u)) return "duration";
+  return "count";
+}
+
+function pluralUnit(unit) {
+  if (typeof unit !== "string" || !unit.trim()) return "incidents";
+  const u = unit.trim();
+  // Already plural? Heuristic-only: if it ends with 's' assume plural,
+  // unless it's a known singular ending in 's' (none here yet).
+  if (/s$/i.test(u)) return u;
+  return `${u}s`;
+}
+
+function singularUnit(unit) {
+  if (typeof unit !== "string" || !unit.trim()) return "incident";
+  const u = unit.trim();
+  if (/ies$/i.test(u)) return `${u.slice(0, -3)}y`;
+  if (/s$/i.test(u)) return u.slice(0, -1);
+  return u;
+}
+
+function capitalize(s) {
+  if (typeof s !== "string" || !s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }


### PR DESCRIPTION
## Summary

- The `IncidentLogWidget` previously assumed every entry contributed downtime, so a goal titled **"Post-Delivery Defect Control"** with `unit: "defects"` / `target: 10` showed `0 / 10 defects · quarter` while silently summing minutes-of-downtime instead of counting defects. Label said "incidents", big number was "downtime", unit said "defects" — three different things on one tile.
- The widget now branches on `spec.manual.unit`:
  - **Duration mode** (time-words like `minutes`, `hours`, `m`, `h`, etc.) — current behaviour, downtime budget, minutes input required.
  - **Count mode** (everything else — `defects`, `incidents`, `bugs`, `tickets`, …) — each `Log` press = +1 entry, minutes input is optional (kept for MTTR if filled), headline = `count / budget`, label uses the configured unit (`Defects · 3`).
- Same mode inference is applied to the **check-in editor**, the **check-in grid cell**, and the **evidence resolver** so all four surfaces agree on what the headline number actually means.
- Unknown units fall into count mode by default — the silent-sum was the worse failure to default to.

## Test plan

- [ ] Open the dashboard with a goal whose `spec.manual.unit` is `"defects"` (or `"incidents"` / `"bugs"`). Confirm:
  - Headline shows `count / budget defects`, not the sum of minutes.
  - Label reads e.g. `Defects · 0`, not `Incidents · 0`.
  - The `min` input shows placeholder `min (opt)` and the `Log` button is enabled even when it's blank.
  - Logging without a duration adds an entry, increments the count, leaves total downtime at `0`.
  - Logging with a duration still records the minutes and computes MTTR.
- [ ] Open an existing reliability goal with `unit: "minutes"` and confirm nothing visually changed (headline still `Σ downtime / budget`, `min` input still required).
- [ ] Open the check-in **single-week** editor for a defects goal — confirm `Log` button works without entering a `min`, summary reads `N defects this week`, and the `Σ N min downtime` line only appears if some entry had a duration.
- [ ] Open the check-in **grid** for a defects goal — cell preview shows just the count, not `N · 0m`.
- [ ] Run the goals evidence export — the INCIDENT_LOG reading for a defects goal compares `entries.length` against the budget instead of summing 0 downtime against 10 defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)