### PR TITLE
feat(checkin): expand SCORECARD into sub-component rows

### DIFF
--- a/apps/web/src/features/checkin/goal-row.jsx
+++ b/apps/web/src/features/checkin/goal-row.jsx
@@ -15,7 +15,7 @@
  * builds inline editors for them too.
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { SPEC_KINDS } from "@/features/goal-specs";
 import {
   avgReviewerComments,
@@ -36,6 +36,11 @@ import {
   UnsupportedStub,
 } from "./editors";
 import { CodeRubricEditor } from "./code-rubric-row";
+import {
+  buildSubGoal,
+  buildSubSpec,
+  seedRubricContextIfNeeded,
+} from "@/features/goal-widgets/widgets/scorecard-subspec";
 
 export function GoalRow({
   goal,
@@ -48,6 +53,53 @@ export function GoalRow({
   tickets,
 }) {
   const widget = spec.widget;
+
+  // SCORECARD goals expand into ONE banner row + N child rows, one per
+  // sub-component. Each child renders a regular GoalRow with the
+  // synthetic sub-spec, so the dispatch below picks the correct
+  // editor (CODE_RUBRIC, RECURRING_MILESTONE, etc.) automatically.
+  // The CODE_RUBRIC seed effect lives a step deeper inside
+  // ScorecardChildRow so the goal-context is populated before
+  // useGradedPrs reads it.
+  if (widget === SPEC_KINDS.SCORECARD) {
+    const components = spec?.scorecard?.components || [];
+    if (components.length === 0) {
+      return (
+        <div className="flex items-start justify-between gap-4 rounded-md border border-border bg-bg/40 px-3 py-2.5">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <ScorecardBannerInner goal={goal} components={0} />
+          </div>
+          <div className="flex-shrink-0">
+            <UnsupportedStub message="No components defined — add some in the dashboard widget" />
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="flex flex-col gap-1.5">
+        <div className="rounded-md border border-border/60 bg-bg/30 px-3 py-2">
+          <ScorecardBannerInner goal={goal} components={components.length} />
+        </div>
+        <div className="flex flex-col gap-1.5 pl-3">
+          {components.map((component, i) => (
+            <ScorecardChildRow
+              key={i}
+              parentGoal={goal}
+              parentSpec={spec}
+              component={component}
+              index={i}
+              weekStart={weekStart}
+              weekEnd={weekEnd}
+              activeLabel={activeLabel}
+              mrs={mrs}
+              events={events}
+              tickets={tickets}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   // Filter integration data to this week's window once for any auto
   // widget that wants it.
@@ -91,6 +143,80 @@ export function GoalRow({
         />
       </div>
     </div>
+  );
+}
+
+/**
+ * Banner row at the top of an expanded SCORECARD — shows the kind
+ * chip + parent goal title + a small "N components" hint. Stays
+ * compact (single line) so the expanded children below get the
+ * visual focus.
+ */
+function ScorecardBannerInner({ goal, components }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className="rounded-[3px] border border-border px-1 py-px text-[9px] uppercase tracking-[0.6px] text-muted-fg"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        scorecard
+      </span>
+      <div className="truncate text-[13px] font-medium text-fg">
+        {goal?.title || "Untitled"}
+      </div>
+      <span
+        className="ml-auto shrink-0 text-[10px] uppercase tracking-[0.4px] text-muted-fg/70"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        {components} component{components === 1 ? "" : "s"}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * One row inside an expanded SCORECARD. Builds the synthetic sub-spec
+ * + sub-goal, seeds CODE_RUBRIC goal-context once on mount (so the
+ * check-in works even when the user hasn't opened the dashboard modal
+ * first), then renders a regular GoalRow which picks the correct
+ * editor by sub-widget kind.
+ */
+function ScorecardChildRow({
+  parentGoal,
+  parentSpec,
+  component,
+  index,
+  weekStart,
+  weekEnd,
+  activeLabel,
+  mrs,
+  events,
+  tickets,
+}) {
+  const subSpec = useMemo(
+    () => buildSubSpec(parentSpec, component, index),
+    [parentSpec, component, index],
+  );
+  const subGoal = useMemo(
+    () => buildSubGoal(parentGoal, subSpec),
+    [parentGoal, subSpec],
+  );
+  // Idempotent seed — only writes when the sub-id has no rubric
+  // context yet AND the component is CODE_RUBRIC with seed items.
+  useEffect(() => {
+    seedRubricContextIfNeeded(subSpec.goalId, component);
+  }, [subSpec.goalId, component]);
+  return (
+    <GoalRow
+      goal={subGoal}
+      spec={subSpec}
+      weekStart={weekStart}
+      weekEnd={weekEnd}
+      activeLabel={activeLabel}
+      mrs={mrs}
+      events={events}
+      tickets={tickets}
+    />
   );
 }
 

--- a/apps/web/src/features/checkin/grid-page.jsx
+++ b/apps/web/src/features/checkin/grid-page.jsx
@@ -17,7 +17,7 @@
  * header (top). Scrolls in both directions when content overflows.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Save, ChevronLeft, ChevronRight } from "lucide-react";
 import { useGoals } from "@/features/goals";
@@ -34,6 +34,11 @@ import { isoDaysAgo } from "@/lib/date";
 import { SPEC_KINDS } from "@/features/goal-specs";
 import { useCheckinGridRange } from "./use-checkin-grid-range";
 import { GridRow, RowCopyButton } from "./grid-row";
+import {
+  buildSubGoal,
+  buildSubSpec,
+  seedRubricContextIfNeeded,
+} from "@/features/goal-widgets/widgets/scorecard-subspec";
 
 const LABEL_COL = 240;
 const CELL_COL = 130;
@@ -202,6 +207,62 @@ function GroupBlock({ group, weekCount, weeks, mrsByWeek, eventsByWeek, ticketsC
 }
 
 function RowGroup({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCount }) {
+  // SCORECARD goals expand into a parent banner row + N child
+  // RowGroups, one per sub-component. Each child uses a synthetic
+  // sub-spec routed through this same RowGroup recursively, so the
+  // dispatch picks the correct cell renderer (CODE_RUBRIC → grade
+  // cells, RECURRING_MILESTONE → checklist cells, etc.) per child.
+  // The trailing "Bulk" column is per-child too, so per-row Copy /
+  // Grade-next affordances still work.
+  if (spec.widget === SPEC_KINDS.SCORECARD) {
+    const components = spec?.scorecard?.components || [];
+    const totalCols = 1 + weeks.length + 1;
+    if (components.length === 0) {
+      return (
+        <>
+          <div
+            className="sticky left-0 z-10 col-span-full border-b border-dashed border-border/60 bg-bg/30 px-3 py-1.5 text-[11px] uppercase tracking-[0.5px] text-muted-fg/80"
+            style={{
+              fontFamily: "var(--font-mono)",
+              gridColumn: `1 / span ${totalCols}`,
+            }}
+          >
+            scorecard · {goal?.title || spec.title} · no components defined yet
+          </div>
+        </>
+      );
+    }
+    return (
+      <>
+        <div
+          className="sticky left-0 z-10 col-span-full border-b border-dashed border-border/60 bg-bg/30 px-3 py-1.5 text-[11px] uppercase tracking-[0.5px] text-muted-fg/90"
+          style={{
+            fontFamily: "var(--font-mono)",
+            gridColumn: `1 / span ${totalCols}`,
+          }}
+        >
+          scorecard · {goal?.title || spec.title} ·{" "}
+          <span className="text-muted-fg/70">
+            {components.length} component{components.length === 1 ? "" : "s"}
+          </span>
+        </div>
+        {components.map((component, i) => (
+          <ScorecardChildRowGroup
+            key={i}
+            parentGoal={goal}
+            parentSpec={spec}
+            component={component}
+            index={i}
+            weeks={weeks}
+            mrsByWeek={mrsByWeek}
+            eventsByWeek={eventsByWeek}
+            ticketsCount={ticketsCount}
+          />
+        ))}
+      </>
+    );
+  }
+
   // CODE_RUBRIC rows render their own trailing "Bulk · Grade all"
   // column inside GridRow → CodeRubricGridRow, so we skip appending
   // RowCopyButton here (which would otherwise overflow the grid
@@ -219,6 +280,49 @@ function RowGroup({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCount }) 
       />
       {!skipBulk && <RowCopyButton goal={goal} spec={spec} weeks={weeks} />}
     </>
+  );
+}
+
+/**
+ * One sub-row inside an expanded SCORECARD on the catch-up grid.
+ *
+ * Builds the synthetic sub-spec, seeds CODE_RUBRIC goal-context on
+ * mount so the rubric isn't empty even when the dashboard modal
+ * hasn't been opened, then routes through RowGroup recursively. The
+ * RowGroup handles the per-child cell dispatch + the trailing column
+ * (CodeRubricGridRow's own bulk button, or RowCopyButton for manual
+ * widgets, or a "—" for stub cases).
+ */
+function ScorecardChildRowGroup({
+  parentGoal,
+  parentSpec,
+  component,
+  index,
+  weeks,
+  mrsByWeek,
+  eventsByWeek,
+  ticketsCount,
+}) {
+  const subSpec = useMemo(
+    () => buildSubSpec(parentSpec, component, index),
+    [parentSpec, component, index],
+  );
+  const subGoal = useMemo(
+    () => buildSubGoal(parentGoal, subSpec),
+    [parentGoal, subSpec],
+  );
+  useEffect(() => {
+    seedRubricContextIfNeeded(subSpec.goalId, component);
+  }, [subSpec.goalId, component]);
+  return (
+    <RowGroup
+      goal={subGoal}
+      spec={subSpec}
+      weeks={weeks}
+      mrsByWeek={mrsByWeek}
+      eventsByWeek={eventsByWeek}
+      ticketsCount={ticketsCount}
+    />
   );
 }
 

--- a/apps/web/src/features/goal-widgets/widgets/recurring-milestone-widget.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/recurring-milestone-widget.jsx
@@ -165,15 +165,15 @@ export function RecurringMilestoneWidget({
             </li>
           ) : null}
           {items.map((it) => (
-            <li key={it.id} className="group flex items-center gap-2">
+            <li key={it.id} className="group flex min-w-0 items-center gap-2">
               <input
                 type="checkbox"
                 checked={!!it.done}
                 onChange={() => toggle(it.id)}
-                className="h-3.5 w-3.5"
+                className="h-3.5 w-3.5 shrink-0"
               />
               <span
-                className="flex-1 truncate"
+                className="min-w-0 flex-1 truncate"
                 style={{
                   textDecoration: it.done ? "line-through" : "none",
                   color: it.done
@@ -263,10 +263,10 @@ function Headline({ pct, streak, cadence, periodLabel, variant }) {
     lineHeight: 1.4,
   };
   return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-baseline gap-2">
+    <div className="flex min-w-0 flex-col gap-1.5">
+      <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
         <div
-          className="font-semibold leading-none"
+          className="shrink-0 font-semibold leading-none"
           style={{
             fontFamily: "var(--font-display)",
             fontSize: 36,
@@ -275,11 +275,11 @@ function Headline({ pct, streak, cadence, periodLabel, variant }) {
         >
           {pct}%
         </div>
-        <div style={monoStyle}>
+        <div className="min-w-0 truncate" style={monoStyle} title={periodLabel}>
           {periodLabel}
         </div>
       </div>
-      <div style={monoStyle}>
+      <div className="min-w-0 truncate" style={monoStyle}>
         {streak === 0
           ? `0 ${cadence === "quarterly" ? "quarters" : "periods"} complete in a row`
           : `${streak} ${cadenceNoun(cadence, streak)} complete in a row`}

--- a/apps/web/src/features/goal-widgets/widgets/scorecard-component-modal.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/scorecard-component-modal.jsx
@@ -3,9 +3,9 @@
 import { useEffect } from "react";
 import { GoalWidget } from "../goal-widget";
 import {
-  readContextFor,
-  saveContextFor,
-} from "@/features/goal-context";
+  buildSubSpec,
+  seedRubricContextIfNeeded,
+} from "./scorecard-subspec";
 
 /**
  * Modal that opens when a SCORECARD ComponentRow is clicked.
@@ -64,24 +64,13 @@ export function ScorecardComponentModal({
       : null;
 
   // Seed criteria for CODE_RUBRIC if context is empty for this sub-id.
-  // Re-seeds when the modal re-opens for a DIFFERENT component (key on
-  // index + parent goal id). When the user edits criteria via the
-  // rubric widget's own ContextCollector, the saveContextFor() call
-  // there updates the store — we don't overwrite it on subsequent
-  // opens because the `if (existing length > 0)` check short-circuits.
+  // Same helper the check-in surfaces use, so the modal and the
+  // check-in always seed under identical rules.
   useEffect(() => {
     if (!open) return;
     if (!subGoalId) return;
-    if (component?.widget !== "CODE_RUBRIC") return;
-    const existing = readContextFor(subGoalId);
-    const hasCriteria =
-      Array.isArray(existing["quality-standards"]) &&
-      existing["quality-standards"].length > 0;
-    if (hasCriteria) return;
-    const seed = component.manual?.items || [];
-    if (seed.length === 0) return;
-    saveContextFor(subGoalId, { "quality-standards": seed });
-  }, [open, subGoalId, component?.widget, component?.manual?.items]);
+    seedRubricContextIfNeeded(subGoalId, component);
+  }, [open, subGoalId, component]);
 
   // ESC closes — bind globally for the duration the modal is open.
   useEffect(() => {
@@ -95,7 +84,7 @@ export function ScorecardComponentModal({
 
   if (!open || !component) return null;
 
-  const syntheticSpec = buildSyntheticSpec(parentSpec, component, index);
+  const syntheticSpec = buildSubSpec(parentSpec, component, index);
   const syntheticGoal = {
     ...(parentGoal || {}),
     id: subGoalId,
@@ -199,70 +188,6 @@ function ModalHeader({ label, parentTitle, onClose }) {
       </button>
     </div>
   );
-}
-
-/**
- * Translate a scorecard component into a full ValidatedSpec shape so
- * the registered widget Component can render it like a standalone
- * spec. Keep this in lockstep with `packages/shared/src/goal-specs`
- * — anything the widget's body reads off the spec object needs a
- * (sensible) default here.
- */
-function buildSyntheticSpec(parentSpec, component, index) {
-  const subGoalId =
-    parentSpec?.goalId != null
-      ? `${parentSpec.goalId}::sc${index}`
-      : `scorecard-component-${index}`;
-  const widget = component?.widget || "MERGED_COUNT";
-  const title =
-    component?.label?.trim() || prettyWidget(widget) || "Component";
-
-  return {
-    schemaVersion: 1,
-    goalId: subGoalId,
-    title,
-    reasoning: "",
-    kind: component?.kind || "auto",
-    widget,
-    source: component?.source || null,
-    manual: component?.manual || null,
-    // CODE_RUBRIC needs context.questions[*].id === "quality-standards"
-    // for `resolveRubric(spec, answers)` to find the criteria. We
-    // attach the question here so the existing standalone widget
-    // logic just works — the criteria live in the goal-context store
-    // (seeded above) and the widget pulls them via useGoalContext.
-    context:
-      widget === "CODE_RUBRIC"
-        ? {
-            required: true,
-            questions: [
-              {
-                id: "quality-standards",
-                prompt: "What are your code quality standards?",
-                kind: "list",
-                placeholder: "e.g. test coverage, naming, docs",
-              },
-            ],
-          }
-        : null,
-    delegated: null,
-    untrackable: null,
-    scorecard: null,
-    firstReviewOnly: component?.firstReviewOnly === true,
-    // No scopeKey — useRubricForSlot also runs without one, so both
-    // row and modal compute the same rubricHash and share verdicts.
-    // See the rationale in scorecard-widget.jsx#useRubricForSlot.
-    classifiedAt: parentSpec?.classifiedAt || Date.now(),
-  };
-}
-
-function prettyWidget(widget) {
-  if (typeof widget !== "string") return "";
-  return widget
-    .toLowerCase()
-    .split("_")
-    .map((w) => w[0]?.toUpperCase() + w.slice(1))
-    .join(" ");
 }
 
 function truncate(s, max) {

--- a/apps/web/src/features/goal-widgets/widgets/scorecard-subspec.js
+++ b/apps/web/src/features/goal-widgets/widgets/scorecard-subspec.js
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * Build a full ValidatedSpec-shaped object from a SCORECARD component
+ * so the standalone widget Components + check-in editors can consume it
+ * uniformly.
+ *
+ * Why this exists
+ * ───────────────
+ * The SCORECARD widget keeps each sub-component as a compact
+ * `{widget, kind, label, source, manual, ...}` object — half a spec.
+ * Three surfaces want to render the full widget body for one of those
+ * sub-components:
+ *
+ *   1. The dashboard SCORECARD modal (`scorecard-component-modal.jsx`)
+ *   2. The check-in single-week editor (`goal-row.jsx`)
+ *   3. The check-in catch-up grid    (`grid-row.jsx` / `grid-page.jsx`)
+ *
+ * They all need the same synthetic spec → the same synthetic sub-goalId
+ * → the same goal-context seeding rules. Putting that in one helper
+ * avoids the bug class where the modal and the check-in derive
+ * subtly different sub-ids and the same component appears empty in
+ * one surface while populated in the other.
+ *
+ * Sub-goal id format
+ * ──────────────────
+ * `${parentGoalId}::sc${componentIndex}` — same convention the
+ * dashboard SCORECARD widget already uses for `useGoalInputs` and
+ * `useGradedPrs` scoping. Anything reading from `goal-inputs` or
+ * `goal-context` keyed on the synthetic id will see the same data
+ * the SCORECARD aggregate already sees.
+ */
+
+import { readContextFor, saveContextFor } from "@/features/goal-context";
+
+/**
+ * Translate a SCORECARD component into a full spec the regular widget
+ * Components / check-in editors expect.
+ *
+ * `parentSpec` carries the parent goal id + classification context;
+ * `component` is the entry from `parentSpec.scorecard.components[index]`;
+ * `index` is the slot index used to derive the synthetic sub-id.
+ */
+export function buildSubSpec(parentSpec, component, index) {
+  const subGoalId =
+    parentSpec?.goalId != null
+      ? `${parentSpec.goalId}::sc${index}`
+      : `scorecard-component-${index}`;
+  const widget = component?.widget || "MERGED_COUNT";
+  const title =
+    component?.label?.trim() || prettyWidget(widget) || "Component";
+
+  return {
+    schemaVersion: 1,
+    goalId: subGoalId,
+    title,
+    reasoning: "",
+    kind: component?.kind || "auto",
+    widget,
+    source: component?.source || null,
+    manual: component?.manual || null,
+    // CODE_RUBRIC needs `context.questions[*].id === "quality-standards"`
+    // for `resolveRubric(spec, answers)` to find the criteria. The
+    // criteria themselves live in the goal-context store under the
+    // synthetic sub-id (seeded by `seedRubricContextIfNeeded` below).
+    context:
+      widget === "CODE_RUBRIC"
+        ? {
+            required: true,
+            questions: [
+              {
+                id: "quality-standards",
+                prompt: "What are your code quality standards?",
+                kind: "list",
+                placeholder: "e.g. test coverage, naming, docs",
+              },
+            ],
+          }
+        : null,
+    delegated: null,
+    untrackable: null,
+    scorecard: null,
+    firstReviewOnly: component?.firstReviewOnly === true,
+    classifiedAt: parentSpec?.classifiedAt || Date.now(),
+  };
+}
+
+/**
+ * Idempotently seed `goal-context` for a CODE_RUBRIC sub-component
+ * from its `component.manual.items`. Mirrors the seed effect the
+ * SCORECARD modal already runs — pulled here so the check-in
+ * surfaces can guarantee the rubric isn't empty even if the user
+ * never opened the modal first.
+ *
+ * Returns true when something was seeded (caller can log), false
+ * when there was nothing to do (already seeded, not a rubric, no
+ * seed items).
+ */
+export function seedRubricContextIfNeeded(subGoalId, component) {
+  if (!subGoalId) return false;
+  if (component?.widget !== "CODE_RUBRIC") return false;
+  const existing = readContextFor(subGoalId);
+  const hasCriteria =
+    Array.isArray(existing?.["quality-standards"]) &&
+    existing["quality-standards"].length > 0;
+  if (hasCriteria) return false;
+  const seed = component?.manual?.items || [];
+  if (seed.length === 0) return false;
+  saveContextFor(subGoalId, { "quality-standards": seed });
+  return true;
+}
+
+/**
+ * Derive a goal-shaped object from a SCORECARD's parent goal +
+ * synthetic sub-spec. The sub-goal inherits dueDate / category /
+ * etc. from the parent so editors that read those fields don't see
+ * undefined.
+ */
+export function buildSubGoal(parentGoal, subSpec) {
+  return {
+    ...(parentGoal || {}),
+    id: subSpec.goalId,
+    title: subSpec.title,
+  };
+}
+
+function prettyWidget(widget) {
+  if (typeof widget !== "string") return "";
+  return widget
+    .toLowerCase()
+    .split("_")
+    .map((w) => w[0]?.toUpperCase() + w.slice(1))
+    .join(" ");
+}


### PR DESCRIPTION
## Summary

SCORECARDs were dead-ends in the check-in surfaces — both the single-week page and the catch-up grid showed an *"Edit components from the dashboard widget"* stub. So if a CODE_RUBRIC sub-component lived inside a SCORECARD (which it does for *"Productivity & Delivery Impact from Agentic Adoption"*), there was no way to grade past weeks from check-in at all. That's the gap the user hit.

Now both surfaces expand a SCORECARD into a parent banner + N child rows — one per `spec.scorecard.components[i]`. Each child renders the appropriate editor for its sub-widget kind via the existing dispatcher:

- CODE_RUBRIC sub-rows get the full per-week grading affordances (multi-select grid + 'Grade next' jumper + week dropdown)
- RECURRING_MILESTONE sub-rows get the checklist editor
- SCALE / COUNTER / INCIDENT_LOG / etc. — same.

### Shared synthetic-spec helper

To avoid duplicating spec-shaping logic across three surfaces (modal, single-week editor, catch-up grid), extracted these into a new module:

```
apps/web/src/features/goal-widgets/widgets/scorecard-subspec.js
  ├── buildSubSpec(parentSpec, component, index)      → full ValidatedSpec
  ├── buildSubGoal(parentGoal, subSpec)               → goal-shape with sub-id
  └── seedRubricContextIfNeeded(subGoalId, component) → idempotent seed
```

`buildSubSpec` previously lived inline in `scorecard-component-modal.jsx`. Now both the modal and the check-in import the shared helper — no more "modal seeded the rubric but the check-in sees an empty rubric" race.

### Sub-goal id format

`${parentGoalId}::sc${componentIndex}` — same convention the dashboard SCORECARD widget already uses for `useGoalInputs` and `useGradedPrs` scoping. Everything that reads from goal-inputs or goal-context keyed on the synthetic id sees the same data the SCORECARD aggregate sees.

### Responsiveness — recurring milestone widget

Defensive treatment for the headline + item rows:
- Headline gains `min-w-0 flex-wrap` so the pct + period text don't overflow when the tile is narrow.
- Item rows gain `min-w-0` + `shrink-0` on the checkbox so long item labels truncate cleanly instead of forcing horizontal overflow.

## Files

- `apps/web/src/features/goal-widgets/widgets/scorecard-subspec.js` (new)
- `apps/web/src/features/goal-widgets/widgets/scorecard-component-modal.jsx` — imports shared helper
- `apps/web/src/features/checkin/goal-row.jsx` — SCORECARD expansion in single-week editor
- `apps/web/src/features/checkin/grid-page.jsx` — SCORECARD expansion in catch-up grid (RowGroup)
- `apps/web/src/features/goal-widgets/widgets/recurring-milestone-widget.jsx` — responsiveness

## Test plan

- [ ] Open `/dev/checkin` (single-week). For a SCORECARD goal, you should see a *"scorecard · {goal title} · N components"* banner followed by one row per sub-component. Each row gets the correct editor (CODE_RUBRIC → analyze button, RECURRING → checklist popover, etc.).
- [ ] Open `/dev/checkin/grid` (catch-up grid). A SCORECARD goal renders a sticky banner row spanning the whole grid, then N child rows. Each child has its own week cells + trailing bulk column.
- [ ] For a SCORECARD with a CODE_RUBRIC component:
  - Open the grid for that goal. The CODE_RUBRIC sub-row should show per-week pass counts, checkboxes for multi-select, and `Next · Wnn` trailing button — all working.
  - Press a per-cell `Analyze` or the multi-select. Verdicts land. Reload the page. Verdicts persist (they're on the same `(prId, rubricHash)` cache the modal uses).
- [ ] Open a non-SCORECARD goal — should look identical to before (single row).
- [ ] Recurring milestone widget at narrow width (e.g. resize browser): headline pct + period label wrap nicely; item labels truncate without horizontal scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)