### PR TITLE
fix: milestone goal-input schema + rate-limit wait/resume (GitHub + Mistral)

### DIFF
--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -1,0 +1,131 @@
+/**
+ * Rate-limit helpers shared by the upstream callers (AI providers, the
+ * provider proxies). Parses the standard rate-limit signals and retries
+ * a fetch a BOUNDED number of times, honouring the server-indicated
+ * wait.
+ *
+ * Bounded on purpose: this runs inside a serverless function with a
+ * hard wall-clock budget (Vercel ~60s). We can smooth over short burst
+ * limits — Mistral typically returns `Retry-After` in single-digit
+ * seconds — but we cannot sit out GitHub's hour-long primary reset from
+ * here. For those, the caller surfaces the wait to the browser (via a
+ * `Retry-After` header / `error.retryAfterMs` envelope field) so the
+ * client can wait and resume in the background without holding a
+ * function open.
+ */
+
+/** Minimal structural view of a fetch `Headers` — avoids depending on a
+ *  globally-available `Headers` lib type. */
+interface HeaderReader {
+  get(name: string): string | null;
+}
+
+/** Minimal structural view of a fetch `Response`. */
+interface MinimalResponse {
+  status: number;
+  headers: HeaderReader;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+/**
+ * Wait (ms) indicated by rate-limit headers, or null when none present.
+ *   - `Retry-After`: delta-seconds OR an HTTP-date.
+ *   - `X-RateLimit-Remaining: 0` + `X-RateLimit-Reset` (epoch seconds):
+ *     GitHub / GitLab style.
+ */
+export function retryAfterMsFromHeaders(headers: HeaderReader): number | null {
+  const ra = headers.get("retry-after");
+  if (ra) {
+    const secs = Number(ra);
+    if (Number.isFinite(secs)) return Math.max(0, secs * 1000);
+    const when = Date.parse(ra);
+    if (Number.isFinite(when)) return Math.max(0, when - Date.now());
+  }
+  const remaining = headers.get("x-ratelimit-remaining");
+  const reset = headers.get("x-ratelimit-reset");
+  if (remaining === "0" && reset) {
+    const resetMs = Number(reset) * 1000;
+    if (Number.isFinite(resetMs)) return Math.max(0, resetMs - Date.now());
+  }
+  return null;
+}
+
+/** True when a response is a rate-limit rejection (vs a plain error). */
+export function isRateLimited(status: number, headers: HeaderReader): boolean {
+  if (status === 429) return true;
+  // GitHub answers 403 for BOTH bad credentials and rate limits; only
+  // the rate-limit case zeroes the remaining counter.
+  if (status === 403 && headers.get("x-ratelimit-remaining") === "0") {
+    return true;
+  }
+  return false;
+}
+
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error("aborted"));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+interface RetryOpts {
+  /** Total fetch attempts (default 3). */
+  maxAttempts?: number;
+  /** Cumulative wait ceiling across all retries (default 25s). */
+  maxTotalWaitMs?: number;
+  signal?: AbortSignal;
+  onWait?: (info: { attempt: number; waitMs: number; status: number }) => void;
+}
+
+/**
+ * Run `doFetch` and, on a rate-limit response, wait the indicated time
+ * and retry — up to `maxAttempts` and `maxTotalWaitMs`. Returns the
+ * final response (which MAY still be a 429 when the budget is exhausted
+ * — the caller decides how to surface that). Never throws on rate
+ * limit; network errors from `doFetch` propagate to the caller.
+ */
+export async function fetchWithRateLimitRetry<T extends MinimalResponse>(
+  doFetch: () => Promise<T>,
+  opts: RetryOpts = {},
+): Promise<T> {
+  const maxAttempts = Math.max(1, opts.maxAttempts ?? 3);
+  const maxTotalWaitMs = opts.maxTotalWaitMs ?? 25_000;
+  let waited = 0;
+  for (let attempt = 1; ; attempt += 1) {
+    const res = await doFetch();
+    if (!isRateLimited(res.status, res.headers)) return res;
+    if (attempt >= maxAttempts) return res;
+    const indicated =
+      retryAfterMsFromHeaders(res.headers) ??
+      Math.min(2_000 * 2 ** (attempt - 1), 8_000); // 2s, 4s, 8s…
+    // Small jitter so concurrent callers waiting on the same reset
+    // don't all retry on the exact same tick (thundering herd).
+    const jitter = Math.floor(Math.random() * 750);
+    const waitMs = Math.min(indicated + jitter, maxTotalWaitMs - waited);
+    if (waitMs <= 0) return res;
+    waited += waitMs;
+    opts.onWait?.({ attempt, waitMs, status: res.status });
+    // Drain the body so the socket is freed before we retry.
+    try {
+      await res.arrayBuffer();
+    } catch {
+      /* ignore — some bodies aren't buffer-able, not fatal */
+    }
+    try {
+      await sleep(waitMs, opts.signal);
+    } catch {
+      return res; // aborted while waiting — hand back the limited response
+    }
+  }
+}

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -20,16 +20,25 @@ export class HttpError extends Error {
   readonly status: number;
   readonly code: string;
   readonly details: unknown;
+  /**
+   * When set, the client is told to wait this long before retrying. The
+   * error handler emits it as both a `Retry-After` header (seconds) and
+   * an `error.retryAfterMs` envelope field so rate-limited batch flows
+   * (grading, classification) can back off and resume in the background.
+   */
+  readonly retryAfterMs: number | undefined;
   constructor(
     status: number,
     code: string,
     message: string,
     details?: unknown,
+    retryAfterMs?: number,
   ) {
     super(message);
     this.status = status;
     this.code = code;
     this.details = details;
+    this.retryAfterMs = retryAfterMs;
   }
 }
 
