### PR TITLE
feat(integrations): provider-agnostic review timing — GitLab parity (ph.1-2)

### DIFF
--- a/apps/web/src/features/integrations/api-clients/gitlab-normalize.js
+++ b/apps/web/src/features/integrations/api-clients/gitlab-normalize.js
@@ -1,0 +1,111 @@
+/**
+ * GitLab → common-shape adapters.
+ *
+ * Counterpart to `github-normalize.js`. The provider-agnostic layers
+ * (review-timing, CODE_RUBRIC grading, the merged-MR metrics) were all
+ * written against one shape; these adapters map GitLab's MR + notes
+ * payloads onto it so a GitLab-only user gets the same features a
+ * GitHub user does — review timing, rubric grading, etc.
+ *
+ * Two shapes produced here:
+ *
+ *   MR DETAILS (matches `githubApi.pullDetails`):
+ *     { title, body, state, author, createdAt, mergedAt, htmlUrl,
+ *       baseRef, headRef,
+ *       comments: [{ id, user, body, kind:"issue"|"review", createdAt,
+ *                    path?, line?, htmlUrl? }] }
+ *
+ *   MERGED MR (matches `normalizeGithubMergedSearch` output):
+ *     the native GitLab MR plus `source:"gitlab"` and a `number` alias —
+ *     so the combined merged list can route each item to its provider's
+ *     details fetch via `parseGitlabLocator`.
+ */
+
+/**
+ * Map one GitLab MR note → the common comment shape.
+ *
+ * GitLab note kinds:
+ *   - `system: true`           auto-generated ("approved", "added 1 commit",
+ *                              "changed the description"). EXCLUDED — these
+ *                              aren't human review comments, and counting
+ *                              them would inflate review-timing/round metrics
+ *                              (GitHub's pullDetails likewise omits bare
+ *                              approvals / system activity).
+ *   - `type: "DiffNote"`       inline code-review comment → kind "review"
+ *   - `type: "DiscussionNote"` / null   conversation comment → kind "issue"
+ */
+function noteToComment(n) {
+  const pos = n?.position || null;
+  return {
+    id: n?.id,
+    user: n?.author?.username || "unknown",
+    body: typeof n?.body === "string" ? n.body : "",
+    kind: n?.type === "DiffNote" ? "review" : "issue",
+    createdAt: n?.created_at || null,
+    path: pos?.new_path || pos?.old_path || null,
+    line: pos?.new_line ?? pos?.old_line ?? null,
+    htmlUrl: null, // GitLab notes carry no direct permalink in this payload
+  };
+}
+
+/**
+ * Normalize a GitLab MR + its notes into the common PR-details shape
+ * (the same contract `githubApi.pullDetails` returns), so review-timing
+ * and the AI grader consume both providers identically.
+ */
+export function normalizeGitlabMrDetails(mr, notes) {
+  const human = (Array.isArray(notes) ? notes : []).filter(
+    (n) => n && !n.system,
+  );
+  return {
+    title: mr?.title || "",
+    body: typeof mr?.description === "string" ? mr.description : "",
+    state: mr?.merged_at
+      ? "merged"
+      : mr?.state === "opened"
+        ? "open"
+        : mr?.state || "open",
+    author: mr?.author?.username || null,
+    createdAt: mr?.created_at || null,
+    mergedAt: mr?.merged_at || null,
+    htmlUrl: mr?.web_url || null,
+    baseRef: mr?.target_branch || null,
+    headRef: mr?.source_branch || null,
+    comments: human.map(noteToComment),
+  };
+}
+
+/**
+ * Tag a GitLab merged-MR list with `source:"gitlab"` + a `number` alias
+ * (GitHub's records use `number`). All native fields the metrics layer
+ * reads — merged_at, created_at, title, description, source_branch,
+ * user_notes_count, web_url, project_id, iid — are preserved verbatim.
+ *
+ * Additive only: pre-existing consumers keep working; the new fields let
+ * the combined list route each item back to its provider for a details
+ * fetch (see `parseGitlabLocator`).
+ */
+export function normalizeGitlabMerged(resp) {
+  const items = Array.isArray(resp) ? resp : [];
+  return items
+    .filter((mr) => mr && mr.merged_at)
+    .map((mr) => ({
+      ...mr,
+      source: "gitlab",
+      number: mr.iid,
+    }));
+}
+
+/**
+ * Resolve `{ projectId, iid }` for a details fetch from a normalized
+ * GitLab MR record. GitLab list/object payloads carry both natively, so
+ * no URL parsing is needed (and the numeric project_id can't be
+ * recovered from web_url anyway). Returns null when the record isn't a
+ * GitLab MR.
+ */
+export function parseGitlabLocator(mr) {
+  if (mr?.project_id != null && mr?.iid != null) {
+    return { projectId: mr.project_id, iid: mr.iid };
+  }
+  return null;
+}

