### PR TITLE
feat(evidence): backend API + API-direct frontend store (C3)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -36,6 +36,7 @@ import { goalContextRouter } from "./modules/goal-context/routes.js";
 import { goalInputsRouter } from "./modules/goal-inputs/routes.js";
 import { snapshotsRouter } from "./modules/snapshots/routes.js";
 import { gradingVerdictsRouter } from "./modules/grading-verdicts/routes.js";
+import { evidenceRouter } from "./modules/evidence/routes.js";
 import { integrationsRouter } from "./modules/integrations/routes.js";
 import { migrateRouter } from "./modules/migrate/routes.js";
 import { hubsRouter } from "./modules/hubs/routes.js";
@@ -130,6 +131,7 @@ export function buildApp(): Application {
   app.use("/api/v1/goal-inputs", goalInputsRouter);
   app.use("/api/v1/snapshots", snapshotsRouter);
   app.use("/api/v1/grading-verdicts", gradingVerdictsRouter);
+  app.use("/api/v1/evidence", evidenceRouter);
   app.use("/api/v1/integrations", integrationsRouter);
   app.use("/api/v1/migrate", migrateRouter);
   app.use("/api/v1/hubs", hubsRouter);

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -21,6 +21,7 @@ import type {
   AuthToken,
   CompanionDevice,
   CompanionPairing,
+  EvidenceItem,
   GoalContextDoc,
   GoalInputEntry,
   GoalSpecRecord,
@@ -100,6 +101,13 @@ export async function getGradingVerdictsCollection(): Promise<
 > {
   const db = await getDb();
   return db.collection<GradingVerdict>("grading_verdicts");
+}
+
+export async function getEvidenceCollection(): Promise<
+  Collection<EvidenceItem>
+> {
+  const db = await getDb();
+  return db.collection<EvidenceItem>("evidence");
 }
 
 export async function getIntegrationsCollection(): Promise<
@@ -357,6 +365,24 @@ async function ensureIndexes(): Promise<void> {
       key: { gradedAt: 1 },
       expireAfterSeconds: 15_552_000,
       name: "grading_verdicts_ttl",
+    },
+  ]);
+
+  const evidence = await getEvidenceCollection();
+  await evidence.createIndexes([
+    {
+      // One row per (orgId, userId, id). Re-starring the same artifact
+      // upserts the existing row (refreshing title / impact / date)
+      // rather than creating a duplicate.
+      key: { orgId: 1, userId: 1, id: 1 },
+      unique: true,
+      name: "evidence_org_user_id_uniq",
+    },
+    {
+      // "Show me what I starred recently" — the evidence page loads
+      // newest-first by starredAt.
+      key: { orgId: 1, userId: 1, starredAt: -1 },
+      name: "evidence_org_user_starred",
     },
   ]);
 

--- a/apps/api/src/db/schemas/evidence.schema.ts
+++ b/apps/api/src/db/schemas/evidence.schema.ts
@@ -1,0 +1,46 @@
+/**
+ * evidence collection — Mongo $jsonSchema validator.
+ *
+ * One document per (orgId, userId, id) — the user's curated artifact
+ * list for their review export. Manual-only; no auto-star path.
+ *
+ * `impact` defaults to an empty string at the controller level so a
+ * row that was starred without a note still satisfies the
+ * required-field check here.
+ */
+
+import type { Document } from "mongodb";
+import { ALL_EVIDENCE_KINDS } from "../types.js";
+
+export const evidenceValidator: Document = {
+  $jsonSchema: {
+    bsonType: "object",
+    required: [
+      "orgId",
+      "userId",
+      "id",
+      "kind",
+      "ref",
+      "title",
+      "date",
+      "impact",
+      "starredAt",
+    ],
+    additionalProperties: false,
+    properties: {
+      _id: { bsonType: "objectId" },
+      orgId: { bsonType: "objectId" },
+      userId: { bsonType: "objectId" },
+      // Stable artifact id. Upper bound is generous — Jira keys can
+      // be long ("PROJECTNAME-99999") and merged-pr / review ids are
+      // already prefixed.
+      id: { bsonType: "string", minLength: 1, maxLength: 256 },
+      kind: { enum: [...ALL_EVIDENCE_KINDS] },
+      ref: { bsonType: "string", maxLength: 256 },
+      title: { bsonType: "string", maxLength: 1_000 },
+      date: { bsonType: "string", maxLength: 64 },
+      impact: { bsonType: "string", maxLength: 4_000 },
+      starredAt: { bsonType: "date" },
+    },
+  },
+};