@@ -39,6 +48,7 @@ interface ErrorResponse {
     message: string;
     requestId: string | undefined;
     details?: unknown;
+    retryAfterMs?: number;
   };
 }
 
@@ -64,12 +74,14 @@ export function errorHandler(
   let code = "internal_error";
   let message = "An unexpected error occurred.";
   let details: unknown;
+  let retryAfterMs: number | undefined;
 
   if (err instanceof HttpError) {
     status = err.status;
     code = err.code;
     message = err.message;
     details = err.details;
+    retryAfterMs = err.retryAfterMs;
   } else if (err instanceof ZodError) {
     status = 400;
     code = "validation_error";
@@ -87,8 +99,15 @@ export function errorHandler(
       message,
       requestId: req.id,
       ...(details !== undefined ? { details } : {}),
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
     },
   };
+
+  if (retryAfterMs !== undefined && !res.headersSent) {
+    // HTTP Retry-After is whole seconds; round up so we never advise a
+    // shorter wait than the upstream asked for.
+    res.setHeader("Retry-After", String(Math.max(1, Math.ceil(retryAfterMs / 1000))));
+  }
 
   if (status >= 500) {
     logger.error({ err, reqId: req.id, path: req.path }, "[err] " + code);

--- a/apps/api/src/modules/ai/classifier/mistral-classifier.ts
+++ b/apps/api/src/modules/ai/classifier/mistral-classifier.ts
@@ -24,6 +24,7 @@
  */
 
 import { validateSpec } from "@espace-devhub/shared/goal-specs";
+import { fetchWithRateLimitRetry } from "../../../lib/rate-limit.js";
 import { AnalysisEvents, type AnalysisEvent } from "./events.js";
 import { SPEC_RESPONSE_SCHEMA } from "./spec-schema.js";
 
@@ -692,20 +693,33 @@ async function* classifyOneGoal(
     response_format: responseFormat,
   });
 
+  // Bounded retry on model-tier rate limits: a 429 mid-classification
+  // shouldn't fail the goal outright. We wait the upstream-indicated
+  // delay and retry within the streaming function's budget; goals that
+  // still fail after that can be re-run individually from the Review
+  // pane (reclassifyOneGoal).
   const requestWithFormat = async (
     responseFormat: unknown,
   ): Promise<Awaited<ReturnType<typeof fetch>>> =>
-    fetch(opts.url, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${opts.apiKey}`,
-        "Content-Type": "application/json",
-        Accept: "text/event-stream",
-        ...opts.extraHeaders,
+    fetchWithRateLimitRetry(
+      () =>
+        fetch(opts.url, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${opts.apiKey}`,
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+            ...opts.extraHeaders,
+          },
+          body: JSON.stringify(buildBody(responseFormat)),
+          signal: opts.signal,
+        }),
+      {
+        maxAttempts: 4,
+        maxTotalWaitMs: 20_000,
+        ...(opts.signal ? { signal: opts.signal } : {}),
       },