--- a/apps/web/src/features/integrations/api-clients/gitlab.js
+++ b/apps/web/src/features/integrations/api-clients/gitlab.js
@@ -1,5 +1,6 @@
 import { proxyFetch } from "./proxy-fetch";
 import { readIntegrations } from "../integrations-store";
+import { normalizeGitlabMrDetails } from "./gitlab-normalize";
 
 /**
  * Page through a GitLab list endpoint until a short page comes back
@@ -65,4 +66,29 @@ export const gitlabApi = {
       "gitlab",
       `events?after=${encodeURIComponent(isoDate.slice(0, 10))}&per_page=100`,
     ),
+
+  /**
+   * MR description + all notes (conversation + inline diff) in one shot,
+   * normalized to the SAME shape as `githubApi.pullDetails` so the
+   * review-timing + CODE_RUBRIC-grading layers consume both providers
+   * identically. `projectId` is the numeric `project_id` and `iid` the
+   * per-project MR number — both present natively on the merged-MR list
+   * records (see `parseGitlabLocator`).
+   *
+   * Notes are fetched ascending so they arrive chronologically (the
+   * timing math sorts anyway). Single page of 100 mirrors GitHub's
+   * pullDetails; system notes (approvals / "added N commits") are
+   * dropped in the normalizer.
+   */
+  mrDetails: async (projectId, iid) => {
+    const base = `projects/${encodeURIComponent(projectId)}/merge_requests/${encodeURIComponent(iid)}`;
+    const [mr, notes] = await Promise.all([
+      proxyFetch("gitlab", base),
+      proxyFetch(
+        "gitlab",
+        `${base}/notes?per_page=100&sort=asc&order_by=created_at`,
+      ),
+    ]);
+    return normalizeGitlabMrDetails(mr, notes);
+  },
 };

--- a/apps/web/src/features/integrations/api-clients/index.js
+++ b/apps/web/src/features/integrations/api-clients/index.js
@@ -7,3 +7,8 @@ export {
   normalizeGithubMergedSearch,
   normalizeGithubEvents,
 } from "./github-normalize";
+export {
+  normalizeGitlabMrDetails,
+  normalizeGitlabMerged,
+  parseGitlabLocator,
+} from "./gitlab-normalize";

--- a/apps/web/src/features/integrations/hooks/use-gitlab-merged.js
+++ b/apps/web/src/features/integrations/hooks/use-gitlab-merged.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { gitlabApi } from "../api-clients";
+import { gitlabApi, normalizeGitlabMerged } from "../api-clients";
 import { useIntegrations } from "../use-integrations";
 import { useSwrIf } from "./use-swr-if";
 import { isoDaysAgo } from "@/lib/date";
@@ -19,7 +19,7 @@ export function useGitlabMergedSince(since) {
         ? isoDaysAgo(since)
         : since;
   return useSwrIf(isConnected("gitlab"), `gitlab:merged:${iso}`, () =>
-    gitlabApi.myMergedSince(iso),
+    gitlabApi.myMergedSince(iso).then(normalizeGitlabMerged),
   );
 }
 

--- a/apps/web/src/features/integrations/hooks/use-pr-review-timings.js
+++ b/apps/web/src/features/integrations/hooks/use-pr-review-timings.js
@@ -3,24 +3,29 @@
 import useSWR from "swr";
 import { useCombinedMergedSince } from "./use-combined";
 import { githubApi } from "../api-clients/github";
