### PR TITLE
fix(snapshots): backfill recomputes every week, not just missing ones

### DIFF
--- a/apps/web/src/features/settings/tabs/snapshots-prefs-tab.jsx
+++ b/apps/web/src/features/settings/tabs/snapshots-prefs-tab.jsx
@@ -88,15 +88,16 @@ export function SnapshotsPrefsTab() {
  * wonder whether something fired silently.
  */
 function BackfillCard() {
-  const { run, isRunning, progress, missingWeeks } = useBackfill();
+  const { run, isRunning, progress, missingWeeks, totalWeeks } = useBackfill();
   const hasMissing = missingWeeks > 0;
 
   // Reset path — wipes AUTO snapshots so a previous bad backfill (e.g.
   // ran while a data source was returning empty) can be re-synthesised
   // from scratch. Manual snapshots are preserved. The follow-up run()
   // re-enumerates from a freshly-cleared store so every completed week
-  // re-enters the work queue.
-  const handleResetAndRebackfill = () => {
+  // re-enters the work queue. Awaiting the clear avoids racing the
+  // delete requests against the re-synthesis POSTs.
+  const handleResetAndRebackfill = async () => {
     if (isRunning) return;
     if (
       !window.confirm(
@@ -105,7 +106,7 @@ function BackfillCard() {
     ) {
       return;
     }
-    clearAutoSnapshots();
+    await clearAutoSnapshots();
     void run();
   };
 
@@ -116,7 +117,7 @@ function BackfillCard() {
           <MonoLabel>
             {hasMissing
               ? `${missingWeeks} week${missingWeeks === 1 ? "" : "s"} missing`
-              : "All clear"}
+              : `${totalWeeks} week${totalWeeks === 1 ? "" : "s"} tracked`}
           </MonoLabel>
           <div
             className="mt-2 font-semibold"
@@ -125,20 +126,20 @@ function BackfillCard() {
             Synthesise weekly snapshots from connected data
           </div>
           <p className="mt-2 text-[13px] leading-[1.55] text-muted-fg">
-            Walks every completed Sun → Thu week of the current year and
-            generates a snapshot for any that don&apos;t already have one,
-            using whatever your providers return for that window. Weeks older
-            than ~90 days are marked <em>partial</em> because the GitHub
-            events feed only reaches that far back — heatmap and reviews-given
-            numbers for those weeks will read as 0, flagged as unavailable
-            rather than zero-effort.
+            Recomputes <em>every</em> completed Sun → Thu week of the current
+            year from your currently-connected providers and overwrites the
+            saved numbers in place — so a week captured while a provider was
+            unreachable (or before an integration fix landed) gets refreshed,
+            not skipped. Merged count, turnaround, linkage and review rounds
+            are PR-derived and fill for the full year. Weeks older than ~90
+            days stay <em>partial</em> because the GitHub events feed only
+            reaches that far back — reviews-given for those weeks reads as 0,
+            flagged as unavailable rather than zero-effort.
           </p>
           <p className="mt-2 text-[12px] leading-[1.5] text-dim-fg">
-            If a previous backfill ran while a provider was unreachable, the
-            saved weeks will be all-zero auto snapshots. Use{" "}
-            <span className="text-fg">Reset &amp; re-backfill</span> to wipe
-            those (manual snapshots are kept) and run again against the
-            current live data.
+            Your hand-typed notes are preserved. <span className="text-fg">Reset
+            &amp; re-backfill</span> additionally deletes auto-captured
+            snapshots first (manual ones are kept) for a clean re-synthesis.
           </p>
           {isRunning && progress ? (
             <div
@@ -153,11 +154,11 @@ function BackfillCard() {
         <div className="flex flex-col items-stretch gap-2">
           <Button
             onClick={() => run()}
-            disabled={isRunning || !hasMissing}
+            disabled={isRunning || totalWeeks === 0}
             title={
-              !hasMissing
-                ? "Every completed week already has a snapshot — use Reset & re-backfill to redo from scratch."
-                : undefined
+              totalWeeks === 0
+                ? "No completed weeks yet this year."
+                : "Recompute and overwrite every completed week from live data."
             }
           >
             {isRunning ? "Running…" : "Backfill now"}

--- a/apps/web/src/features/snapshots/synthesise-week.js
+++ b/apps/web/src/features/snapshots/synthesise-week.js
@@ -77,6 +77,7 @@ export function synthesiseWeek({
   tickets,
   allInputs,
   capturedBy = "auto",
+  note,
 }) {
   const startMs = range.start.getTime();
   const endMs = range.end.getTime();
@@ -113,6 +114,13 @@ export function synthesiseWeek({
   const prior = existing
     .filter((s) => s.week && s.week < range.weekLabel)
     .sort((a, b) => b.week.localeCompare(a.week))[0] || null;
+  // synthesise is the ONLY writer of the headline metrics + goalReadings,
+  // so recomputing them is always safe. The `note`, however, is hand-typed
+  // by the user and must survive a re-capture (backfill refresh or a
+  // check-in re-save). Preserve the stored note unless the caller passes
+  // an explicit one.
+  const currentWeekSnap =
+    existing.find((s) => s.week === range.weekLabel) || null;
 
   const goalReadings = captureGoalReadings({
     weekStart: range.start,
@@ -135,7 +143,7 @@ export function synthesiseWeek({
     turnaround: median == null ? 0 : Math.round(median * 24),
     linkage,
     rounds: Math.round(rounds * 10) / 10,
-    note: "",
+    note: note ?? currentWeekSnap?.note ?? "",
     goalReadings,
     partial,
     gaps,

--- a/apps/web/src/features/snapshots/use-backfill.js
+++ b/apps/web/src/features/snapshots/use-backfill.js
@@ -1,27 +1,36 @@
 "use client";
 
 /**
- * Backfill — synthesise weekly snapshots for the past N completed
- * Sun → Thu work-weeks that don't have a snapshot yet, using whatever
- * integration data is already loaded.
+ * Backfill — (re)synthesise weekly snapshots for EVERY completed
+ * Sun → Thu work-week of the current year, using whatever integration
+ * data is already loaded.
  *
- * Two onboarding paths this addresses:
+ * Two paths this addresses:
  *
  *   - **Case 1 (mid-year join):** user installs in April. `useAutoSnapshot`
  *     would only capture the most recent completed week going forward,
  *     so weeks 1-15 of the year stay empty in the snapshot store.
- *     Without backfill, compliance reads "1 of 1 closed week" forever.
+ *     Backfill creates the missing ones.
  *
- *   - **Case 2 (full-year onboard):** user is on the app from week 1.
- *     `useAutoSnapshot` captures organically each week. Backfill is a
- *     no-op because every week already has a snapshot.
+ *   - **Case 2 (stale data refresh):** a week was captured while a
+ *     provider was unreachable, or before an integration fix landed
+ *     (e.g. the un-paginated merged-PR fetch that made every older week
+ *     read 0 merged). Those weeks already HAVE a snapshot, so a "fill
+ *     only the missing weeks" backfill would skip them forever. We
+ *     instead recompute every completed week and overwrite the stored
+ *     numbers in place.
  *
  * What this implementation does
  * ─────────────────────────────
  * Walks every completed Sun → Thu week between Jan 1 of the current
- * year and "now". For each missing week, it slices the loaded merged-PR
- * + event data to that week's window and synthesises a snapshot using
- * `captureGoalReadings`.
+ * year and "now". For EACH week, it slices the loaded merged-PR + event
+ * data to that week's window and synthesises a fresh snapshot using
+ * `captureGoalReadings`. Each write preserves the week's existing
+ * `capturedBy` so it lands through matching server precedence
+ * (auto-over-auto / manual-over-manual) — an `auto` write can't clobber
+ * a `manual` week, which is exactly why a plain "fill missing" backfill
+ * left stale manual zeros stuck. The hand-typed `note` is preserved by
+ * `synthesiseWeek`; only machine-derived fields are recomputed.
  *
  * Limitations (acknowledged honestly):
  *   - The events feed only goes back ~90 days regardless of how far we
@@ -59,10 +68,11 @@ const EVENTS_HORIZON_DAYS = 90;
 
 /**
  * @returns {{
- *   run:        () => Promise<void>,
+ *   run:        () => Promise<void>,  // recompute ALL completed weeks
  *   isRunning:  boolean,
  *   progress:   { done: number, total: number } | null,
- *   missingWeeks: number,   // count of completed weeks missing a snapshot
+ *   missingWeeks: number,   // completed weeks with NO snapshot yet
+ *   totalWeeks:   number,   // completed weeks since Jan 1 (refresh target)
  * }}
  */
 export function useBackfill() {
@@ -85,8 +95,8 @@ export function useBackfill() {
   const [progress, setProgress] = useState(null);
   const cancelledRef = useRef(false);
 
-  // Identify completed Sun → Thu weeks since Jan 1 that don't have a
-  // snapshot yet. Used by the banner to show "X weeks need backfill".
+  // Completed Sun → Thu weeks since Jan 1 with NO snapshot yet. Drives
+  // the onboarding banner ("X weeks need backfill").
   const missingWeeks = useMemo(() => {
     if (typeof window === "undefined") return 0;
     const ranges = enumerateCompletedWeeks();
@@ -94,31 +104,43 @@ export function useBackfill() {
     return ranges.filter((r) => !existing.has(r.weekLabel)).length;
   }, [isRunning]); // re-evaluate after a run
 
+  // Total completed weeks since Jan 1 — the refresh target count. A run
+  // recomputes all of these, not just the missing ones.
+  const totalWeeks = useMemo(() => {
+    if (typeof window === "undefined") return 0;
+    return enumerateCompletedWeeks().length;
+  }, [isRunning]);
+
   const run = useCallback(async () => {
     if (isRunning) return;
     if (typeof window === "undefined") return;
     cancelledRef.current = false;
     setIsRunning(true);
 
+    // Recompute EVERY completed week — not just the ones missing a
+    // snapshot. Preserve each week's existing `capturedBy` so the write
+    // lands through matching server precedence (a fresh week defaults to
+    // "auto"). synthesiseWeek preserves any hand-typed note.
     const ranges = enumerateCompletedWeeks();
-    const existing = new Set(readSnapshots().map((s) => s.week));
-    const missing = ranges.filter((r) => !existing.has(r.weekLabel));
+    const existing = new Map(readSnapshots().map((s) => [s.week, s]));
 
-    setProgress({ done: 0, total: missing.length });
+    setProgress({ done: 0, total: ranges.length });
 
-    for (let i = 0; i < missing.length; i++) {
+    for (let i = 0; i < ranges.length; i++) {
       if (cancelledRef.current) break;
+      const range = ranges[i];
+      const prior = existing.get(range.weekLabel);
       synthesiseWeek({
-        range: missing[i],
+        range,
         goals,
         specs,
         mrs: mrs || [],
         events: events || [],
         tickets: Array.isArray(jira?.issues) ? jira.issues : [],
         allInputs,
-        capturedBy: "auto",
+        capturedBy: prior?.capturedBy ?? "auto",
       });
-      setProgress({ done: i + 1, total: missing.length });
+      setProgress({ done: i + 1, total: ranges.length });
       // Yield to the browser so the banner re-renders.
       // eslint-disable-next-line no-await-in-loop
       await new Promise((r) => setTimeout(r, 0));
@@ -126,9 +148,9 @@ export function useBackfill() {
 
     setIsRunning(false);
     setProgress(null);
-    if (missing.length > 0 && !cancelledRef.current) {
+    if (ranges.length > 0 && !cancelledRef.current) {
       toast.success(
-        `Backfilled ${missing.length} week${missing.length === 1 ? "" : "s"} of history`,
+        `Refreshed ${ranges.length} week${ranges.length === 1 ? "" : "s"} of history`,
       );
     }
   }, [goals, specs, mrs, events, jira, allInputs, isRunning]);


### PR DESCRIPTION
## Summary
Follow-up to #141 (myMergedSince pagination). The data was now fetchable, but backfill still left older weeks at 0 merged because it never touched weeks that already had a snapshot:

1. `run()` only synthesised weeks with **no** snapshot. Once every week had one (auto or manual), the "missing" set was empty → backfill was a no-op.
2. Backfill writes `capturedBy:"auto"`, and the server refuses `auto`-over-`manual`, so it could never overwrite the stale manual zeros left by an earlier grid Save-all.

## Changes
- **`use-backfill.js`** — `run()` recomputes **all** completed weeks of the year and preserves each week's existing `capturedBy`, so writes land through matching precedence (`auto`-over-`auto` / `manual`-over-`manual`). Exposes `totalWeeks`.
- **`synthesise-week.js`** — preserves the existing week's hand-typed `note` on recompute. It previously hardcoded `note:""`, which also silently wiped notes on every check-in re-save (latent bug, now fixed).
- **`snapshots-prefs-tab.jsx`** — "Backfill now" is enabled whenever there are completed weeks (was disabled once every week had a snapshot — exactly the stuck state). Copy updated to say it recomputes and overwrites.

Headline metrics + `goalReadings` are always machine-derived, so the recompute is safe; only the user-authored note is preserved.

## How to use
Settings → Cycle history → **Backfill now**. Walks every completed week, re-pulls the full-year merged-PR list, rewrites the numbers and goal readings in place.

## Known limitation
The GitHub events feed only reaches back ~90 days, so reviews-*given* for weeks older than that stay `partial`/0. Merged count, turnaround, linkage and review rounds are PR-derived and fill for the full year.

## Test plan
- [x] `npm run build:web` compiles clean
- [ ] On a heavy-author account with stale 0-merged weeks: Settings → Backfill now → confirm older weeks show real merged counts + turnaround