-      body: JSON.stringify(buildBody(responseFormat)),
-      signal: opts.signal,
-    });
+    );
 
   let res: Awaited<ReturnType<typeof fetch>>;
   try {

--- a/apps/api/src/modules/ai/controller.ts
+++ b/apps/api/src/modules/ai/controller.ts
@@ -13,6 +13,11 @@
 
 import type { NextFunction, Request, Response } from "express";
 import { logger } from "../../lib/logger.js";
+import {
+  fetchWithRateLimitRetry,
+  isRateLimited,
+  retryAfterMsFromHeaders,
+} from "../../lib/rate-limit.js";
 import { HttpError } from "../../middleware/error-handler.js";
 import { selectProvider } from "./provider.js";
 import { chatSchema, gradePrSchema } from "./schemas.js";
@@ -120,18 +125,28 @@ async function callProvider(
   // NOTE: deliberately untyped. Annotating `upstream: Response` would
   // resolve to Express's Response (imported above), not the global
   // fetch Response. Inference picks up the right shape from `fetch()`.
+  //
+  // Bounded retry on rate limits: model-tier 429s tend to clear in a
+  // few seconds, so we wait the upstream-indicated `Retry-After` and
+  // retry within the function budget. If it's still limited after that,
+  // we surface the wait time to the caller (see below) so the browser
+  // can resume in the background rather than failing the batch.
   let upstream;
   try {
-    upstream = await fetch(provider.url, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${provider.apiKey}`,
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        ...provider.extraHeaders,
-      },
-      body: JSON.stringify(body),
-    });
+    upstream = await fetchWithRateLimitRetry(
+      () =>
+        fetch(provider.url, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${provider.apiKey}`,
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            ...provider.extraHeaders,
+          },
+          body: JSON.stringify(body),
+        }),
+      { maxAttempts: 3, maxTotalWaitMs: 20_000 },
+    );
   } catch (err) {
     throw new HttpError(
       502,
@@ -145,11 +160,18 @@ async function callProvider(
   const raw = await upstream.text();
   if (!upstream.ok) {
     // Surface the upstream status verbatim — useful for ops debugging
-    // model-tier rate limits or quota errors.
+    // model-tier rate limits or quota errors. On a persistent rate
+    // limit, attach the retry delay so the client can back off and
+    // resume the batch in the background.
+    const rateLimited = isRateLimited(upstream.status, upstream.headers);
     throw new HttpError(
       upstream.status,
-      "ai_provider_error",
+      rateLimited ? "ai_provider_rate_limited" : "ai_provider_error",
       `${provider.label} ${upstream.status}: ${raw.slice(0, 500)}`,
+      undefined,
+      rateLimited
+        ? (retryAfterMsFromHeaders(upstream.headers) ?? 30_000)
+        : undefined,
     );
   }
   let data: unknown;

--- a/apps/api/src/modules/goal-inputs/controller.ts
+++ b/apps/api/src/modules/goal-inputs/controller.ts
@@ -23,23 +23,46 @@ import type {
 import { networkMeta, writeAudit } from "../../lib/audit.js";
 import { HttpError } from "../../middleware/error-handler.js";
 
-// Polymorphic value: number / string / boolean / list of strings /
-// flat object map. Caps each shape so a runaway widget can't blow
-// out a single document.
+// Polymorphic value. Each manual widget stores its own shape:
+//   Counter / Scale → number, Free-text → string, Counter-bool → boolean,
+//   Milestone → { periodKey, items: [{ id, label, done }] },
+//   Before/After → { baseline, current }.
+// The backend stays widget-agnostic — the widget interprets per-spec and
+// the Mongo $jsonSchema validator already accepts object/array values —
+// so we accept any JSON-serialisable value rather than enumerating each
+// widget's shape (the prior flat-primitive union rejected Milestone's
+// `items` array-of-objects with an `invalid_union` error). String length
+// and collection breadth are capped so a runaway payload can't blow out a
+// single document.
+type JsonInput =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonInput[]
+  | { [key: string]: JsonInput };
+
+// Recursive JSON node — `null` is allowed at nested positions (e.g. an
+// optional field inside a Milestone item) but NOT as a bare top-level
+// value (the Mongo validator rejects a null `value`; absence is the
+// document not existing).
+const jsonNode: z.ZodType<JsonInput> = z.lazy(() =>
+  z.union([
+    z.string().max(8_000),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonNode).max(500),
+    z.record(z.string().min(1).max(200), jsonNode),
+  ]),
+);
+
 const inputValue = z.union([
-  z.number(),
   z.string().max(8_000),
+  z.number(),
   z.boolean(),
-  z.array(z.string().max(2_000)).max(200),
-  z.record(
-    z.string().min(1).max(200),
-    z.union([
-      z.string().max(2_000),
-      z.number(),
-      z.boolean(),
-      z.null(),
-    ]),
-  ),
+  z.array(jsonNode).max(500),
+  z.record(z.string().min(1).max(200), jsonNode),
 ]);
 
 const appendInputSchema = z.object({

--- a/apps/web/src/features/grading/use-graded-prs.js
+++ b/apps/web/src/features/grading/use-graded-prs.js
@@ -39,6 +39,7 @@ import {
 } from "./verdicts-store";
 import { normalizeRubric, rubricHash } from "./rubric-hash";
 import { firstReviewComments } from "./first-review-comments";
+import { fetchWithRateLimitRetry, isRateLimitStatus } from "@/lib/rate-limit";
 
 /** Concurrency cap for grading calls — honour Mistral rate limits. */
 const GRADE_CONCURRENCY = 3;
@@ -164,7 +165,9 @@ export function useGradedPrs(spec, options = {}) {
   const [listError, setListError] = useState(null);
   const [isListLoading, setIsListLoading] = useState(false);
   const [progress, setProgress] = useState({ done: 0, total: 0, running: false });
-  const cancelRef = useRef({ aborted: false });
+  // `controller` lets us abort an in-flight rate-limit wait when the hook
+  // unmounts or the rubric changes, instead of hanging on a backoff sleep.
+  const cancelRef = useRef({ aborted: false, controller: null });
 
   // Step 1 — load the PR list ONCE per (connected, year) combo.
   // GitHub's search API is aggressively rate-limited (30 req/min/user), and
@@ -242,7 +245,7 @@ export function useGradedPrs(spec, options = {}) {
     const pending = subset.filter((pr) => !readVerdict(pr.id, hash));
     if (pending.length === 0) return;
 
-    cancelRef.current = { aborted: false };
+    cancelRef.current = { aborted: false, controller: new AbortController() };
     const token = cancelRef.current;
 
     setProgress({ done: 0, total: pending.length, running: true });
@@ -276,41 +279,57 @@ export function useGradedPrs(spec, options = {}) {
             const commentsForGrading = firstReviewOnly
               ? firstReviewComments(details.comments, pr.author)
               : details.comments;
-            const res = await fetch("/api/v1/ai/grade-pr", {
-              method: "POST",
-              credentials: "include",
-              headers: {
-                "Content-Type": "application/json",
-                "x-ai-provider": aiProvider,
-              },
-              body: JSON.stringify({
-                pr: {
-                  id: pr.id,
-                  title: details.title || pr.title,
-                  body: details.body,
-                  comments: commentsForGrading,
+            // Rate-limited grade calls wait the upstream-indicated delay
+            // and retry transparently (see fetchWithRateLimitRetry). The
+            // signal lets a cancel/unmount abort the backoff wait.
+            const res = await fetchWithRateLimitRetry(
+              "/api/v1/ai/grade-pr",
+              {
+                method: "POST",
+                credentials: "include",
+                headers: {
+                  "Content-Type": "application/json",
+                  "x-ai-provider": aiProvider,
                 },
-                rubric,
-                provider: aiProvider,
-              }),
-            });
+                body: JSON.stringify({
+                  pr: {
+                    id: pr.id,
+                    title: details.title || pr.title,
+                    body: details.body,
+                    comments: commentsForGrading,
+                  },
+                  rubric,
+                  provider: aiProvider,
+                }),
+              },
+              { provider: "ai", signal: token.controller?.signal },
+            );
             if (token.aborted) return;
             const body = await res.json().catch(() => ({}));
-            if (!res.ok) {
-              // Persist the failure as a verdict so we don't retry until
-              // the rubric changes. Violations carry the error message so
-              // the UI can surface it.
+            if (res.ok && body?.verdict) {
+              saveVerdict(pr.id, hash, body.verdict);
+            } else if (isRateLimitStatus(res.status, res.headers)) {
+              // Still rate-limited after the retry budget. Leave this PR
+              // UNGRADED so a later run picks it up — do NOT poison the
+              // cache with an errored verdict the user can't clear
+              // without changing the rubric.
+            } else if (!res.ok) {
+              // Genuine failure (4xx/5xx that isn't a rate limit).
+              // Persist it so we don't re-attempt until the rubric
+              // changes; violations carry the message for the UI.
               saveVerdict(pr.id, hash, {
                 pass: false,
                 reasoning: `Grading failed: ${body?.error?.message || body?.error || res.status}`,
                 violations: [],
                 errored: true,
               });
-            } else if (body?.verdict) {
-              saveVerdict(pr.id, hash, body.verdict);
             }
           } catch (err) {
-            if (token.aborted) return;
+            if (token.aborted || err?.name === "AbortError") return;
+            // A persistent upstream rate limit surfaced from pullDetails
+            // (via the proxy) is transient infrastructure, not a
+            // gradeable failure — leave the PR ungraded for a later run.
+            if (err?.rateLimited) return;
             saveVerdict(pr.id, hash, {
               pass: false,
               reasoning: `Grading error: ${err?.message || err}`,
@@ -343,6 +362,9 @@ export function useGradedPrs(spec, options = {}) {
   useEffect(() => {
     return () => {
       cancelRef.current.aborted = true;
+      // Abort any in-flight rate-limit backoff so we don't sit on a
+      // timer after the owner is gone / the rubric changed.
+      cancelRef.current.controller?.abort();
     };
   }, [hash]);
 

--- a/apps/web/src/features/integrations/api-clients/proxy-fetch.js
+++ b/apps/web/src/features/integrations/api-clients/proxy-fetch.js
@@ -17,7 +17,22 @@
  * from localStorage and ship it as `x-devhub-token` to a Next.js
  * proxy route. That pattern defeated the M6 encryption-at-rest
  * design and is now retired.
+ *
+ * @see {@link "@/lib/rate-limit"} for the retry/backoff primitives.
+ *
+ * Rate limits: GitHub's search API (30 req/min) and self-hosted
+ * GitLab/Jira are easy to trip during a backfill or a grade-all sweep.
+ * Every call routes through `fetchWithRateLimitRetry`, which honours the
+ * upstream `Retry-After` / `X-RateLimit-Reset` (passed through by the
+ * proxy) and waits + retries transparently — so a 429 pauses the call
+ * instead of failing it. A persistent limit (budget exhausted) throws an
+ * Error tagged `rateLimited: true` so batch callers can defer the item.
  */
+import {
+  fetchWithRateLimitRetry,
+  isRateLimitStatus,
+} from "@/lib/rate-limit";
+
 export async function proxyFetch(providerId, path, init = {}) {
   if (!providerId) throw new Error("proxyFetch: providerId is required");
   const cleanPath = String(path || "").replace(/^\//, "");
@@ -33,12 +48,16 @@ export async function proxyFetch(providerId, path, init = {}) {
     headers.set("Accept", "application/json");
   }
 
-  const res = await fetch(url, {
-    method,
-    credentials: "include",
-    headers,
-    ...(init.body !== undefined ? { body: init.body } : {}),
-  });
+  const res = await fetchWithRateLimitRetry(
+    url,
+    {
+      method,
+      credentials: "include",
+      headers,
+      ...(init.body !== undefined ? { body: init.body } : {}),
+    },
+    { provider: providerId, signal: init.signal },
+  );
 
   if (!res.ok) {
     let detail = "";
@@ -50,9 +69,17 @@ export async function proxyFetch(providerId, path, init = {}) {
     } catch {
       /* ignore parse errors — empty detail is fine */
     }
-    throw new Error(
+    const error = new Error(
       `${providerId} ${res.status}${detail ? `: ${detail}` : ""}`,
     );
+    error.status = res.status;
+    // Tag a still-limited response so batch callers (PR grading) can
+    // leave the item for a later run instead of caching a permanent
+    // failure.
+    if (isRateLimitStatus(res.status, res.headers)) {
+      error.rateLimited = true;
+    }
+    throw error;
   }
   return res.json();
 }

--- a/apps/web/src/lib/rate-limit.js
+++ b/apps/web/src/lib/rate-limit.js
@@ -1,0 +1,179 @@
+"use client";
+
+/**
+ * Client-side rate-limit handling, shared by the provider proxy fetcher
+ * (`proxyFetch`) and the AI batch orchestrators (PR grading, goal
+ * classification).
+ *
+ * The API streams upstream rate-limit signals straight through — the
+ * proxy's passthrough allowlist includes `Retry-After`,
+ * `X-RateLimit-Reset` and `X-RateLimit-Remaining` — and the AI
+ * controller forwards the model provider's `Retry-After` as both a
+ * `Retry-After` header and an `error.retryAfterMs` envelope field. We
+ * read those here to wait exactly as long as the upstream asks, then
+ * resume, so a 429 PAUSES the work instead of failing it.
+ *
+ * "In the background": these are async calls the UI already awaits
+ * behind progress indicators; waiting + retrying inside the promise
+ * keeps the page responsive while the batch quietly resumes. A throttled
+ * toast tells the user it's waiting rather than stuck.
+ */
+
+import { toast } from "sonner";
+
+export const RATE_LIMIT_EVENT = "espace-devhub:rate-limit-wait";
+
+/**
+ * Largest single wait we'll honour before giving up. GitHub's PRIMARY
+ * rate limit can reset up to an hour out — we won't freeze the tab that
+ * long; we cap the wait, and if the limit persists the caller surfaces a
+ * normal error (and the work can be re-run later).
+ */
+const MAX_SINGLE_WAIT_MS = 2 * 60_000; // 2 minutes
+
+/** Default attempt ceiling for a single logical request. */
+export const DEFAULT_MAX_ATTEMPTS = 6;
+
+/** True when a response is a rate-limit rejection (vs a plain error). */
+export function isRateLimitStatus(status, headers) {
+  if (status === 429) return true;
+  // GitHub answers 403 for BOTH bad credentials and rate limits; only
+  // the rate-limit case zeroes the remaining counter.
+  if (status === 403 && headers?.get?.("x-ratelimit-remaining") === "0") {
+    return true;
+  }
+  return false;
+}
+
+function clampWait(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return 0;
+  return Math.min(ms, MAX_SINGLE_WAIT_MS);
+}
+
+/**
+ * Parse the wait (ms) from a rate-limited response's headers, with the
+ * parsed JSON body as a fallback (our API exposes the model provider's
+ * delay as `error.retryAfterMs`). Falls back to exponential backoff with
+ * jitter when nothing is advertised.
+ */
+export function rateLimitDelayMs(status, headers, body, attempt = 1) {
+  // 1) Retry-After: delta-seconds OR an HTTP-date.
+  const ra = headers?.get?.("retry-after");
+  if (ra) {
+    const secs = Number(ra);
+    if (Number.isFinite(secs)) return clampWait(secs * 1000);
+    const when = Date.parse(ra);
+    if (Number.isFinite(when)) return clampWait(when - Date.now());
+  }
+  // 2) Our API forwards the model provider's wait as error.retryAfterMs.
+  const fromBody = Number(body?.error?.retryAfterMs);
+  if (Number.isFinite(fromBody) && fromBody > 0) return clampWait(fromBody);
+  // 3) GitHub/GitLab: epoch-seconds reset when the window is exhausted.
+  const remaining = headers?.get?.("x-ratelimit-remaining");
+  const reset = headers?.get?.("x-ratelimit-reset");
+  if (remaining === "0" && reset) {
+    const resetMs = Number(reset) * 1000;
+    if (Number.isFinite(resetMs)) return clampWait(resetMs - Date.now());
+  }
+  // 4) Fallback: exponential backoff (2s, 4s, 8s…) + jitter.
+  const backoff = Math.min(2_000 * 2 ** (attempt - 1), 30_000);
+  return clampWait(backoff + Math.random() * 1_000);
+}
+
+/** Cancellable sleep. Rejects with an AbortError if the signal fires. */
+export function sleep(ms, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener?.("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener?.("abort", onAbort, { once: true });
+  });
+}
+
+// Throttle the "waiting" toast so a fan-out of concurrent workers all
+// hitting the same limit doesn't stack a dozen toasts.
+const _lastToastAt = {};
+const TOAST_THROTTLE_MS = 10_000;
+
+/** Non-blocking notification the user is being made to wait. */
+export function notifyRateLimitWait({ provider, waitMs, attempt }) {
+  if (typeof window !== "undefined") {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(RATE_LIMIT_EVENT, {
+          detail: { provider, waitMs, attempt },
+        }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+  const now = Date.now();
+  if (!_lastToastAt[provider] || now - _lastToastAt[provider] > TOAST_THROTTLE_MS) {
+    _lastToastAt[provider] = now;
+    const secs = Math.max(1, Math.ceil(waitMs / 1000));
+    const who =
+      provider === "ai"
+        ? "AI provider"
+        : provider === "upstream"
+          ? "Upstream"
+          : provider;
+    try {
+      toast.message(
+        `${who} rate limit hit — waiting ${secs}s, then continuing…`,
+        { duration: Math.min(Math.max(waitMs, 3_000), 6_000) },
+      );
+    } catch {
+      /* sonner not mounted (SSR / tests) — ignore */
+    }
+  }
+}
+
+/**
+ * Run `fetch(input, init)` and, on a rate-limit response, wait the
+ * indicated time and retry — up to `maxAttempts`. Returns the final
+ * Response (the caller reads `.ok` / `.json()` as usual). Throws only on
+ * a network error or an abort (AbortError) while waiting.
+ *
+ * The same `init` is replayed each attempt, so this is only used for
+ * idempotent reads or for requests a 429 guarantees were NOT processed
+ * (a rate-limited request never reached the handler).
+ */
+export async function fetchWithRateLimitRetry(input, init = {}, opts = {}) {
+  const { maxAttempts = DEFAULT_MAX_ATTEMPTS, signal, provider = "upstream" } =
+    opts;
+  const requestInit = signal ? { ...init, signal } : init;
+  for (let attempt = 1; ; attempt += 1) {
+    const res = await fetch(input, requestInit);
+    if (
+      res.ok ||
+      !isRateLimitStatus(res.status, res.headers) ||
+      attempt >= maxAttempts
+    ) {
+      return res;
+    }
+    // Peek at the body for a forwarded retryAfterMs without consuming
+    // the caller-visible stream.
+    let body = null;
+    try {
+      body = await res.clone().json();
+    } catch {
+      /* not JSON — headers still drive the wait */
+    }
+    const waitMs = rateLimitDelayMs(res.status, res.headers, body, attempt);
+    if (waitMs <= 0) return res;
+    notifyRateLimitWait({ provider, waitMs, attempt });
+    // May throw AbortError → propagates to the caller, which treats it
+    // as a cancellation (not a grading failure).
+    await sleep(waitMs, signal);
+  }
+}


### PR DESCRIPTION
Two independent fixes (one commit each).

## 1. `fix(goal-inputs)` — milestone/object values rejected
Saving a Milestone / RecurringMilestone input 400'd with
`{ code: "invalid_union", path: ["value"] }`. The zod request schema
only accepted flat primitives or a record of primitives, but these
widgets store `{ periodKey, items: [{ id, label, done }] }` — a record
whose `items` value is an array of objects.

The controller contract already says `value` is "intentionally
polymorphic … the widget interprets per-spec," and both the TS type
(`Record<string, unknown>`) and the Mongo `$jsonSchema` validator
(bsonType includes `object`/`array`) allow it — only the request schema
was too strict. Replaced the flat union with a **bounded recursive JSON
value** (string/number/boolean caps + array/record breadth caps),
excluding a bare top-level `null` to match the Mongo validator.

## 2. `feat(rate-limit)` — wait + resume instead of failing
Heavy operations (backfill, grade-all, classify) trip GitHub's search
limit (30/min) and the model provider's tier limits. A 429 used to
either throw (GitHub) or get baked into a permanent `errored` verdict
(grading) — so work silently dropped.

Shared backoff honouring the upstream-indicated wait:
- **`api/lib/rate-limit.ts` + `web/lib/rate-limit.js`** — parse
  `Retry-After` / `X-RateLimit-Reset`, detect 429 (and GitHub's 403 +
  `remaining:0`), cancellable sleep, bounded fetch-retry. Web throttles
  a "waiting Ns…" toast so the user sees it's resuming.
- **Server** — `HttpError` carries `retryAfterMs`; the error handler
  emits a `Retry-After` header + `error.retryAfterMs`. `callProvider`
  (chat + grade-pr) retries 429s within budget then forwards the wait;
  the classifier retries per-goal 429s.
- **Client** — `proxyFetch` (all GitHub/GitLab/Jira) waits + retries
  transparently; a persistent limit throws an Error tagged
  `rateLimited`. The grading loop waits + retries and leaves a
  still-limited PR **ungraded** (for a later run) instead of caching a
  permanent failure; an `AbortController` cancels the backoff on unmount
  / rubric change.

Bounded by design: server waits are short (serverless budget); GitHub's
hour-long primary reset is capped at a 2-min client wait, after which
the item is deferred to a later run rather than hanging the tab.

## Test plan
- [x] `npm run typecheck:api` clean
- [x] `npm run build:web` clean
- [ ] Save a Milestone widget value → persists (no `invalid_union`)
- [ ] Grade-all under a forced 429 → pauses with toast, resumes, no
      permanent errored verdicts