### PR TITLE
fix(docker): pre-wire extra_hosts for corporate VPN upstreams

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,31 @@ services:
       # so set MONGO_URI=mongodb://mongo:27017/devhub-dev in
       # .env.local if you want the local-mongo path.
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-https://espace-hubs.vercel.app,http://localhost:3000}
+    extra_hosts:
+      # `host.docker.internal` is the standard gateway-style hostname
+      # that lets the container reach the Docker host. Always
+      # available; harmless when unused.
+      - "host.docker.internal:host-gateway"
+      # Corporate hosts whose DNS only resolves via a VPN's internal
+      # resolver. The container's bridge network can't reach the
+      # corporate DNS (10.x.x.x) so `git.bcn.crealogix.net` fails to
+      # resolve with ENOTFOUND even though the host (on VPN) resolves
+      # it fine. Map the hostname directly to bypass DNS — the IP is
+      # stable for the life of the engagement (corporate internal
+      # infra doesn't load-balance), so a one-time mapping holds.
+      #
+      # Find the IP on the host:
+      #   ping git.bcn.crealogix.net   # output starts with the IP
+      #
+      # Then uncomment the matching line below and replace the IP.
+      # Symptom that means you need this: the dashboard surfaces
+      # `integration_unreachable: Network error reaching gitlab:
+      # fetch failed (ENOTFOUND)` while a `curl` from the host
+      # succeeds.
+      #
+      # - "git.bcn.crealogix.net:192.168.104.31"
+      # - "jira.bcn.crealogix.net:10.x.x.x"
+      # - "jenkins.bcn.crealogix.net:10.x.x.x"
     depends_on:
       mongo:
         condition: service_healthy
@@ -87,7 +112,9 @@ services:
     # Uncomment if your host's VPN client (e.g. corporate Cisco /
     # GlobalProtect) doesn't share routes with Docker's bridge —
     # network_mode: host bypasses Docker networking and uses the
-    # host's interfaces directly so VPN routes apply.
+    # host's interfaces directly so VPN routes apply. Most VPNs only
+    # need the extra_hosts mapping above; flip to host networking
+    # only when the container can resolve but can't reach the IP.
     # network_mode: "host"
 
   tunnel:

--- a/docs/RUN_LOCALLY.md
+++ b/docs/RUN_LOCALLY.md
@@ -146,19 +146,54 @@ DNS, works the same inside the container as outside.
 
 ### "Cannot reach git.bcn.crealogix.net from inside the container"
 
-The container shares the host's network via the default bridge
-driver — but some VPN clients (Cisco AnyConnect, GlobalProtect)
-don't push routes into the bridge. If the api inside Docker can't
-reach an upstream that the host CAN reach, edit
+Symptom: the dashboard surfaces
+`integration_unreachable: Network error reaching gitlab: fetch failed`
+(usually with `(ENOTFOUND)` in the cause) while a `curl` to the same
+URL from the host succeeds. The container's DNS resolver can't
+reach the corporate DNS server (typically `10.x.x.x` served by your
+VPN client).
+
+#### Fix 1 — map the hostname directly (preferred)
+
+Find the IP on the VPN-connected host:
+
+```bash
+ping git.bcn.crealogix.net          # Windows shows IP in output
+# or
+Resolve-DnsName git.bcn.crealogix.net   # PowerShell
+```
+
+`docker-compose.yml` has commented-out `extra_hosts` entries for
+the common engagement targets. Uncomment + paste the IP:
+
+```yaml
+api:
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+    - "git.bcn.crealogix.net:192.168.104.31"     # uncomment + your IP
+    # - "jira.bcn.crealogix.net:10.x.x.x"
+    # - "jenkins.bcn.crealogix.net:10.x.x.x"
+```
+
+Then `docker compose down && docker compose up -d`. Corporate-internal
+IPs are static for the life of the engagement (no cloud load-balancing
+on internal infra); if IT ever migrates the host, just update the IP.
+
+#### Fix 2 — host networking (fallback)
+
+If the container can resolve but still can't reach the IP (some VPN
+split-tunnel configs don't share routes with Docker's bridge), edit
 `docker-compose.yml`:
 
 ```yaml
 api:
-  network_mode: "host"    # uncomment this; remove `ports:` (no needed)
+  network_mode: "host"    # uncomment this; remove `ports:` (not needed)
 ```
 
 This makes the container share the host's loopback + interfaces
-directly, so VPN routes apply unchanged.
+directly, so VPN routes apply unchanged. Has limitations on
+Docker Desktop Windows with WSL2 — works best on Docker Engine
+running on a Linux host that's directly on the VPN.
 
 ### Tunnel won't start: "TUNNEL_TOKEN required"
 


### PR DESCRIPTION
## Summary

User reported the dashboard surfacing
\`integration_unreachable: Network error reaching gitlab: fetch failed\`
for the Crealogix GitLab while a \`curl\` from the VPN-connected host succeeded.

Diagnostic confirmed:
- Host (VPN-connected): \`curl https://git.bcn.crealogix.net\` → 302 OK
- Container DNS: \`EAI_AGAIN\` / \`ENOTFOUND\`
- Container fetch: \`ENOTFOUND\`

### Root cause

Docker's default bridge network can't reach the corporate DNS server (10.x.x.x, served by FortiClient). The Windows host's resolver knows \`git.bcn.crealogix.net\` through the VPN adapter, but that DNS path doesn't propagate into Docker's bridge.

### Fix

\`docker-compose.yml\`'s \`api\` service now has commented-out \`extra_hosts\` entries for the common corporate upstreams (\`git/jira/jenkins.bcn.crealogix.net\`). The Crealogix user finds the IP via \`ping <hostname>\` on the VPN-connected host (192.168.104.31 in the reporter's case), uncomments the matching line, restarts compose. The IP is stable for the life of the engagement (no cloud load-balancing on corporate internal infra), so this is a one-time setup.

\`host.docker.internal:host-gateway\` is added unconditionally — it's the standard gateway hostname, always available, harmless when unused.

\`docs/RUN_LOCALLY.md\`'s troubleshooting section was rewritten to cover this as Fix 1 (the new YAML pattern) and \`network_mode: host\` as Fix 2 (fallback for VPN split-tunnel configs that don't share routes with the bridge).

## Files

- \`docker-compose.yml\` — \`extra_hosts:\` block + comments
- \`docs/RUN_LOCALLY.md\` — troubleshooting section rewritten

## Test plan

- [ ] \`docker compose config --quiet\` exits 0 (YAML valid).
- [ ] \`docker compose up -d\` with the entries still commented out → API container starts normally, eSpace integration (gitlab.espace.ws on public DNS) still works.
- [ ] Uncomment the Crealogix line with the real IP → \`docker exec espace-devhub-api node -e \"fetch('https://git.bcn.crealogix.net/api/v4/version').then(r => console.log(r.status))\"\` returns 200/401 (DNS+routing both work).
- [ ] Reported dashboard error gone — GitLab tiles start loading their data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)