### PR TITLE
feat(prefs): migrate user prefs to API-direct (C7)

### DIFF
--- a/apps/api/src/db/schemas/users.schema.ts
+++ b/apps/api/src/db/schemas/users.schema.ts
@@ -104,6 +104,17 @@ export const usersValidator: Document = {
         bsonType: ["string", "null"],
         enum: [...ALL_ENGAGEMENTS, null],
       },
+      // C7: synced user preferences. Optional/nullable so pre-C7 rows
+      // validate; additionalProperties:false on the nested object so a
+      // new pref key is a deliberate schema change, not an accident.
+      prefs: {
+        bsonType: ["object", "null"],
+        additionalProperties: false,
+        properties: {
+          aiProvider: { bsonType: "string", maxLength: 32 },
+          lastReviewDate: { bsonType: "string", maxLength: 40 },
+        },
+      },
       // Companion-app registration (Phase 3). When set, the Vercel
       // catch-all proxies /api/v1/* requests for this user to the
       // companion's tunnel hostname instead of running the bundled

--- a/apps/api/src/db/types.ts
+++ b/apps/api/src/db/types.ts
@@ -221,6 +221,20 @@ export interface User {
   department?: string | null;
 
   /**
+   * C7: synced user preferences — small, additive, self-service
+   * (the user edits these about themselves via PATCH /auth/me).
+   * Readers apply defaults so pre-C7 rows (missing/null) keep working.
+   *   aiProvider     — chat/classify/grade model provider id
+   *                    ("mistral" | "glm" | "openrouter")
+   *   lastReviewDate — ISO date of the user's last formal review,
+   *                    driving the "Since review" date-range preset.
+   *                    "" / absent = unset.
+   * Device-local prefs (last-seen marker, active hub pick) deliberately
+   * stay in the browser — they're per-device by design.
+   */
+  prefs?: { aiProvider?: string; lastReviewDate?: string } | null;
+
+  /**
    * Companion-app registration. When set, the Vercel catch-all
    * (apps/web/src/pages/api/v1/[...path].ts) PROXIES every /api/v1/*
    * call for this user to `hostname` instead of running the bundled

--- a/apps/api/src/modules/auth/controller.ts
+++ b/apps/api/src/modules/auth/controller.ts
@@ -109,6 +109,12 @@ export function toPublicUser(u: User): PublicUser {
     department: u.department ?? null,
     primaryHub: u.primaryHub ?? null,
     engagement: u.engagement ?? "espace",
+    // C7: normalise prefs to an always-present object with null for
+    // unset fields, so the frontend store reads a stable shape.
+    prefs: {
+      aiProvider: u.prefs?.aiProvider ?? null,
+      lastReviewDate: u.prefs?.lastReviewDate ?? null,
+    },
   };
 }
 
@@ -397,6 +403,18 @@ export async function updateMeHandler(
       set.department = payload.department;
       before.department = user.department ?? null;
       after.department = payload.department;
+    }
+    // C7: prefs are PARTIAL — merge the sent keys over the stored prefs
+    // so a `{ aiProvider }` patch doesn't wipe `lastReviewDate`. Only
+    // write when the merged result actually differs.
+    if (payload.prefs !== undefined) {
+      const current = user.prefs ?? {};
+      const merged = { ...current, ...payload.prefs };
+      if (JSON.stringify(merged) !== JSON.stringify(current)) {
+        set.prefs = merged;
+        before.prefs = current;
+        after.prefs = merged;
+      }
     }
 
     if (Object.keys(set).length === 0) {

--- a/apps/api/src/modules/auth/schemas.ts
+++ b/apps/api/src/modules/auth/schemas.ts
@@ -112,10 +112,29 @@ export type PasswordResetInput = z.infer<typeof passwordResetSchema>;
  * Every field is optional. Empty body parses fine but the
  * controller treats it as a no-op (no audit row, no DB write).
  */
+/**
+ * C7: synced user preferences. PARTIAL by design — the client sends
+ * only the key it's changing (e.g. `{ aiProvider }`), and the
+ * controller merges it over the stored prefs. `lastReviewDate` accepts
+ * "" to clear it.
+ */
+const aiProviderId = z.enum(["mistral", "glm", "openrouter"]);
+export const prefsSchema = z
+  .object({
+    aiProvider: aiProviderId.optional(),
+    // ISO date (yyyy-mm-dd or full ISO) or "" to unset. Kept loose —
+    // the date-range preset tolerates an unparseable value by falling
+    // back to a 90-day window.
+    lastReviewDate: z.string().max(40).optional(),
+  })
+  .strict();
+export type PrefsInput = z.infer<typeof prefsSchema>;
+
 export const profileUpdateSchema = z.object({
   displayName: displayName.optional(),
   employeeId: z.string().min(1).max(64).nullable().optional(),
   department: z.string().min(1).max(200).nullable().optional(),
+  prefs: prefsSchema.optional(),
 });
 export type ProfileUpdateInput = z.infer<typeof profileUpdateSchema>;
 
@@ -180,6 +199,15 @@ export interface PublicUser {
    * unset on legacy rows.
    */
   engagement: string;
+  /**
+   * C7: synced user preferences. Always present in the response
+   * (normalised), with null for unset fields. The frontend prefs store
+   * hydrates from this.
+   */
+  prefs: {
+    aiProvider: string | null;
+    lastReviewDate: string | null;
+  };
 }
 
 // ─── companion-tunnel registration (Phase 3) ─────────────────────────

--- a/apps/web/src/features/analyst/reclassify-one-goal.js
+++ b/apps/web/src/features/analyst/reclassify-one-goal.js
@@ -27,6 +27,7 @@
  */
 
 import { ANALYSIS } from "./ai/analysis-events";
+import { getAiProvider } from "./use-ai-provider";
 
 /**
  * Read a ReadableStream of NDJSON line-by-line. Identical to the
@@ -89,10 +90,7 @@ export async function reclassifyOneGoal({ goal, contextAnswers, signal }) {
   if (!goal?.id) {
     throw new Error("reclassifyOneGoal: goal.id is required");
   }
-  const provider =
-    typeof localStorage !== "undefined"
-      ? localStorage.getItem("espace-devhub:ai-provider") || "mistral"
-      : "mistral";
+  const provider = getAiProvider();
 
   // Build the request body. The API trims + filters empty Q/A pairs
   // server-side so we don't repeat that here; we just pass through.

--- a/apps/web/src/features/analyst/use-ai-provider.js
+++ b/apps/web/src/features/analyst/use-ai-provider.js
@@ -1,23 +1,32 @@
 "use client";
 
 /**
- * Client-side AI provider preference.
+ * AI provider preference — account-synced via the prefs store (C7).
  *
- * Stored in localStorage so the choice survives reloads. All three AI
- * routes (`/api/v1/ai/{chat,classify-goals,grade-pr}`) honor either an
- * `x-ai-provider` header or a `provider` field on the request body —
- * we send both to keep server-side selection bulletproof regardless
- * of fetch flavor.
+ * Was localStorage-only; now it rides on the user's server-side prefs
+ * (`user.prefs.aiProvider`) so the choice follows the user across
+ * devices. This module is a thin, back-compat facade over
+ * `@/features/prefs/prefs-store` — the public API (useAiProvider,
+ * getAiProvider, setAiProvider, AI_PROVIDERS) is unchanged so existing
+ * callers don't move.
  *
- * Default is "mistral" (matches what was running before this feature).
- * If the user picks a provider they don't have an API key for, the
- * server returns a 500 with a clear message — handled per-route.
+ * All three AI routes (`/api/v1/ai/{chat,classify-goals,grade-pr}`)
+ * honor either an `x-ai-provider` header or a `provider` body field — we
+ * send both to keep server-side selection bulletproof regardless of
+ * fetch flavor.
+ *
+ * Default is "mistral". Picking a provider with no server-side API key
+ * surfaces a clear 500 per-route.
  */
 
 import { useCallback, useSyncExternalStore } from "react";
+import {
+  getPrefs,
+  getPrefsServerSnapshot,
+  setAiProviderPref,
+  subscribePrefs,
+} from "@/features/prefs/prefs-store";
 
-const STORAGE_KEY = "espace-devhub:ai-provider";
-const CHANGE_EVENT = "ai-provider:change";
 const DEFAULT_PROVIDER = "mistral";
 
 export const AI_PROVIDERS = Object.freeze([
@@ -26,33 +35,9 @@ export const AI_PROVIDERS = Object.freeze([
   { id: "openrouter", label: "OpenRouter", env: "OPENROUTER_API_KEY" },
 ]);
 
-function readProvider() {
-  if (typeof window === "undefined") return DEFAULT_PROVIDER;
-  try {
-    const v = localStorage.getItem(STORAGE_KEY);
-    if (v && AI_PROVIDERS.some((p) => p.id === v)) return v;
-  } catch {
-    /* ignore */
-  }
-  return DEFAULT_PROVIDER;
-}
-
+/** Imperative setter (non-React callers). Persists via the prefs store. */
 export function setAiProvider(id) {
-  if (typeof window === "undefined") return;
-  if (!AI_PROVIDERS.some((p) => p.id === id)) return;
-  localStorage.setItem(STORAGE_KEY, id);
-  window.dispatchEvent(new Event(CHANGE_EVENT));
-}
-
-function subscribe(cb) {
-  if (typeof window === "undefined") return () => {};
-  const handler = () => cb();
-  window.addEventListener(CHANGE_EVENT, handler);
-  window.addEventListener("storage", handler);
-  return () => {
-    window.removeEventListener(CHANGE_EVENT, handler);
-    window.removeEventListener("storage", handler);
-  };
+  void setAiProviderPref(id);
 }
 
 /**
@@ -66,11 +51,11 @@ function subscribe(cb) {
  */
 export function useAiProvider() {
   const provider = useSyncExternalStore(
-    subscribe,
-    readProvider,
-    () => DEFAULT_PROVIDER,
+    subscribePrefs,
+    () => getPrefs().aiProvider,
+    getPrefsServerSnapshot,
   );
-  const setProvider = useCallback((id) => setAiProvider(id), []);
+  const setProvider = useCallback((id) => setAiProviderPref(id), []);
   return {
     provider,
     setProvider,
@@ -80,9 +65,10 @@ export function useAiProvider() {
 }
 
 /**
- * Non-React reader. Some callers (e.g. the grading orchestrator's
- * concurrent fetch loop) use this synchronously inside async fns.
+ * Non-React reader. Some callers (the grading / classify fetch loops)
+ * read this synchronously inside async fns. Backed by the prefs store's
+ * module-level state, hydrated from the session on load.
  */
 export function getAiProvider() {
-  return readProvider();
+  return getPrefs().aiProvider || DEFAULT_PROVIDER;
 }

--- a/apps/web/src/features/analyst/use-classify-goals.js
+++ b/apps/web/src/features/analyst/use-classify-goals.js
@@ -18,6 +18,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getAiProvider } from "./use-ai-provider";
 import { useGoals } from "@/features/goals";
 import { markAnalyzedAt, saveSpec } from "@/features/goal-specs";
 import { ANALYSIS } from "./ai/analysis-events";
@@ -345,10 +346,7 @@ export function useClassifyGoals() {
       const ctrl = new AbortController();
       abortRef.current = ctrl;
       try {
-        const provider =
-          typeof localStorage !== "undefined"
-            ? localStorage.getItem("espace-devhub:ai-provider") || "mistral"
-            : "mistral";
+        const provider = getAiProvider();
         const res = await fetch("/api/v1/ai/classify-goals", {
           method: "POST",
           credentials: "include",

--- a/apps/web/src/features/chat/use-chat.js
+++ b/apps/web/src/features/chat/use-chat.js
@@ -10,6 +10,7 @@
  */
 
 import { useSyncExternalStore } from "react";
+import { getAiProvider } from "@/features/analyst/use-ai-provider";
 
 const STORAGE_KEY = "espace-devhub:chat";
 const CHANGE_EVENT = "chat:change";
@@ -125,13 +126,10 @@ export async function sendChatMessage(_userMessage) {
     throw new Error("Nothing to send — write a message first.");
   }
 
-  // Read the user's provider preference (mistral | glm) from localStorage
-  // and ship it via BOTH the header and the body — server-side
-  // `selectProvider()` checks header first, body second, env third.
-  const provider =
-    typeof localStorage !== "undefined"
-      ? localStorage.getItem("espace-devhub:ai-provider") || "mistral"
-      : "mistral";
+  // Read the user's provider preference and ship it via BOTH the header
+  // and the body — server-side `selectProvider()` checks header first,
+  // body second, env third. Sourced from the synced prefs store (C7).
+  const provider = getAiProvider();
 
   const res = await fetch("/api/v1/ai/chat", {
     method: "POST",

--- a/apps/web/src/features/dashboard/date-range/last-review-store.js
+++ b/apps/web/src/features/dashboard/date-range/last-review-store.js
@@ -1,33 +1,32 @@
 /**
  * "When was your last formal performance review?"
  *
- * One ISO date in localStorage. Backs the `lastreview` date-range preset and
- * the Settings page's "Last review date" input.
+ * Backs the `lastreview` date-range preset and the Settings page's
+ * "Last review date" input. Account-synced via the prefs store (C7) —
+ * was localStorage; now it rides on `user.prefs.lastReviewDate` so the
+ * date follows the user across devices.
  *
- * Empty value → preset falls back to a 90-day rolling window so the chip
- * never produces a confusing empty dashboard for new users.
+ * This module is a thin, back-compat facade over the prefs store: the
+ * public API (readLastReviewDate / writeLastReviewDate /
+ * LAST_REVIEW_CHANGE_EVENT) is unchanged, so presets.js and the account
+ * tab keep working without edits.
+ *
+ * Empty value → the preset falls back to a 90-day rolling window so the
+ * chip never produces a confusing empty dashboard for new users.
  */
 
-const STORAGE_KEY = "espace-devhub:last-review-date";
-const CHANGE_EVENT = "last-review-date:change";
+import {
+  getPrefs,
+  setLastReviewDatePref,
+  LAST_REVIEW_CHANGE_EVENT as PREFS_LAST_REVIEW_CHANGE_EVENT,
+} from "@/features/prefs/prefs-store";
 
-export const LAST_REVIEW_CHANGE_EVENT = CHANGE_EVENT;
+export const LAST_REVIEW_CHANGE_EVENT = PREFS_LAST_REVIEW_CHANGE_EVENT;
 
 export function readLastReviewDate() {
-  if (typeof window === "undefined") return "";
-  try {
-    return localStorage.getItem(STORAGE_KEY) || "";
-  } catch {
-    return "";
-  }
+  return getPrefs().lastReviewDate || "";
 }
 
 export function writeLastReviewDate(iso) {
-  if (typeof window === "undefined") return;
-  if (!iso) {
-    localStorage.removeItem(STORAGE_KEY);
-  } else {
-    localStorage.setItem(STORAGE_KEY, iso);
-  }
-  window.dispatchEvent(new Event(CHANGE_EVENT));
+  void setLastReviewDatePref(iso);
 }

--- a/apps/web/src/features/grading/use-graded-prs.js
+++ b/apps/web/src/features/grading/use-graded-prs.js
@@ -40,6 +40,7 @@ import {
 import { normalizeRubric, rubricHash } from "./rubric-hash";
 import { firstReviewComments } from "./first-review-comments";
 import { fetchWithRateLimitRetry, isRateLimitStatus } from "@/lib/rate-limit";
+import { getAiProvider } from "@/features/analyst/use-ai-provider";
 
 /** Concurrency cap for grading calls — honour Mistral rate limits. */
 const GRADE_CONCURRENCY = 3;
@@ -266,10 +267,7 @@ export function useGradedPrs(spec, options = {}) {
               pr.number,
             );
             if (token.aborted) return;
-            const aiProvider =
-              typeof localStorage !== "undefined"
-                ? localStorage.getItem("espace-devhub:ai-provider") || "mistral"
-                : "mistral";
+            const aiProvider = getAiProvider();
             // Phase F: when firstReviewOnly is set, clip comments
             // to the first-review cluster BEFORE sending. The grader
             // sees only the PR body + the first reviewer comment

--- a/apps/web/src/features/prefs/prefs-store.js
+++ b/apps/web/src/features/prefs/prefs-store.js
@@ -1,0 +1,227 @@
+"use client";
+
+/**
+ * API-direct store for synced user preferences (C7).
+ *
+ * Scope: the two prefs that belong to the PERSON, not the device —
+ *   - aiProvider     ("mistral" | "glm" | "openrouter")
+ *   - lastReviewDate (ISO date driving the "Since review" preset)
+ * Device-local state (last-seen marker, active hub pick) deliberately
+ * stays in localStorage — syncing it would break per-device behaviour.
+ *
+ * Source of truth: the server. Prefs ride down on the session user
+ * (`GET /auth/me` → `user.prefs`, already fetched by SessionProvider),
+ * so this store BRIDGES off the session store instead of issuing its
+ * own fetch. Writes go through `PATCH /auth/me { prefs }` (the existing
+ * self-service profile endpoint), optimistic with rollback.
+ *
+ * Synchronous reads: `getPrefs()` returns module-level state so the
+ * non-React callers that read the AI provider inside async loops
+ * (grading, classify) keep working without awaiting a hook.
+ *
+ * Legacy migration: pre-C7 users have these values only in localStorage.
+ * On first hydration for a user, any legacy value the server doesn't yet
+ * have is migrated up via a one-shot PATCH, then the local key is
+ * dropped. (Auth transitions also wipe the legacy keys via
+ * clear-user-storage.js; we reset to defaults on that event.)
+ */
+
+import { apiPatch } from "@/lib/api-client";
+import { getSession, subscribeSession } from "@/features/auth/session-store";
+
+const DEFAULTS = Object.freeze({ aiProvider: "mistral", lastReviewDate: "" });
+const VALID_PROVIDERS = new Set(["mistral", "glm", "openrouter"]);
+
+// Legacy localStorage keys (pre-C7). Read once for migrate-up, then
+// dropped. Kept in sync with clear-user-storage.js's allowlist.
+const LEGACY_AI_KEY = "espace-devhub:ai-provider";
+const LEGACY_REVIEW_KEY = "espace-devhub:last-review-date";
+
+export const PREFS_CHANGE_EVENT = "prefs:change";
+// Preserved from the old last-review store so existing subscribers
+// (account tab, date-range consumers) keep reacting unchanged.
+export const LAST_REVIEW_CHANGE_EVENT = "last-review-date:change";
+
+let state = { ...DEFAULTS };
+let tick = 0;
+/** Which user id we've already hydrated prefs for — guards against a
+ *  session re-emit clobbering local/optimistic values back to server. */
+let hydratedForUserId = null;
+
+function isAuthError(error) {
+  return (
+    error?.code === "unauthenticated" || error?.code === "totp_required"
+  );
+}
+
+function commit(next) {
+  const prev = state;
+  state = next;
+  tick += 1;
+  if (typeof window === "undefined") return;
+  try {
+    window.dispatchEvent(new Event(PREFS_CHANGE_EVENT));
+  } catch {
+    /* ignore */
+  }
+  // Fire the legacy event ONLY when the review date actually changed,
+  // so subscribers keyed on it don't churn on aiProvider-only updates.
+  if (prev.lastReviewDate !== next.lastReviewDate) {
+    try {
+      window.dispatchEvent(new Event(LAST_REVIEW_CHANGE_EVENT));
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/* ─────────────────────── reads ─────────────────────── */
+
+export function getPrefs() {
+  return state;
+}
+
+export function getPrefsTick() {
+  return tick;
+}
+
+export function getPrefsServerSnapshot() {
+  return 0;
+}
+
+export function subscribePrefs(cb) {
+  if (typeof window === "undefined") return () => {};
+  const handler = () => cb();
+  window.addEventListener(PREFS_CHANGE_EVENT, handler);
+  return () => window.removeEventListener(PREFS_CHANGE_EVENT, handler);
+}
+
+/* ─────────────────────── legacy localStorage ─────────────────────── */
+
+function readLegacy() {
+  if (typeof window === "undefined") return {};
+  const out = {};
+  try {
+    const v = localStorage.getItem(LEGACY_AI_KEY);
+    if (v && VALID_PROVIDERS.has(v)) out.aiProvider = v;
+  } catch {
+    /* ignore */
+  }
+  try {
+    const v = localStorage.getItem(LEGACY_REVIEW_KEY);
+    if (v) out.lastReviewDate = v;
+  } catch {
+    /* ignore */
+  }
+  return out;
+}
+
+function clearLegacy() {
+  if (typeof window === "undefined") return;
+  for (const key of [LEGACY_AI_KEY, LEGACY_REVIEW_KEY]) {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/* ─────────────────────── session bridge ─────────────────────── */
+
+/**
+ * Derive prefs from the current session user. Runs on every session
+ * change but only HYDRATES once per user id (so a later refresh / a
+ * post-write re-emit doesn't overwrite an optimistic local value).
+ */
+function syncFromSession() {
+  if (typeof window === "undefined") return;
+  const { user } = getSession();
+  const uid = user?.id ?? null;
+  if (!uid) return; // logged out — reset handled by the auth event
+  if (uid === hydratedForUserId) return;
+  hydratedForUserId = uid;
+
+  const serverPrefs = user.prefs || {};
+  const legacy = readLegacy();
+
+  // Server value wins; else adopt a legacy localStorage value; else
+  // default. `lastReviewDate === ""` is an INTENTIONAL clear (distinct
+  // from null = never set), so only fall back when it's null/undefined.
+  const aiProvider =
+    (VALID_PROVIDERS.has(serverPrefs.aiProvider) && serverPrefs.aiProvider) ||
+    legacy.aiProvider ||
+    DEFAULTS.aiProvider;
+  const lastReviewDate =
+    serverPrefs.lastReviewDate != null
+      ? serverPrefs.lastReviewDate
+      : legacy.lastReviewDate || DEFAULTS.lastReviewDate;
+
+  commit({ aiProvider, lastReviewDate });
+
+  // One-time migrate-up: push legacy values the server doesn't have yet,
+  // then drop the local keys so we never re-adopt a stale value.
+  const migrate = {};
+  if (serverPrefs.aiProvider == null && legacy.aiProvider) {
+    migrate.aiProvider = legacy.aiProvider;
+  }
+  if (serverPrefs.lastReviewDate == null && legacy.lastReviewDate) {
+    migrate.lastReviewDate = legacy.lastReviewDate;
+  }
+  if (Object.keys(migrate).length > 0) {
+    void apiPatch("/auth/me", { prefs: migrate }).then((r) => {
+      if (r.ok) clearLegacy();
+    });
+  } else {
+    clearLegacy();
+  }
+}
+
+function reset() {
+  hydratedForUserId = null;
+  commit({ ...DEFAULTS });
+}
+
+if (typeof window !== "undefined") {
+  // Re-hydrate when a fresh user's /me lands; reset on logout/login wipe.
+  subscribeSession(() => syncFromSession());
+  window.addEventListener("auth:user-storage-cleared", reset);
+  // Catch a session that already resolved before this module loaded.
+  syncFromSession();
+}
+
+/* ─────────────────────── writes ─────────────────────── */
+
+/**
+ * Persist the AI provider choice. Optimistic + background PATCH; rolls
+ * back on a non-auth failure. No-op for an unknown id or an unchanged
+ * value.
+ */
+export async function setAiProviderPref(id) {
+  if (!VALID_PROVIDERS.has(id) || state.aiProvider === id) return;
+  const prev = state;
+  commit({ ...state, aiProvider: id });
+  const r = await apiPatch("/auth/me", { prefs: { aiProvider: id } });
+  if (!r.ok && !isAuthError(r.error)) {
+    commit(prev);
+    // eslint-disable-next-line no-console
+    console.warn("[prefs] aiProvider save failed:", r.error?.code);
+  }
+}
+
+/**
+ * Persist the last-review date (ISO string, or "" to clear). Optimistic
+ * + background PATCH; rolls back on a non-auth failure.
+ */
+export async function setLastReviewDatePref(iso) {
+  const value = iso || "";
+  if (state.lastReviewDate === value) return;
+  const prev = state;
+  commit({ ...state, lastReviewDate: value });
+  const r = await apiPatch("/auth/me", { prefs: { lastReviewDate: value } });
+  if (!r.ok && !isAuthError(r.error)) {
+    commit(prev);
+    // eslint-disable-next-line no-console
+    console.warn("[prefs] lastReviewDate save failed:", r.error?.code);
+  }
+}


### PR DESCRIPTION
Final localStorage→API store migration. Two **person-level** prefs now sync to the user's account so they follow across devices:
- `aiProvider` — chat/classify/grade model choice
- `lastReviewDate` — drives the "Since review" date-range preset

**Device-local** state (last-seen marker, active hub pick) deliberately stays in localStorage — syncing it would break per-device behavior (confirmed with the requester).

## Backend — prefs ride on the user doc, reusing the existing self-service `PATCH /auth/me`
- `db/types.ts` + `db/schemas/users.schema.ts` — optional/nullable `prefs` object (`additionalProperties:false`)
- `modules/auth/schemas.ts` — `prefs` in `PublicUser` + a strict, partial `prefsSchema`
- `modules/auth/controller.ts` — `/me` returns normalised prefs; `updateMeHandler` **merges** partial prefs so a `{aiProvider}` patch can't wipe `lastReviewDate` (with audit)

## Frontend
- **NEW** `features/prefs/prefs-store.js` — API-direct store that bridges off the session store (no extra `/me` fetch), exposes synchronous reads for async callers, optimistic `PATCH` + rollback, resets on `auth:user-storage-cleared`, and **migrates any legacy localStorage value up once** then drops the local key
- `analyst/use-ai-provider.js` + `dashboard/date-range/last-review-store.js` — thin facades over the store; **public APIs unchanged** so `account-tab`, `presets.js`, `command-palette`, `pr-reviews`, `evidence` keep working untouched
- `chat/use-chat.js`, `analyst/use-classify-goals.js`, `analyst/reclassify-one-goal.js`, `grading/use-graded-prs.js` — the four spots that read the ai-provider localStorage key directly now call `getAiProvider()` (so they don't break once the legacy key is cleared)

## Migration
Existing users keep their settings — legacy localStorage values migrate up automatically on first load. No user action.

## Test plan
- [x] `npm run typecheck:api` clean
- [x] `npm run build:web` clean
- [ ] Change AI provider on device A → reflected on device B after reload
- [ ] Set last-review date in Settings → "Since review" preset uses it; persists across reload/devices
- [ ] Pre-C7 localStorage value present → migrates up on first load, local key cleared