+import { gitlabApi } from "../api-clients/gitlab";
+import { parseGitlabLocator } from "../api-clients/gitlab-normalize";
 import { computePrReviewTiming } from "../metrics/review-timing";
 
 /**
- * For every merged PR in the window, fetch its conversation + review-line
+ * For every merged PR/MR in the window, fetch its conversation + review
  * comments and compute review-timing stats (TTFR, ATTNR, idle).
  *
- * GitHub-only today — GitLab MRs are surfaced in the list but skipped for
- * details (their REST shape is different and needs a separate adapter).
- * The tile/page label "GitHub PRs" reflects this; GitLab support can plug
- * in later by extending `parseGithubLocator` and the fetch branch.
+ * Provider-agnostic: each item in the combined merged list is routed to
+ * its own provider's details fetch — `githubApi.pullDetails` for GitHub
+ * PRs, `gitlabApi.mrDetails` for GitLab MRs — both of which return the
+ * SAME normalized `{ createdAt, author, comments:[{user,createdAt,…}] }`
+ * shape, so `computePrReviewTiming` consumes them identically. A GitLab-
+ * only user now gets the same review-timing section a GitHub user does.
  *
  * Network discipline:
- *   - One SWR cache entry keyed by the sorted PR ids in the window. Same
- *     window across tiles → one fetch.
- *   - Bounded concurrency (`CONCURRENCY`) so we don't hammer GitHub's
- *     5000-req/hr secondary limit when the user has 30+ merged PRs.
- *   - Per-PR errors are isolated: a failing PR yields `null` and the rest
- *     still come back. The aggregate metric just ignores nulls.
+ *   - One SWR cache entry keyed by the sorted item ids in the window.
+ *     Same window across tiles → one fetch.
+ *   - Bounded concurrency (`CONCURRENCY`) so a 30+ MR/PR window doesn't
+ *     hammer a provider's secondary rate limit (and proxyFetch's
+ *     rate-limit wait/resume backs that up).
+ *   - Per-item errors are isolated: a failing item yields a null timing
+ *     and the rest still come back; the aggregate ignores nulls.
  */
 
 const CONCURRENCY = 4;
