### PR TITLE
fix(integrations): paginate myMergedSince across GitHub + GitLab

### DIFF
--- a/apps/web/src/features/integrations/api-clients/github.js
+++ b/apps/web/src/features/integrations/api-clients/github.js
@@ -103,14 +103,21 @@ export const githubApi = {
   /**
    * PRs authored by the current user and merged at/after isoDate.
    * Uses GitHub issue-search, which returns `pull_request.merged_at` on each hit.
+   *
+   * Paginated to GitHub's 1000-result search ceiling. Heavy authors
+   * (Crealogix scale) merge well over 100 PRs across the backfill window
+   * (a year), and this list is what drives the snapshot "merged" count +
+   * the weekly buckets in `synthesiseWeek`. The previous single 100-item
+   * page got fully consumed by the two most recent weeks, so every older
+   * week synthesised as 0 merged even though the PRs existed — the exact
+   * failure `myPrsSince` already paginates around. Returns the raw search
+   * items array; `normalizeGithubMergedSearch` accepts an array or a
+   * `{ items }` envelope.
    */
   myMergedSince: (isoDate) => {
     const day = (isoDate || "").slice(0, 10);
     const q = `is:pr author:@me is:merged merged:>=${day}`;
-    return proxyFetch(
-      "github",
-      `search/issues?q=${encodeURIComponent(q)}&per_page=100`,
-    );
+    return searchIssuesPaginated(q);
   },
 
   /**

--- a/apps/web/src/features/integrations/api-clients/gitlab.js
+++ b/apps/web/src/features/integrations/api-clients/gitlab.js
@@ -1,6 +1,33 @@
 import { proxyFetch } from "./proxy-fetch";
 import { readIntegrations } from "../integrations-store";
 
+/**
+ * Page through a GitLab list endpoint until a short page comes back
+ * (fewer than a full page = the last page) or we hit the page ceiling.
+ *
+ * Mirrors the GitHub `searchIssuesPaginated` fix: the snapshot "merged"
+ * count and the weekly buckets in `synthesiseWeek` need the author's FULL
+ * backfill window (a year). The previous single `per_page=100` call got
+ * fully consumed by the two most recent weeks for a heavy author, so every
+ * older week synthesised as 0 merged even though the MRs existed.
+ *
+ * 10 pages = 1000 MRs, matching GitHub's search ceiling. `buildPath(page)`
+ * returns the endpoint path for a given 1-based page. Pages are fetched
+ * serially to stay friendly to the proxy's rate limits.
+ */
+const GL_PER_PAGE = 100;
+const GL_MAX_PAGES = 10; // 1000 MRs — matches GitHub's search ceiling
+async function gitlabPaginate(buildPath) {
+  const out = [];
+  for (let page = 1; page <= GL_MAX_PAGES; page++) {
+    const batch = await proxyFetch("gitlab", buildPath(page));
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    out.push(...batch);
+    if (batch.length < GL_PER_PAGE) break;
+  }
+  return out;
+}
+
 export const gitlabApi = {
   me: () => proxyFetch("gitlab", "user"),
 
@@ -19,11 +46,17 @@ export const gitlabApi = {
     );
   },
 
-  /** MRs I authored that merged since a given ISO date. */
+  /**
+   * MRs I authored that merged since a given ISO date.
+   *
+   * Paginated (see `gitlabPaginate`) so heavy authors get their full year
+   * of merged MRs, not just the most recent 100. This list drives the
+   * snapshot "merged" count and the per-week buckets in `synthesiseWeek`.
+   */
   myMergedSince: (isoDate) =>
-    proxyFetch(
-      "gitlab",
-      `merge_requests?scope=created_by_me&state=merged&updated_after=${encodeURIComponent(isoDate)}&per_page=100`,
+    gitlabPaginate(
+      (page) =>
+        `merge_requests?scope=created_by_me&state=merged&updated_after=${encodeURIComponent(isoDate)}&per_page=${GL_PER_PAGE}&page=${page}&order_by=created_at&sort=desc`,
     ),
 
   /** Current user's activity events since a date (yyyy-mm-dd). */


### PR DESCRIPTION
## Summary
- Snapshot weeks older than the two most recent showed **0 merged PRs** even when the data existed.
- Root cause: both `githubApi.myMergedSince` and `gitlabApi.myMergedSince` fetched only the first 100 results with no pagination. A heavy author's two recent weeks (~90 merged) consumed the single page, so every older week fetched an empty list and synthesised as `0 merged`.
- **GitHub**: routes through the existing `searchIssuesPaginated` helper (walks to GitHub's 1000-result search ceiling).
- **GitLab**: adds a symmetric `gitlabPaginate` helper (10 pages / 1000 MRs).
- This list drives the snapshot "merged" count and the per-week buckets in `synthesiseWeek`.

## Note (manual follow-up after merge)
Existing W09–W20 snapshots are stored as **manual** zeros and won't self-heal (backfill skips weeks that already have a snapshot; auto-capture can't overwrite manual). To refresh: open the Catch-up grid (`/checkin/grid`) → **Save all**, which recomputes each week against the now-complete merged-PR list and overwrites the stale manual zeros (server allows manual-over-manual).

## Test plan
- [x] `npm run build:web` compiles clean
- [ ] Connect a heavy-author account, open `/snapshots`, confirm older weeks show real merged counts after a grid **Save all**