--- a/apps/api/src/db/schemas/index.ts
+++ b/apps/api/src/db/schemas/index.ts
@@ -15,6 +15,7 @@ import { goalContextValidator } from "./goal-context.schema.js";
 import { goalInputsValidator } from "./goal-inputs.schema.js";
 import { snapshotsValidator } from "./snapshots.schema.js";
 import { gradingVerdictsValidator } from "./grading-verdicts.schema.js";
+import { evidenceValidator } from "./evidence.schema.js";
 import { integrationsValidator } from "./integrations.schema.js";
 import { hubConfigsValidator } from "./hub-configs.schema.js";
 import { companionDevicesValidator } from "./companion-devices.schema.js";
@@ -38,6 +39,7 @@ export const COLLECTION_DEFS: readonly CollectionDef[] = [
   { name: "goal_inputs", validator: goalInputsValidator },
   { name: "snapshots", validator: snapshotsValidator },
   { name: "grading_verdicts", validator: gradingVerdictsValidator },
+  { name: "evidence", validator: evidenceValidator },
   { name: "integrations", validator: integrationsValidator },
   { name: "hub_configs", validator: hubConfigsValidator },
   { name: "companion_devices", validator: companionDevicesValidator },

--- a/apps/api/src/db/types.ts
+++ b/apps/api/src/db/types.ts
@@ -564,6 +564,43 @@ export interface GradingVerdict {
   provider: string | null;
 }
 
+// ─── evidence (user-starred review artifacts) ───────────────────────
+
+/**
+ * One row per artifact the user explicitly starred for their review
+ * export. Per-user scoped; an artifact (PR / ticket) starred by user A
+ * is invisible to user B even within the same org. Typical scale: 5–20
+ * items per user per review cycle.
+ *
+ * `id` is the artifact's stable identifier — usually the upstream
+ * provider's primary key prefixed with the kind:
+ *   "mr-12345"     (GitHub PR / GitLab MR)
+ *   "ticket-PROJ-42" (Jira ticket)
+ *   "review-…"     (review comment cluster)
+ * The unique (orgId, userId, id) index dedupes re-stars.
+ */
+
+export const ALL_EVIDENCE_KINDS = ["merged-pr", "ticket", "review"] as const;
+export type EvidenceKind = (typeof ALL_EVIDENCE_KINDS)[number];
+
+export interface EvidenceItem {
+  _id: ObjectId;
+  orgId: ObjectId;
+  userId: ObjectId;
+  /** Stable artifact id — see header doc for format. */
+  id: string;
+  kind: EvidenceKind;
+  /** Display ref shown in the UI ("!456", "PROJ-42"). */
+  ref: string;
+  /** Human-readable title from the upstream artifact. */
+  title: string;
+  /** Display date string (already pre-formatted by the frontend). */
+  date: string;
+  /** Optional user-written impact note. Empty string when unused. */
+  impact: string;
+  starredAt: Date;
+}
+
 // ─── integrations (per-user provider tokens) ────────────────────────
 
 /**

--- a/apps/api/src/modules/evidence/controller.ts
+++ b/apps/api/src/modules/evidence/controller.ts
@@ -1,0 +1,254 @@
+/**
+ * Evidence controller — list / upsert / patch / delete user-starred
+ * artifacts for the review export.
+ *
+ * Scope: per-user. Items are visible only to the user who starred
+ * them, even within the same org. There's no shared "team evidence"
+ * collection at this layer.
+ *
+ * Upsert semantics: POST always refreshes title / ref / date / impact
+ * on re-star. This matches the frontend's toggle behaviour — re-clicking
+ * the same artifact in the picker after its title was edited upstream
+ * will show the new title. To remove, the frontend issues DELETE
+ * /:id rather than another POST with a "remove" flag.
+ */
+
+import type { NextFunction, Request, Response } from "express";
+import { z } from "zod";
+import { getEvidenceCollection } from "../../db/collections.js";
+import type { EvidenceItem, EvidenceKind } from "../../db/types.js";
+import { ALL_EVIDENCE_KINDS } from "../../db/types.js";
+import { networkMeta, writeAudit } from "../../lib/audit.js";
+import { HttpError } from "../../middleware/error-handler.js";
+
+// ─── schemas ─────────────────────────────────────────────────────────
+
+const evidenceItemKindSchema = z.enum(
+  ALL_EVIDENCE_KINDS as unknown as [EvidenceKind, ...EvidenceKind[]],
+);
+
+const upsertSchema = z.object({
+  id: z.string().min(1).max(256),
+  kind: evidenceItemKindSchema,
+  ref: z.string().max(256).default(""),
+  title: z.string().max(1_000).default(""),
+  date: z.string().max(64).default(""),
+  impact: z.string().max(4_000).default(""),
+});
+
+const patchSchema = z.object({
+  impact: z.string().max(4_000),
+});
+
+const listQuerySchema = z.object({
+  // Practical upper bound — typical scale is 5–20 items / user.
+  limit: z.coerce.number().int().min(1).max(500).default(200),
+});
+
+// ─── shape helpers ───────────────────────────────────────────────────
+
+interface PublicEvidence {
+  id: string;
+  kind: EvidenceKind;
+  ref: string;
+  title: string;
+  date: string;
+  impact: string;
+  starredAt: string;
+}
+
+function toPublic(e: EvidenceItem): PublicEvidence {
+  return {
+    id: e.id,
+    kind: e.kind,
+    ref: e.ref,
+    title: e.title,
+    date: e.date,
+    impact: e.impact,
+    starredAt: e.starredAt.toISOString(),
+  };
+}
+
+function idParam(req: Request): string {
+  const { id } = req.params;
+  if (typeof id !== "string" || id.length === 0 || id.length > 256) {
+    throw new HttpError(400, "validation_error", "Invalid evidence id.");
+  }
+  return id;
+}
+
+// ─── GET /api/v1/evidence ────────────────────────────────────────────
+
+export async function listEvidenceHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const { limit } = listQuerySchema.parse(req.query);
+    const col = await getEvidenceCollection();
+    const items = await col
+      .find({ orgId: session.orgId, userId: session.userId })
+      .sort({ starredAt: -1 })
+      .limit(limit)
+      .toArray();
+    res.json({ items: items.map(toPublic) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── POST /api/v1/evidence ───────────────────────────────────────────
+
+/**
+ * Upsert by `id`. Re-starring the same artifact refreshes the
+ * cosmetic fields (title / ref / date) so a renamed PR shows its
+ * latest title on next sync. `impact` is preserved through re-stars
+ * — only PATCH and the user's manual edits change it.
+ */
+export async function upsertEvidenceHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const payload = upsertSchema.parse(req.body);
+    const now = new Date();
+    const col = await getEvidenceCollection();
+    const result = await col.findOneAndUpdate(
+      {
+        orgId: session.orgId,
+        userId: session.userId,
+        id: payload.id,
+      },
+      {
+        $set: {
+          kind: payload.kind,
+          ref: payload.ref,
+          title: payload.title,
+          date: payload.date,
+          // Preserve impact across re-stars: only update if the
+          // caller explicitly sent a non-empty value. The frontend's
+          // toggleEvidence path sends impact:"" when starring fresh,
+          // which would otherwise clobber a prior impact note. We
+          // detect "non-empty" rather than "present" because z.string()
+          // doesn't distinguish "" from missing.
+          ...(payload.impact ? { impact: payload.impact } : {}),
+        },
+        $setOnInsert: {
+          orgId: session.orgId,
+          userId: session.userId,
+          id: payload.id,
+          impact: payload.impact,
+          starredAt: now,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+    if (!result) {
+      throw new HttpError(500, "internal_error", "Evidence upsert failed.");
+    }
+    await writeAudit({
+      orgId: session.orgId,
+      actorUserId: session.userId,
+      actorRole: session.role,
+      action: "evidence.star",
+      targetType: "evidence",
+      targetId: payload.id,
+      after: { kind: payload.kind },
+      ...networkMeta(req),
+    });
+    res.json({ item: toPublic(result) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── PATCH /api/v1/evidence/:id ──────────────────────────────────────
+
+export async function patchEvidenceHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const id = idParam(req);
+    const { impact } = patchSchema.parse(req.body);
+    const col = await getEvidenceCollection();
+    const result = await col.findOneAndUpdate(
+      {
+        orgId: session.orgId,
+        userId: session.userId,
+        id,
+      },
+      { $set: { impact } },
+      { returnDocument: "after" },
+    );
+    if (!result) {
+      throw new HttpError(404, "not_found", "Evidence item not found.");
+    }
+    await writeAudit({
+      orgId: session.orgId,
+      actorUserId: session.userId,
+      actorRole: session.role,
+      action: "evidence.patch",
+      targetType: "evidence",
+      targetId: id,
+      ...networkMeta(req),
+    });
+    res.json({ item: toPublic(result) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── DELETE /api/v1/evidence/:id ─────────────────────────────────────
+
+export async function deleteEvidenceHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const id = idParam(req);
+    const col = await getEvidenceCollection();
+    const result = await col.deleteOne({
+      orgId: session.orgId,
+      userId: session.userId,
+      id,
+    });
+    if (result.deletedCount === 0) {
+      // 404 is more useful than 200 here — the frontend can confirm
+      // whether the unstar actually removed something.
+      throw new HttpError(404, "not_found", "Evidence item not found.");
+    }
+    await writeAudit({
+      orgId: session.orgId,
+      actorUserId: session.userId,
+      actorRole: session.role,
+      action: "evidence.unstar",
+      targetType: "evidence",
+      targetId: id,
+      ...networkMeta(req),
+    });
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/apps/api/src/modules/evidence/routes.ts
+++ b/apps/api/src/modules/evidence/routes.ts
@@ -1,0 +1,24 @@
+/**
+ * /api/v1/evidence/* router.
+ *
+ *   GET     /         authed — list user's starred items (newest-first)
+ *   POST    /         authed — upsert by `id` (toggle on / refresh)
+ *   PATCH   /:id      authed — update impact note
+ *   DELETE  /:id      authed — toggle off
+ */
+
+import { Router } from "express";
+import { requireAuth } from "../../middleware/require-auth.js";
+import {
+  deleteEvidenceHandler,
+  listEvidenceHandler,
+  patchEvidenceHandler,
+  upsertEvidenceHandler,
+} from "./controller.js";
+
+export const evidenceRouter: Router = Router();
+
+evidenceRouter.get("/", requireAuth(), listEvidenceHandler);
+evidenceRouter.post("/", requireAuth(), upsertEvidenceHandler);
+evidenceRouter.patch("/:id", requireAuth(), patchEvidenceHandler);
+evidenceRouter.delete("/:id", requireAuth(), deleteEvidenceHandler);

--- a/apps/web/src/features/evidence/evidence-store.js
+++ b/apps/web/src/features/evidence/evidence-store.js
@@ -1,40 +1,298 @@
+"use client";
+
 /**
- * localStorage-backed evidence store: what the user has starred as
- * "this is what I want in my next review export".
+ * In-memory + API-backed evidence store.
  *
- * Items have shape:
+ * Holds the user's manually-starred review artifacts (merged PRs,
+ * Jira tickets, review-comment clusters). Items have shape:
+ *
  *   { id, kind: "merged-pr" | "ticket" | "review", ref, title, date, impact? }
+ *
+ * History
+ * ───────
+ * This replaces the prior localStorage-only store. There was no
+ * mirror layer to begin with — evidence was purely client-side until
+ * this migration. The backend collection lives under `evidence` with
+ * the routes at `/api/v1/evidence/*`.
+ *
+ * Same API-direct pattern as goals (C1), grading (C4), and
+ * snapshots (C2): module-level state, useSyncExternalStore-friendly
+ * snapshot, optimistic mutations with rollback on API failure, reset
+ * on `auth:user-storage-cleared` so the next user's mount triggers a
+ * fresh fetch.
  */
 
-const STORAGE_KEY = "espace-devhub:evidence";
+import { apiDelete, apiGet, apiPatch, apiPost } from "@/lib/api-client";
+
 const CHANGE_EVENT = "evidence:change";
 
-export function readStarred() {
-  if (typeof window === "undefined") return [];
-  try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
-  } catch {
-    return [];
-  }
+export const EVIDENCE_CHANGE_EVENT = CHANGE_EVENT;
+
+/* ─────────────────────── state ─────────────────────── */
+
+const INITIAL_STATE = Object.freeze({
+  /** True while the initial `GET /evidence` is in flight. */
+  loading: false,
+  /** Whether the hydration GET has resolved for the active session. */
+  fetched: false,
+  /** Last fetch / write error envelope or null. */
+  error: null,
+  /** The starred items array — sorted newest-first by starredAt
+   *  (server returns this order, we preserve it). */
+  items: [],
+});
+
+let state = INITIAL_STATE;
+let inflightFetch = null;
+let snapshotTick = 0;
+
+function bumpSnapshot() {
+  snapshotTick += 1;
 }
 
-function writeAll(next) {
+function emit() {
   if (typeof window === "undefined") return;
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
   window.dispatchEvent(new Event(CHANGE_EVENT));
 }
 
+function setState(patch) {
+  state = { ...state, ...patch };
+  bumpSnapshot();
+  emit();
+}
+
+/** Read the current state synchronously. */
+export function getEvidenceState() {
+  return state;
+}
+
+/** Subscribe to state changes. Returns an unsubscribe. */
+export function subscribeEvidence(cb) {
+  if (typeof window === "undefined") return () => {};
+  const handler = () => cb();
+  window.addEventListener(CHANGE_EVENT, handler);
+  return () => window.removeEventListener(CHANGE_EVENT, handler);
+}
+
+/** Monotonic tick for useSyncExternalStore — increments whenever the
+ *  store changes. Consumers read the actual items via readStarred(). */
+export function getEvidenceSnapshot() {
+  return snapshotTick;
+}
+export function getEvidenceServerSnapshot() {
+  return 0;
+}
+
+/** Reset in-memory state. Called by the auth-transition listener. */
+export function resetEvidence() {
+  state = INITIAL_STATE;
+  inflightFetch = null;
+  bumpSnapshot();
+  emit();
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("auth:user-storage-cleared", resetEvidence);
+}
+
+/* ─────────────────────── reads ─────────────────────── */
+
+/** Synchronous read. Returns the in-memory starred-items array.
+ *  Empty before hydration completes — pair with useStarredEvidence()
+ *  to drive the fetch. */
+export function readStarred() {
+  return state.items;
+}
+
+/* ─────────────────────── hydration ─────────────────────── */
+
+/**
+ * Idempotent — concurrent callers share the in-flight promise.
+ * Empty-server case replaces in-memory state with `[]` so a fresh
+ * sign-in never inherits the prior user's items (same cross-user-leak
+ * guard goals-store + snapshots-store apply).
+ */
+export async function fetchEvidence() {
+  if (inflightFetch) return inflightFetch;
+  setState({ loading: true, error: null });
+  inflightFetch = (async () => {
+    const r = await apiGet("/evidence?limit=500");
+    inflightFetch = null;
+    if (!r.ok) {
+      const isAuth =
+        r.error?.code === "unauthenticated" ||
+        r.error?.code === "totp_required";
+      setState({ loading: false, error: isAuth ? null : r.error });
+      return state.items;
+    }
+    const incoming = Array.isArray(r.data?.items) ? r.data.items : [];
+    const normalized = incoming.map(toLocal).filter(Boolean);
+    setState({
+      loading: false,
+      fetched: true,
+      error: null,
+      items: normalized,
+    });
+    return normalized;
+  })();
+  return inflightFetch;
+}
+
+/* ─────────────────────── writes ─────────────────────── */
+
+/**
+ * Add an item to the starred list. The frontend's existing
+ * `toggleEvidence` (in `use-evidence.js`) decides whether to call
+ * this or `unstarEvidence` based on current state; this function
+ * unconditionally adds / refreshes.
+ *
+ * Optimistic: the new item appears at the top of the local list
+ * immediately. The server's response replaces the optimistic row
+ * with the canonical version (sets starredAt to the server's clock).
+ */
+export async function starEvidence(item) {
+  if (!item || !item.id) return;
+  const prev = state.items;
+  // Optimistic: replace any existing entry with same id, prepend new.
+  const optimisticItem = {
+    id: item.id,
+    kind: item.kind || "merged-pr",
+    ref: item.ref ?? "",
+    title: item.title ?? "",
+    date: item.date ?? "",
+    impact: item.impact ?? "",
+    starredAt: new Date().toISOString(),
+  };
+  const optimistic = [
+    optimisticItem,
+    ...prev.filter((x) => x.id !== item.id),
+  ];
+  setState({ items: optimistic, error: null });
+
+  const r = await apiPost("/evidence", {
+    id: optimisticItem.id,
+    kind: optimisticItem.kind,
+    ref: optimisticItem.ref,
+    title: optimisticItem.title,
+    date: optimisticItem.date,
+    impact: optimisticItem.impact,
+  });
+  if (r.ok) {
+    const serverItem = toLocal(r.data?.item);
+    if (serverItem) {
+      const reconciled = [
+        serverItem,
+        ...state.items.filter((x) => x.id !== serverItem.id),
+      ];
+      setState({ items: reconciled });
+    }
+    return;
+  }
+  if (
+    r.error?.code === "unauthenticated" ||
+    r.error?.code === "totp_required"
+  ) {
+    return;
+  }
+  // Rollback.
+  setState({ items: prev, error: r.error });
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[evidence] star failed:",
+    r.error?.code,
+    r.error?.message,
+  );
+}
+
+/**
+ * Remove an item from the starred list.
+ *
+ * Optimistic: the item disappears immediately. On API failure we
+ * roll back. A 404 means the server already didn't have it — that's
+ * a "success" outcome (server agrees the item is gone) so we keep
+ * the optimistic removal.
+ */
+export async function unstarEvidence(id) {
+  if (!id) return;
+  const prev = state.items;
+  const optimistic = prev.filter((x) => x.id !== id);
+  setState({ items: optimistic, error: null });
+  const r = await apiDelete(`/evidence/${encodeURIComponent(id)}`);
+  if (r.ok) return;
+  // 404 == server already has it removed → keep optimistic state.
+  if (r.error?.code === "not_found" || r.status === 404) return;
+  if (
+    r.error?.code === "unauthenticated" ||
+    r.error?.code === "totp_required"
+  ) {
+    return;
+  }
+  setState({ items: prev, error: r.error });
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[evidence] unstar failed:",
+    r.error?.code,
+    r.error?.message,
+  );
+}
+
+/**
+ * Toggle — adds if absent, removes if present. Backwards-compat
+ * shim for the existing `toggleStar` / `toggleEvidence` callers.
+ */
 export function toggleStar(item) {
-  const all = readStarred();
-  const exists = all.find((x) => x.id === item.id);
-  const next = exists ? all.filter((x) => x.id !== item.id) : [...all, item];
-  writeAll(next);
+  if (!item || !item.id) return;
+  const exists = state.items.find((x) => x.id === item.id);
+  if (exists) {
+    void unstarEvidence(item.id);
+  } else {
+    void starEvidence(item);
+  }
 }
 
-export function setImpact(id, impact) {
-  const all = readStarred();
-  const next = all.map((x) => (x.id === id ? { ...x, impact } : x));
-  writeAll(next);
+/**
+ * Patch the impact note on an existing starred item. Optimistic
+ * with rollback on failure.
+ */
+export async function setImpact(id, impact) {
+  if (!id) return;
+  const prev = state.items;
+  const optimistic = prev.map((x) =>
+    x.id === id ? { ...x, impact } : x,
+  );
+  setState({ items: optimistic, error: null });
+  const r = await apiPatch(`/evidence/${encodeURIComponent(id)}`, {
+    impact,
+  });
+  if (r.ok) return;
+  if (
+    r.error?.code === "unauthenticated" ||
+    r.error?.code === "totp_required"
+  ) {
+    return;
+  }
+  setState({ items: prev, error: r.error });
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[evidence] patch impact failed:",
+    r.error?.code,
+    r.error?.message,
+  );
 }
 
-export const EVIDENCE_CHANGE_EVENT = CHANGE_EVENT;
+/* ─────────────────────── helpers ─────────────────────── */
+
+/** Map API row → local-store shape. Returns null on a malformed row. */
+function toLocal(s) {
+  if (!s || typeof s !== "object") return null;
+  return {
+    id: typeof s.id === "string" ? s.id : "",
+    kind: s.kind || "merged-pr",
+    ref: typeof s.ref === "string" ? s.ref : "",
+    title: typeof s.title === "string" ? s.title : "",
+    date: typeof s.date === "string" ? s.date : "",
+    impact: typeof s.impact === "string" ? s.impact : "",
+    starredAt:
+      typeof s.starredAt === "string" ? s.starredAt : null,
+  };
+}

--- a/apps/web/src/features/evidence/use-evidence.js
+++ b/apps/web/src/features/evidence/use-evidence.js
@@ -1,37 +1,42 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import {
-  EVIDENCE_CHANGE_EVENT,
+  fetchEvidence,
+  getEvidenceServerSnapshot,
+  getEvidenceSnapshot,
+  getEvidenceState,
   readStarred,
-  toggleStar as storeToggle,
+  subscribeEvidence,
+  toggleStar,
 } from "./evidence-store";
+import { useSession } from "@/features/auth";
 import {
   useCombinedMergedSince,
   useJiraTickets,
 } from "@/features/integrations";
 import { isoDaysAgo } from "@/lib/date";
 
-function subscribe(callback) {
-  if (typeof window === "undefined") return () => {};
-  const handler = () => callback();
-  window.addEventListener(EVIDENCE_CHANGE_EVENT, handler);
-  window.addEventListener("storage", handler);
-  return () => {
-    window.removeEventListener(EVIDENCE_CHANGE_EVENT, handler);
-    window.removeEventListener("storage", handler);
-  };
-}
-function getSnapshot() {
-  return JSON.stringify(readStarred());
-}
-function getServerSnapshot() {
-  return "[]";
-}
-
+/**
+ * Subscribe to the in-memory evidence store + trigger a one-shot
+ * hydration on first mount per session. Same pattern as
+ * useSnapshots / useGradedPrs — idempotent fetch, in-flight promise
+ * is shared across concurrent consumers.
+ */
 export function useStarredEvidence() {
-  const raw = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-  return JSON.parse(raw);
+  useSyncExternalStore(
+    subscribeEvidence,
+    getEvidenceSnapshot,
+    getEvidenceServerSnapshot,
+  );
+  const { user, loading: sessionLoading } = useSession();
+  useEffect(() => {
+    if (sessionLoading || !user) return;
+    const s = getEvidenceState();
+    if (s.fetched || s.loading) return;
+    void fetchEvidence();
+  }, [user, sessionLoading]);
+  return readStarred();
 }
 
 /**
@@ -71,7 +76,7 @@ export function useEvidenceCandidates() {
 }
 
 export function toggleEvidence(item) {
-  storeToggle(item);
+  toggleStar(item);
 }
 
 function shortDate(iso) {


### PR DESCRIPTION
## Summary

C3 of the storage migration series. Unlike the prior C migrations (goals, snapshots, grading) which had server-side collections already in place, **evidence was localStorage-only** — this PR lands both the backend collection + routes AND the frontend rewrite.

### Backend (new)

- **Collection** \`evidence\` with \$jsonSchema validator
- **Types**: \`EvidenceItem\`, \`EvidenceKind\` ("merged-pr" | "ticket" | "review")
- **Indexes**:
  - Unique \`(orgId, userId, id)\` for upsert dedupe
  - \`(orgId, userId, starredAt: -1)\` for newest-first listing
- **Routes** at \`/api/v1/evidence\`:
  - \`GET    /\` — list (max 500, default 200)
  - \`POST   /\` — upsert by \`id\` (refreshes cosmetic fields, preserves \`impact\` unless explicitly overridden)
  - \`PATCH  /:id\` — update impact note
  - \`DELETE /:id\` — unstar
- Audit entries fire on each mutation (\`evidence.star\` / \`patch\` / \`unstar\`).

### Frontend (rewrite)

Same pattern as goals (C1, #117), snapshots (C2, #137), grading (C4, #129):

- Module-level state + \`useSyncExternalStore\`-compatible monotonic tick
- \`fetchEvidence()\` idempotent hydration triggered on first authed mount
- Optimistic POST / PATCH / DELETE with rollback on API failure
- Resets on \`auth:user-storage-cleared\`
- \`starEvidence\` / \`unstarEvidence\` / \`setImpact\` are the new primitives
- \`toggleStar\` kept as a backwards-compat shim for \`toggleEvidence()\` callers

### Migration of existing localStorage data

Not included. Users with prior localStorage starred items lose them on the next auth-transition wipe. Acceptable for the current engagement window — no Crealogix user has reached the evidence-curation phase yet. A follow-up could extend \`collectMigrationPayload\` to include evidence if needed.

## Files

- \`apps/api/src/db/schemas/evidence.schema.ts\` (new)
- \`apps/api/src/modules/evidence/controller.ts\` (new)
- \`apps/api/src/modules/evidence/routes.ts\` (new)
- \`apps/api/src/db/types.ts\` (added \`EvidenceItem\` + \`EvidenceKind\`)
- \`apps/api/src/db/collections.ts\` (added accessor + indexes)
- \`apps/api/src/db/schemas/index.ts\` (registered \`evidence\` validator)
- \`apps/api/src/app.ts\` (mounted router)
- \`apps/web/src/features/evidence/evidence-store.js\` (rewritten API-direct)
- \`apps/web/src/features/evidence/use-evidence.js\` (drives hydration)

## Test plan

- [ ] Star a PR on the evidence page → appears at the top of the list, persists across reload.
- [ ] Unstar → disappears, persists across reload.
- [ ] Re-star a previously-unstarred item → cosmetic fields refresh (e.g. renamed PR title shows new title).
- [ ] Sign out → sign in as a different user → no cross-user evidence leak.
- [ ] Open the page on a fresh browser → hydration GET fires once, items appear on first paint.
- [ ] Network failure during star → optimistic add appears briefly, then rolls back when POST fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)