### PR TITLE
fix(proxy): bound upstream fetch + raise Vercel maxDuration

### DIFF
--- a/apps/api/src/modules/integrations/proxy.ts
+++ b/apps/api/src/modules/integrations/proxy.ts
@@ -346,14 +346,57 @@ async function runProxy(
       body = JSON.stringify(req.body ?? {});
     }
 
+    // Bound the upstream call so a slow self-hosted GitLab / Jira
+    // doesn't sit on the connection until Vercel's function timeout
+    // kills the whole chain (which produces a bare 502 with no body).
+    // 45s gives headroom for genuinely slow corporate boxes while
+    // staying under the typical 60s Vercel maxDuration so the abort
+    // happens with a clean 504 surface before Vercel intervenes.
+    const FETCH_TIMEOUT_MS = 45_000;
+    const abortController = new AbortController();
+    const timeoutHandle = setTimeout(
+      () => abortController.abort(),
+      FETCH_TIMEOUT_MS,
+    );
     let upstream;
     try {
       upstream = await fetch(targetUrl, {
         method: req.method,
         headers: upstreamHeaders,
+        signal: abortController.signal,
         ...(body !== undefined ? { body } : {}),
       });
     } catch (err) {
+      // Differentiate timeout aborts from generic network failures so
+      // the UI can suggest a smaller time window instead of "check
+      // your token / VPN".
+      const aborted =
+        err instanceof Error &&
+        (err.name === "AbortError" ||
+          (err as { cause?: { name?: string } }).cause?.name ===
+            "AbortError");
+      if (aborted) {
+        logger.warn(
+          {
+            providerId: ctx.providerId,
+            targetUrl,
+            reqId: req.id,
+            timeoutMs: FETCH_TIMEOUT_MS,
+          },
+          "[proxy] upstream fetch timed out",
+        );
+        void markIntegrationError({
+          orgId: session.orgId,
+          userId: session.userId,
+          providerId: ctx.providerId,
+          message: `Timeout after ${FETCH_TIMEOUT_MS / 1000}s`,
+        });
+        throw new HttpError(
+          504,
+          "integration_timeout",
+          `Upstream ${ctx.providerId} took longer than ${FETCH_TIMEOUT_MS / 1000}s to respond. Try a shorter time window or check upstream availability.`,
+        );
+      }
       // Node's undici-backed fetch throws a generic `TypeError: fetch
       // failed` for every network-layer failure — the actual cause
       // (ENOTFOUND, ECONNREFUSED, UND_ERR_CONNECT_TIMEOUT, TLS chain
@@ -394,6 +437,8 @@ async function runProxy(
         "integration_unreachable",
         `Network error reaching ${ctx.providerId}: ${detail}`,
       );
+    } finally {
+      clearTimeout(timeoutHandle);
     }
 
     // Allowlist response headers — drop everything else.

--- a/apps/web/src/pages/api/v1/[...path].ts
+++ b/apps/web/src/pages/api/v1/[...path].ts
@@ -245,6 +245,16 @@ export const config = {
     responseLimit: false,
     externalResolver: true,
   },
+  // Lift the function-execution cap to 60s (Pro/Enterprise) so slow
+  // upstream integrations — Crealogix's self-hosted GitLab takes
+  // ~20–40s to scan a 60-day `updated_after` window for heavy
+  // authors — finish inside the function lifetime instead of getting
+  // killed mid-flight and returning an empty 502. Hobby plans cap at
+  // 10s regardless of this setting; on Pro it's honoured up to 60s,
+  // and Enterprise up to 900s. The companion-side proxy.ts now
+  // aborts its own fetch at 45s with a 504 `integration_timeout`
+  // so the user sees a clear error rather than a bare 502.
+  maxDuration: 60,
 };
 
 /**


### PR DESCRIPTION
## Summary

User reported sporadic 502s on the same GitLab endpoint when the \`updated_after\` window stretched back 2 months — recent windows succeeded, longer ones failed. Crealogix's self-hosted GitLab takes ~20–40s to scan a 60-day window for heavy authors. Two points in the chain were eating those slow responses without surfacing a useful error.

### Two bugs, two fixes

**1. Vercel function timeout — empty 502s.** The catch-all had no \`maxDuration\` set, inheriting the platform default (10s on Hobby, 60s on Pro only when opted in). A slow GitLab scan blew past that and Vercel killed the function mid-flight with no body. Added \`maxDuration: 60\` so Pro plans honour the longer window.

**2. Companion proxy hang — no timeout.** \`apps/api/src/modules/integrations/proxy.ts\` called \`fetch()\` with no signal. If GitLab took 30s+, the fetch sat there until the outer Vercel function got killed. Wrapped the fetch in an AbortController with 45s timeout (under the 60s function cap, so the abort surfaces a clean envelope before Vercel intervenes):

- AbortError → \`HttpError(504, "integration_timeout", "...try a shorter time window or check upstream availability.")\`
- Other network errors → unchanged \`502 integration_unreachable\`
- Detection covers both \`err.name === "AbortError"\` and \`err.cause?.name === "AbortError"\` because undici sometimes nests the abort signal.

The timer is cleared in a \`finally\` so successful fetches don't leak.

## Files

- \`apps/web/src/pages/api/v1/[...path].ts\` — \`maxDuration: 60\` in the config
- \`apps/api/src/modules/integrations/proxy.ts\` — AbortController + 504 timeout envelope

## Test plan

- [ ] Trigger a slow GitLab call (e.g. heatmap with 90-day window). Expect either a successful response inside 45s OR a clean 504 with \`code: "integration_timeout"\` after 45s.
- [ ] Fast calls still succeed without observable change.
- [ ] DNS / connect-refused errors still surface \`502 integration_unreachable\` with the underlying cause (no regression on PR #122's error surfacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)