### PR TITLE
feat(review): per-component repo dropdown in SCORECARD editor

### DIFF
--- a/apps/web/src/features/analyst/review-pane.jsx
+++ b/apps/web/src/features/analyst/review-pane.jsx
@@ -565,6 +565,7 @@ function PendingCard({
       {isScorecard && !isUntrackable ? (
         <ScorecardEditor
           scorecard={spec.scorecard}
+          repoOptions={repoOptions}
           onChange={onChangeScorecard}
         />
       ) : null}
@@ -957,7 +958,7 @@ const SCORECARD_MIN_COMPONENTS = 2;
  * normalises by Σweights anyway, so adding a 4th 50-weight component
  * to two 50-weight ones just means each has weight 1/3 effectively.
  */
-function ScorecardEditor({ scorecard, onChange }) {
+function ScorecardEditor({ scorecard, repoOptions = [], onChange }) {
   const components = scorecard?.components || [];
 
   function setComponentAt(index, patch) {
@@ -1039,6 +1040,7 @@ function ScorecardEditor({ scorecard, onChange }) {
           key={i}
           index={i}
           component={c}
+          repoOptions={repoOptions}
           onPatch={(patch) => setComponentAt(i, patch)}
           onRemove={() => removeAt(i)}
           canRemove={components.length > SCORECARD_MIN_COMPONENTS}
@@ -1058,9 +1060,31 @@ function ScorecardEditor({ scorecard, onChange }) {
  * etc.). The user can refine source.window / cadence / target by
  * hand below.
  */
-function ComponentEditorRow({ index, component, onPatch, onRemove, canRemove }) {
+function ComponentEditorRow({
+  index,
+  component,
+  repoOptions = [],
+  onPatch,
+  onRemove,
+  canRemove,
+}) {
   const target =
     component?.source?.target || component?.manual?.target || null;
+  // Repo scoping is meaningful when the component reads from a code-host
+  // provider (GitHub / GitLab / combined / github_actions). Manual
+  // widgets (COUNTER, SCALE, …) and CODE_RUBRIC have no `source.filter`
+  // so the picker stays hidden for them.
+  const provider = component?.source?.provider;
+  const supportsRepoScope =
+    component?.kind === "auto" &&
+    (provider === "github" ||
+      provider === "gitlab" ||
+      provider === "combined" ||
+      provider === "github_actions");
+  const currentRepo = component?.source?.filter?.repo || null;
+  const onChangeRepo = (next) => {
+    onPatch({ source: patchFilter(component.source, "repo", next) });
+  };
 
   function setWidget(widget) {
     const meta = SPEC_KIND_META[widget];
@@ -1245,6 +1269,20 @@ function ComponentEditorRow({ index, component, onPatch, onRemove, canRemove }) 
           />
         </label>
       </div>
+      {/* Repo scope picker — only for AUTO components reading from a
+          code-host provider. Lets the user pin a FIRST_PASS_RATE
+          (or MERGED_COUNT / LINKAGE / TURNAROUND / etc.) component
+          to one specific repo, or leave it on "all repos" to count
+          across every connected repo. `source.filter.repo` already
+          exists in the spec schema and is honoured by useDataSource
+          before the metric is computed. */}
+      {supportsRepoScope ? (
+        <RepoPicker
+          value={currentRepo}
+          options={repoOptions}
+          onChange={onChangeRepo}
+        />
+      ) : null}
       {/* Phase F: rubric criteria + first-review toggle, only when
           this component is CODE_RUBRIC. The criteria live on the
           component's `manual.items` array (re-uses the existing


### PR DESCRIPTION
## Summary

The user spotted that SCORECARD components (FIRST_PASS_RATE × 3 in the screenshot) had no way to scope to a specific repo. All three components counted across every connected repo, so duplicating them was pointless.

Now each AUTO sub-component reading from a code-host provider (`github` / `gitlab` / `combined` / `github_actions`) gets the existing `<RepoPicker>` UI, right below the target row. Selecting a repo writes `component.source.filter.repo = "owner/name"`; selecting "All repos" clears the filter.

### Why this is a small change

The spec schema already supports per-component `source.filter.repo` (`packages/shared` validator, see report comment in PR description). And `useDataSource()` already applies the filter before computing the metric (`filterMrsByRepo(merged.data, repoFilter)` → `firstPassRatePct(filteredMerged)`). So this was a pure UI gap — no backend or data-flow changes.

### Implementation

- `ScorecardEditor` accepts a new `repoOptions` prop (passed in from `ReviewPane` which already derives it via `useCombinedMergedSince` + `listReposFromMrs`).
- `ComponentEditorRow` accepts `repoOptions` and renders `<RepoPicker>` only when the component is AUTO + code-host provider.
- The picker calls the existing `patchFilter(source, 'repo', slug)` helper — same code path the top-level RepoPicker already uses.
- Manual widgets (COUNTER / SCALE / RECURRING) and CODE_RUBRIC have no `source.filter.repo` so the picker stays hidden for them.

## Files

- `apps/web/src/features/analyst/review-pane.jsx` — 40 insertions, 2 deletions across 4 spots:
  - PendingCard `<ScorecardEditor>` invocation passes `repoOptions`
  - `ScorecardEditor` accepts + forwards `repoOptions`
  - `ComponentEditorRow` accepts `repoOptions` + computes `supportsRepoScope` + `currentRepo`
  - Inserts `<RepoPicker>` between the target row and the rubric editor

## Test plan

- [ ] Open Review pane for a SCORECARD goal. Each FIRST_PASS_RATE component should show a "Repo scope" picker below its target row.
- [ ] Set component 1 to repo A, component 2 to repo B, component 3 to "All repos". Save.
- [ ] Reload — each component's filter persists. The SCORECARD aggregate should now reflect three different scopes.
- [ ] MERGED_COUNT / LINKAGE / TURNAROUND components also get the picker (same provider list).
- [ ] CODE_RUBRIC sub-component does NOT show the picker (no `source.filter.repo`).
- [ ] Manual COUNTER / SCALE / RECURRING sub-components also don't show the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)