@@ -29,10 +34,10 @@ export function usePrReviewTimings(since) {
   const { data: prs, isLoading: listLoading, error: listError } =
     useCombinedMergedSince(since);
 
-  // Stable key — sorted PR ids — so SWR re-fetches only when the window or
-  // the PR set actually changes, not on every render.
-  const ghPrs = (prs || []).filter((p) => p.source === "github");
-  const idsKey = ghPrs
+  const list = prs || [];
+  // Stable key — sorted ids across BOTH providers — so SWR re-fetches
+  // only when the window or the item set actually changes.
+  const idsKey = list
     .map((p) => p.id)
     .filter(Boolean)
     .sort()
@@ -42,11 +47,35 @@ export function usePrReviewTimings(since) {
   const swr = useSWR(
     swrKey,
     async () => {
-      const tasks = ghPrs
+      // Build a per-item task carrying a provider-specific details
+      // fetcher. Items we can't locate (no parseable locator) are
+      // dropped rather than failing the batch.
+      const tasks = list
         .map((pr) => {
+          if (pr?.source === "gitlab") {
+            const loc = parseGitlabLocator(pr);
+            if (!loc) return null;
+            return {
+              pr,
+              source: "gitlab",
+              owner: null,
+              repo: null,
+              number: pr.number ?? loc.iid,
+              fetchDetails: () => gitlabApi.mrDetails(loc.projectId, loc.iid),
+            };
+          }
+          // Default to GitHub (source "github" or legacy untagged).
           const loc = parseGithubLocator(pr);
           if (!loc) return null;
-          return { pr, loc };
+          return {
+            pr,
+            source: "github",
+            owner: loc.owner,
+            repo: loc.repo,
+            number: pr.number ?? loc.number,
+            fetchDetails: () =>
+              githubApi.pullDetails(loc.owner, loc.repo, loc.number),
+          };
         })
         .filter(Boolean);
 
@@ -58,32 +87,28 @@ export function usePrReviewTimings(since) {
           while (true) {
             const i = cursor++;
             if (i >= tasks.length) return;
-            const { pr, loc } = tasks[i];
+            const t = tasks[i];
             try {
-              const details = await githubApi.pullDetails(
-                loc.owner,
-                loc.repo,
-                loc.number,
-              );
+              const details = await t.fetchDetails();
               const timing = computePrReviewTiming(
                 {
-                  createdAt: details.createdAt || pr.created_at,
+                  createdAt: details.createdAt || t.pr.created_at,
                   author: details.author,
                 },
                 details.comments || [],
               );
               out.push({
                 pr: {
-                  id: pr.id,
-                  number: pr.number || loc.number,
-                  title: pr.title || details.title || "",
-                  htmlUrl: pr.web_url || details.htmlUrl || null,
-                  owner: loc.owner,
-                  repo: loc.repo,
-                  createdAt: details.createdAt || pr.created_at,
-                  mergedAt: details.mergedAt || pr.merged_at,
+                  id: t.pr.id,
+                  number: t.number,
+                  title: t.pr.title || details.title || "",
+                  htmlUrl: t.pr.web_url || details.htmlUrl || null,
+                  owner: t.owner,
+                  repo: t.repo,
+                  createdAt: details.createdAt || t.pr.created_at,
+                  mergedAt: details.mergedAt || t.pr.merged_at,
                   author: details.author,
-                  source: "github",
+                  source: t.source,
                 },
                 details,
                 timing,
@@ -91,16 +116,16 @@ export function usePrReviewTimings(since) {
             } catch {
               out.push({
                 pr: {
-                  id: pr.id,
-                  number: pr.number || loc.number,
-                  title: pr.title || "",
-                  htmlUrl: pr.web_url || null,
-                  owner: loc.owner,
-                  repo: loc.repo,
-                  createdAt: pr.created_at,
-                  mergedAt: pr.merged_at,
+                  id: t.pr.id,
+                  number: t.number,
+                  title: t.pr.title || "",
+                  htmlUrl: t.pr.web_url || null,
+                  owner: t.owner,
+                  repo: t.repo,
+                  createdAt: t.pr.created_at,
+                  mergedAt: t.pr.merged_at,
                   author: null,
-                  source: "github",
+                  source: t.source,
                 },
                 details: null,
                 timing: null,
@@ -121,7 +146,7 @@ export function usePrReviewTimings(since) {
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,
-      // PR comments don't move once a PR is merged — cache for 5 min.
+      // PR/MR comments don't move once merged — cache for 5 min.
       dedupingInterval: 5 * 60_000,
     },
   );
@@ -134,11 +159,11 @@ export function usePrReviewTimings(since) {
 }
 
 /**
- * Parse `{owner, repo, number}` out of the merged-PR record.
+ * Parse `{owner, repo, number}` out of a GitHub merged-PR record.
  *
  * GitHub web_url shape: `https://github.com/{owner}/{repo}/pull/{n}`
- * (issue search returns this directly as `html_url`; the normalizer
- * passes it through as `web_url`.)
+ * (issue search returns this as `html_url`; the normalizer passes it
+ * through as `web_url`). Returns null for non-GitHub URLs.
  */
 export function parseGithubLocator(pr) {
   const url = pr?.web_url || "";


### PR DESCRIPTION
First two phases of making the GitHub-centric components render **GitLab** data too, based on which provider the user connected. (The dashboard tiles, snapshots, evidence, check-in and goal-widget data sources are *already* provider-agnostic via `useCombinedMergedSince`/`useCombinedEventsSince`; this addresses the remaining per-PR-detail holdouts.)

## Phase 1 — GitLab parity foundation
- **NEW `api-clients/gitlab-normalize.js`** — maps a GitLab MR + its notes into the **exact** shape `githubApi.pullDetails` returns (`{title, body, author, createdAt, mergedAt, comments:[{user, body, kind, createdAt, path?, line?}]}`). System notes (approvals / "added N commits") are dropped to match GitHub's human-comment semantics. Also `normalizeGitlabMerged` (tags the merged list `source:"gitlab"`) and `parseGitlabLocator` (`{projectId, iid}` from native MR fields).
- **`gitlabApi.mrDetails(projectId, iid)`** — fetches MR + notes, returns the normalized shape.
- `use-gitlab-merged` tags items `source:"gitlab"` (additive; metrics ignore `source`).

## Phase 2 — review timing provider-agnostic
- `usePrReviewTimings` routes **each** item in the combined merged list to its own provider's details fetch (`pullDetails` for GitHub, `mrDetails` for GitLab), then runs the same `computePrReviewTiming`. **Dropped the `source === "github"` filter** — a GitLab-only user now gets the full review-timing section (TTFR / ATTNR / idle, "most idle" list) instead of an empty one.

## Still to come
- **Phase 3**: grading / CODE_RUBRIC (still GitHub-only via `myPrsSince` + `pullDetails`)
- **Phase 4**: "PRs / MRs" wording sweep

## Test plan
- [x] `npm run build:web` clean
- [ ] GitLab-only account: review-timing tile + PR-reviews page populate from MRs (TTFR/idle computed from MR notes)
- [ ] Mixed GitHub+GitLab account: both providers' items appear, each routed to the right details fetch