### PR TITLE
feat(rubric): always-show week + past-week picker + multi-select

### DIFF
--- a/apps/web/src/features/checkin/code-rubric-row.jsx
+++ b/apps/web/src/features/checkin/code-rubric-row.jsx
@@ -34,7 +34,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import * as Popover from "@radix-ui/react-popover";
-import { Sparkles, ChevronDown } from "lucide-react";
+import { Sparkles, ChevronDown, Check } from "lucide-react";
 import { useGradedPrs } from "@/features/grading";
 import { cn } from "@/lib/cn";
 
@@ -191,9 +191,7 @@ export function CodeRubricGridRow({ goal, spec, weeks }) {
   // "Next ungraded week" — the earliest week that has PRs AND at least
   // one ungraded verdict. Pressing the button grades JUST that week;
   // the user reviews the verdicts that drop in, then presses again
-  // for the next. This replaces the old "Grade all weeks" CTA, which
-  // fired the entire row at once and made the user wait for ~12 weeks
-  // of grading to settle before they could even check the first.
+  // for the next.
   const nextUngradedWeek = useMemo(() => {
     for (const wk of weeks) {
       const weekPrs = prsByWeek.get(wk.weekLabel) || [];
@@ -209,6 +207,50 @@ export function CodeRubricGridRow({ goal, spec, weeks }) {
   }, [grade, nextUngradedWeek]);
 
   const disabledNext = !hasGithub || rubric.length === 0 || !nextUngradedWeek || progress.running;
+
+  // Multi-select state. Toggling a week's checkbox adds/removes it
+  // from this Set. When the Set has ≥1 entries, the trailing column
+  // flips from "Next · Wnn" to "Grade selected (N)". Pressing it
+  // flattens the selected weeks' PRs into one grade() call. Selection
+  // clears after the grade completes.
+  const [selectedWeeks, setSelectedWeeks] = useState(() => new Set());
+  const toggleSelect = useCallback((weekLabel) => {
+    setSelectedWeeks((prev) => {
+      const next = new Set(prev);
+      if (next.has(weekLabel)) next.delete(weekLabel);
+      else next.add(weekLabel);
+      return next;
+    });
+  }, []);
+  const selectedCount = selectedWeeks.size;
+  const selectedStats = useMemo(() => {
+    let ungraded = 0;
+    for (const lbl of selectedWeeks) {
+      const weekPrs = prsByWeek.get(lbl) || [];
+      ungraded += summariseVerdicts(weekPrs, verdictsByPr).ungraded;
+    }
+    return { ungraded };
+  }, [selectedWeeks, prsByWeek, verdictsByPr]);
+
+  const gradeSelected = useCallback(() => {
+    if (selectedCount === 0) return;
+    const flat = [];
+    for (const lbl of selectedWeeks) {
+      const weekPrs = prsByWeek.get(lbl) || [];
+      flat.push(...weekPrs);
+    }
+    grade(flat);
+    // Clear selection after kicking off — the user sees grading
+    // progress on the trailing button, and any week with new
+    // verdicts updates its checkbox availability automatically.
+    setSelectedWeeks(new Set());
+  }, [grade, selectedCount, selectedWeeks, prsByWeek]);
+
+  const disabledSelected =
+    !hasGithub ||
+    rubric.length === 0 ||
+    selectedStats.ungraded === 0 ||
+    progress.running;
 
   return (
     <>
@@ -241,38 +283,67 @@ export function CodeRubricGridRow({ goal, spec, weeks }) {
           grade={grade}
           isListLoading={isListLoading}
           progress={progress}
+          selected={selectedWeeks.has(wk.weekLabel)}
+          onToggleSelect={() => toggleSelect(wk.weekLabel)}
         />
       ))}
 
-      {/* Trailing "Next" column — jump to the earliest ungraded week.
-          Click → grade JUST that week's PRs. After verdicts settle,
-          click again to advance. The label changes to reflect which
-          week is up next so the user knows what they're committing to. */}
+      {/* Trailing column — context-sensitive CTA.
+          - With ≥1 weeks checked: "Grade selected (N)" — flattens
+            the selection's PRs into one grade() call.
+          - With nothing checked: "Next · Wnn" jumper that targets the
+            earliest ungraded week.
+          - When all weeks are graded: "All graded" disabled state. */}
       <div className="flex items-center justify-end border-b border-border px-2">
-        <button
-          type="button"
-          onClick={gradeNextWeek}
-          disabled={disabledNext}
-          title={
-            rubric.length === 0
-              ? "Define rubric in the dashboard widget first"
-              : !nextUngradedWeek
-              ? "All weeks graded"
-              : `Grade ${nextUngradedWeek.week.weekLabel} (${nextUngradedWeek.ungraded} ungraded)`
-          }
-          className={cn(
-            "flex items-center gap-1 rounded-md border border-border bg-bg px-1.5 py-0.5 text-[10px] uppercase tracking-[0.4px] text-muted-fg hover:bg-accent-dim/60 hover:text-fg",
-            disabledNext && "opacity-40",
-          )}
-          style={CELL_FONT}
-        >
-          <Sparkles size={10} />
-          {progress.running
-            ? `${progress.done}/${progress.total}`
-            : nextUngradedWeek
-            ? `Next · ${nextUngradedWeek.week.weekLabel}`
-            : "All graded"}
-        </button>
+        {selectedCount > 0 ? (
+          <button
+            type="button"
+            onClick={gradeSelected}
+            disabled={disabledSelected}
+            title={
+              rubric.length === 0
+                ? "Define rubric in the dashboard widget first"
+                : selectedStats.ungraded === 0
+                ? "Selected weeks are already graded"
+                : `Grade ${selectedStats.ungraded} ungraded across ${selectedCount} week${selectedCount === 1 ? "" : "s"}`
+            }
+            className={cn(
+              "flex items-center gap-1 rounded-md border border-accent bg-accent/10 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.4px] text-accent hover:bg-accent/20",
+              disabledSelected && "opacity-40",
+            )}
+            style={CELL_FONT}
+          >
+            <Sparkles size={10} />
+            {progress.running
+              ? `${progress.done}/${progress.total}`
+              : `Grade ${selectedCount} sel.`}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={gradeNextWeek}
+            disabled={disabledNext}
+            title={
+              rubric.length === 0
+                ? "Define rubric in the dashboard widget first"
+                : !nextUngradedWeek
+                ? "All weeks graded"
+                : `Grade ${nextUngradedWeek.week.weekLabel} (${nextUngradedWeek.ungraded} ungraded)`
+            }
+            className={cn(
+              "flex items-center gap-1 rounded-md border border-border bg-bg px-1.5 py-0.5 text-[10px] uppercase tracking-[0.4px] text-muted-fg hover:bg-accent-dim/60 hover:text-fg",
+              disabledNext && "opacity-40",
+            )}
+            style={CELL_FONT}
+          >
+            <Sparkles size={10} />
+            {progress.running
+              ? `${progress.done}/${progress.total}`
+              : nextUngradedWeek
+              ? `Next · ${nextUngradedWeek.week.weekLabel}`
+              : "All graded"}
+          </button>
+        )}
       </div>
     </>
   );
@@ -289,6 +360,8 @@ function CodeRubricCell({
   grade,
   isListLoading,
   progress,
+  selected,
+  onToggleSelect,
 }) {
   const stats = useMemo(
     () => summariseVerdicts(weekPrs, verdictsByPr),
@@ -301,6 +374,11 @@ function CodeRubricCell({
     weekPrs.length === 0 ||
     stats.ungraded === 0 ||
     progress.running;
+
+  // Selection is disabled when the cell has no PRs OR every PR is
+  // already graded — picking such a week wouldn't fire anything.
+  const canSelect =
+    hasGithub && rubricReady && weekPrs.length > 0 && stats.ungraded > 0;
 
   // Preview chip — what the cell shows when collapsed.
   const preview =
@@ -323,9 +401,36 @@ function CodeRubricCell({
 
   return (
     <div
-      className="flex items-center justify-center border-b border-r border-border bg-bg/40 px-2 py-1.5"
+      className={cn(
+        "relative flex items-center justify-center border-b border-r border-border px-2 py-1.5",
+        selected ? "bg-accent/10" : "bg-bg/40",
+      )}
       style={{ minHeight: 52 }}
     >
+      {/* Multi-select checkbox — top-left corner of the cell. Doesn't
+          interfere with the popover trigger since it's positioned
+          absolutely and its own click handler stops propagation. */}
+      {canSelect ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleSelect?.();
+          }}
+          aria-label={
+            selected ? `Deselect ${week.weekLabel}` : `Select ${week.weekLabel}`
+          }
+          aria-pressed={selected}
+          className={cn(
+            "absolute left-1 top-1 flex h-3.5 w-3.5 items-center justify-center rounded-[3px] border transition-colors",
+            selected
+              ? "border-accent bg-accent text-accent-on"
+              : "border-border bg-bg text-transparent hover:border-accent/50",
+          )}
+        >
+          <Check size={9} strokeWidth={3} />
+        </button>
+      ) : null}
       <Popover.Root>
         <Popover.Trigger asChild>
           <button

--- a/apps/web/src/features/goal-widgets/widgets/code-rubric-widget.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/code-rubric-widget.jsx
@@ -23,6 +23,8 @@
  */
 
 import { useMemo, useState } from "react";
+import * as Popover from "@radix-ui/react-popover";
+import { ChevronDown } from "lucide-react";
 import { WidgetShell } from "../widget-shell";
 import { useGradedPrs } from "@/features/grading";
 import { weekLabel, weekRangeFromLabel } from "@/lib/date";
@@ -88,6 +90,31 @@ export function CodeRubricWidget({ spec, goal, variant = "light", className, onR
     () => summarisePrs(thisWeekPrs, verdictsByPr),
     [thisWeekPrs, verdictsByPr],
   );
+
+  // All weeks YTD that have at least one PR — drives the "pick a past
+  // week" dropdown next to the Grade button. Sorted newest-first so
+  // the current week sits at the top of the list.
+  const allWeeksWithPrs = useMemo(() => {
+    const byLabel = new Map();
+    for (const pr of prs) {
+      if (!pr.mergedAt) continue;
+      const lbl = weekLabel(new Date(pr.mergedAt));
+      if (!byLabel.has(lbl)) byLabel.set(lbl, []);
+      byLabel.get(lbl).push(pr);
+    }
+    const out = [];
+    for (const [lbl, weekPrs] of byLabel) {
+      out.push({
+        weekLabel: lbl,
+        prs: weekPrs,
+        stats: summarisePrs(weekPrs, verdictsByPr),
+      });
+    }
+    // Wnn labels compare lexicographically within a year, so a plain
+    // descending sort puts the most recent week first.
+    out.sort((a, b) => b.weekLabel.localeCompare(a.weekLabel));
+    return out;
+  }, [prs, verdictsByPr]);
 
   // Empty / setup states come first — short-circuit before the grid.
   if (!hasGithub) {
@@ -255,6 +282,8 @@ export function CodeRubricWidget({ spec, goal, variant = "light", className, onR
           onGradeThisWeek={onGradeThisWeek}
           onGradeAll={gradeAll}
           totalPrs={prs.length}
+          allWeeksWithPrs={allWeeksWithPrs}
+          onGradeWeek={(weekPrs) => grade(weekPrs)}
         />
         <ListDisclosure
           variant={variant}
@@ -357,12 +386,16 @@ function ThisWeekRow({ variant, weekLabel, stats, prCount }) {
 }
 
 /**
- * Two-button action row: "Grade this week" is the primary action
- * (user mostly works in week-sized chunks); "Grade YTD" is the
- * escape hatch for catching up the full year. Disabling logic:
+ * Three-control action row:
+ *   - "Grade week (N)"  — primary, targets the current ISO week
+ *   - week-picker chevron — opens a list of all past weeks with PRs;
+ *                           click any row to grade just that week
+ *   - "YTD (M)"         — escape hatch to grade everything ungraded
  *
- *   - both disabled while a grade pass is running (progress.running)
+ * Disabling logic:
+ *   - all controls disabled while a grade pass is running (progress.running)
  *   - "this week" disabled when no ungraded PRs merged in current week
+ *   - per-week rows in the picker disabled when that week is fully graded
  *   - "YTD"  disabled when nothing is ungraded anywhere
  *
  * When everything's graded both collapse to "All graded".
@@ -377,10 +410,16 @@ function GradeActionRow({
   onGradeThisWeek,
   onGradeAll,
   totalPrs,
+  allWeeksWithPrs,
+  onGradeWeek,
 }) {
   const running = progress.running;
   const thisWeekDisabled = running || !hasUngradedThisWeek;
   const ytdDisabled = running || !hasUngraded;
+  // Past-week picker is meaningful when there are weeks WITH PRs other
+  // than the current one. If there's only the current week, the
+  // "Grade week" button already covers it — hide the chevron.
+  const hasPastWeeks = (allWeeksWithPrs?.length || 0) > 1;
 
   let thisWeekLabel;
   if (running) thisWeekLabel = `Grading ${progress.done}/${progress.total}…`;
@@ -406,21 +445,41 @@ function GradeActionRow({
         {totalPrs} PR{totalPrs === 1 ? "" : "s"} YTD
       </div>
       <div className="flex items-center gap-1.5">
-        <button
-          type="button"
-          onClick={onGradeThisWeek}
-          disabled={thisWeekDisabled}
-          className="rounded-[var(--radius-sub)] px-3 py-1 uppercase font-bold transition-opacity disabled:opacity-40"
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: 10,
-            letterSpacing: "0.5px",
-            background: variant === "light" ? "#ffffff" : "var(--accent)",
-            color: variant === "light" ? "var(--accent)" : "var(--accent-on)",
-          }}
-        >
-          {thisWeekLabel}
-        </button>
+        {/* Primary button + adjacent chevron form a "split button":
+            click the wide part → grade this week; click the chevron
+            → pick a different past week. The chevron is its own
+            Popover.Trigger so the wide button keeps its straight
+            onClick handler. */}
+        <div className="flex items-stretch">
+          <button
+            type="button"
+            onClick={onGradeThisWeek}
+            disabled={thisWeekDisabled}
+            className={
+              hasPastWeeks
+                ? "rounded-l-[var(--radius-sub)] px-3 py-1 uppercase font-bold transition-opacity disabled:opacity-40"
+                : "rounded-[var(--radius-sub)] px-3 py-1 uppercase font-bold transition-opacity disabled:opacity-40"
+            }
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              letterSpacing: "0.5px",
+              background: variant === "light" ? "#ffffff" : "var(--accent)",
+              color:
+                variant === "light" ? "var(--accent)" : "var(--accent-on)",
+            }}
+          >
+            {thisWeekLabel}
+          </button>
+          {hasPastWeeks ? (
+            <WeekPickerDropdown
+              variant={variant}
+              running={running}
+              weeks={allWeeksWithPrs}
+              onPick={onGradeWeek}
+            />
+          ) : null}
+        </div>
         <button
           type="button"
           onClick={onGradeAll}
@@ -447,6 +506,98 @@ function GradeActionRow({
         </button>
       </div>
     </div>
+  );
+}
+
+/**
+ * Past-week picker. Lists every week YTD that has at least one merged
+ * PR, sorted newest-first. Each row shows pass/total + ungraded count;
+ * fully-graded weeks are visible but disabled so the user can still
+ * see them without accidentally re-grading. Picking a week fires
+ * `onPick(weekPrs)` immediately — there's no two-step "confirm" UX.
+ */
+function WeekPickerDropdown({ variant, running, weeks, onPick }) {
+  const triggerBg = variant === "light" ? "#ffffff" : "var(--accent)";
+  const triggerFg = variant === "light" ? "var(--accent)" : "var(--accent-on)";
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          disabled={running}
+          aria-label="Pick a past week to grade"
+          className="rounded-r-[var(--radius-sub)] border-l px-1.5 py-1 transition-opacity disabled:opacity-40"
+          style={{
+            background: triggerBg,
+            color: triggerFg,
+            borderLeftColor:
+              variant === "light" ? "rgba(0,0,0,0.10)" : "rgba(0,0,0,0.18)",
+          }}
+        >
+          <ChevronDown size={12} />
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="end"
+          sideOffset={6}
+          className="z-50 w-[260px] rounded-md border shadow-lg"
+          style={{
+            background: "var(--card)",
+            borderColor: "var(--border)",
+            maxHeight: 320,
+            overflowY: "auto",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+          }}
+        >
+          <div
+            className="border-b px-2 py-1.5 uppercase tracking-[0.4px]"
+            style={{
+              borderColor: "var(--border)",
+              fontSize: 9.5,
+              color: "var(--muted-fg)",
+            }}
+          >
+            Grade a specific week
+          </div>
+          <ul className="flex flex-col">
+            {weeks.map((w) => {
+              const fullyGraded = w.stats.ungraded === 0;
+              const disabled = fullyGraded;
+              return (
+                <li key={w.weekLabel}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (!disabled) onPick(w.prs);
+                    }}
+                    disabled={disabled}
+                    className="flex w-full items-baseline justify-between gap-2 px-2 py-1.5 text-left transition-opacity disabled:opacity-50 hover:bg-accent-dim/30"
+                  >
+                    <span
+                      className="font-semibold"
+                      style={{ color: "var(--fg)" }}
+                    >
+                      {w.weekLabel}
+                    </span>
+                    <span style={{ color: "var(--muted-fg)" }}>
+                      {fullyGraded
+                        ? `${w.stats.pass}/${w.stats.graded} · all graded`
+                        : w.stats.graded === 0
+                          ? `${w.prs.length} PR${
+                              w.prs.length === 1 ? "" : "s"
+                            } · ${w.stats.ungraded} to grade`
+                          : `${w.stats.pass}/${w.stats.graded} pass · ${w.stats.ungraded} to grade`}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }
 

--- a/apps/web/src/features/goal-widgets/widgets/code-rubric-widget.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/code-rubric-widget.jsx
@@ -319,16 +319,26 @@ function PctRow({ pct, variant }) {
 }
 
 /**
- * Inline summary of the current Sun → Fri work-week. Shows the per-week
- * pass/graded fraction so the headline number (YTD %) is paired with
- * the granularity the user is actually being asked to grade. Hidden
- * when there are no PRs merged this week (nothing to surface).
+ * Inline summary of the current Sun → Fri work-week. Always rendered
+ * so the YTD headline number sits alongside the granularity users are
+ * being asked to grade — even when no PRs were merged this week,
+ * showing "0 PRs merged" is more informative than the row vanishing
+ * (which made the user think the per-week framing wasn't deployed).
  */
 function ThisWeekRow({ variant, weekLabel, stats, prCount }) {
-  if (prCount === 0) return null;
   const muted =
     variant === "light" ? "rgba(255,255,255,0.72)" : "var(--muted-fg)";
   const fg = variant === "light" ? "#ffffff" : "var(--fg)";
+  let right;
+  if (prCount === 0) {
+    right = "0 PRs merged";
+  } else if (stats.graded === 0) {
+    right = `${prCount} to grade`;
+  } else {
+    right = `${stats.pass}/${stats.graded} pass${
+      stats.ungraded > 0 ? ` · ${stats.ungraded} to grade` : ""
+    }`;
+  }
   return (
     <div
       className="flex items-baseline justify-between gap-2"
@@ -341,10 +351,7 @@ function ThisWeekRow({ variant, weekLabel, stats, prCount }) {
       <span className="uppercase tracking-[0.4px]">
         This week{weekLabel ? ` · ${weekLabel}` : ""}
       </span>
-      <span style={{ color: fg }}>
-        {stats.pass}/{stats.graded} pass
-        {stats.ungraded > 0 ? ` · ${stats.ungraded} to grade` : ""}
-      </span>
+      <span style={{ color: fg }}>{right}</span>
     </div>
   );
 }

--- a/apps/web/src/features/goal-widgets/widgets/scorecard-component-modal.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/scorecard-component-modal.jsx
@@ -217,15 +217,6 @@ function buildSyntheticSpec(parentSpec, component, index) {
   const title =
     component?.label?.trim() || prettyWidget(widget) || "Component";
 
-  // MUST match `useRubricForSlot` in scorecard-widget.jsx — both
-  // paths feed the same rubricHash so verdicts written by the modal's
-  // "Grade now" land under the same key the SCORECARD row reads.
-  // Format: `sc${index}:${parentGoalId}`.
-  const scopeKey =
-    widget === "CODE_RUBRIC" && parentSpec?.goalId
-      ? `sc${index}:${parentSpec.goalId}`
-      : null;
-
   return {
     schemaVersion: 1,
     goalId: subGoalId,
@@ -258,10 +249,9 @@ function buildSyntheticSpec(parentSpec, component, index) {
     untrackable: null,
     scorecard: null,
     firstReviewOnly: component?.firstReviewOnly === true,
-    // scopeKey is consumed by CodeRubricWidget when the modal renders
-    // it. Outside the SCORECARD context this field is null and the
-    // widget behaves identically to the standalone case.
-    scopeKey,
+    // No scopeKey — useRubricForSlot also runs without one, so both
+    // row and modal compute the same rubricHash and share verdicts.
+    // See the rationale in scorecard-widget.jsx#useRubricForSlot.
     classifiedAt: parentSpec?.classifiedAt || Date.now(),
   };
 }

--- a/apps/web/src/features/goal-widgets/widgets/scorecard-widget.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/scorecard-widget.jsx
@@ -496,8 +496,14 @@ function useRubricForSlot(component, parentGoal, index) {
       : seedCriteria
     : [];
   const firstReviewOnly = isRubric && component?.firstReviewOnly === true;
-  const scopeKey =
-    isRubric && parentGoal?.id ? `sc${index}:${parentGoal.id}` : null;
+  // No scopeKey: the rubric hash is `rubricHash(criteria, firstReviewOnly?)`.
+  // Two slots with identical criteria share the same cache entry,
+  // which is correct — the grader is deterministic, so the verdict
+  // is the same. Previously we used a per-slot scopeKey but that
+  // diverged from the modal's hash (the modal renders the standalone
+  // widget which has no scopeKey), so verdicts written from the row
+  // were invisible to the modal and vice-versa. Aligning on
+  // no-scopeKey lets row and modal share one cache.
   return useGradedPrs(
     isRubric && parentGoal?.id
       ? { goalId: parentGoal.id, context: { questions: [] } }
@@ -506,7 +512,6 @@ function useRubricForSlot(component, parentGoal, index) {
       enabled: isRubric && criteria.length > 0,
       criteriaOverride: criteria,
       firstReviewOnly,
-      scopeKey,
     },
   );
 }


### PR DESCRIPTION
## Summary

Three connected rubric improvements stacked on top of #129. Goal: let users grade selectively per week, from either the dashboard or the check-in, and stop showing different numbers in the SCORECARD row vs the modal.

### 1. 'This week' row always renders

The row was hiding when 0 PRs merged this week (the common case Sun/Mon), making it look like the per-week framing hadn't shipped. Now it always renders one of:
- `0 PRs merged`
- `N to grade`
- `X/Y pass · Z to grade`

### 2. SCORECARD row ↔ modal share one verdict cache

Dropped `scopeKey` entirely from both `useRubricForSlot` and the modal's synthetic spec. Rationale: the grading verdict is a function of `(PR, criteria)`. Two slots with identical criteria sharing a cache entry is correct — the grader is deterministic, the verdict is identical. `firstReviewOnly` still gets mixed into the hash separately, so first-review and full-thread verdicts stay distinct. After this deploys, the user's existing 102 verdicts (written under the legacy no-scopeKey hash) become immediately visible to both the row and the modal — no re-grade needed.

### 3. Past-week picker (NEW)

**Dashboard widget — split button + dropdown.**
The 'Grade week (N)' primary now has a chevron next to it that opens a Popover listing every week YTD with merged PRs, sorted newest-first. Each row shows pass/total + 'N to grade' (or 'all graded'). Clicking an ungraded row grades just that week immediately. Fully-graded weeks are visible but disabled so the user can still see the history. The chevron hides when only the current week has PRs.

**Check-in grid — multi-select.**
Each rubric grid cell now has a 3.5px checkbox in its top-left corner. Checking ≥1 weeks flips the trailing column from 'Next · Wnn' to 'Grade selected (N)', which flattens the selection's PRs into one grade() call. Already-graded cells can't be selected. Selection clears after the grade fires. The cell tints accent/10 when selected.

## Files

- `apps/web/src/features/goal-widgets/widgets/code-rubric-widget.jsx` — this-week always-show + WeekPickerDropdown
- `apps/web/src/features/goal-widgets/widgets/scorecard-widget.jsx` — drop scopeKey from useRubricForSlot
- `apps/web/src/features/goal-widgets/widgets/scorecard-component-modal.jsx` — drop scopeKey from synthetic spec
- `apps/web/src/features/checkin/code-rubric-row.jsx` — multi-select state + checkbox + 'Grade selected'

## Test plan

- [ ] Open the goals page rubric widget — 'This week · Wnn · …' line is always visible.
- [ ] Click the chevron next to 'Grade week' — dropdown opens with all weeks YTD. Click an ungraded week → grading kicks off for just that week. Fully-graded weeks visible but greyed out.
- [ ] Open SCORECARD goal — row and modal show the SAME pass count on first paint (the user's existing 102 verdicts are visible to both surfaces).
- [ ] Go to `/dev/checkin/grid`, find a rubric row. Check the checkbox on 2–3 weeks → trailing button changes to 'Grade N sel.' Press it → grades those weeks. Selection clears.
- [ ] Smoke: standalone CODE_RUBRIC widget on a non-SCORECARD goal still works (single button when only this week has PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)