### PR TITLE
fix(dashboard): attention band ingests GitHub PRs too — provider symmetry (ph.4)

### DIFF
--- a/apps/web/src/features/dashboard/attention-band.jsx
+++ b/apps/web/src/features/dashboard/attention-band.jsx
@@ -4,16 +4,25 @@ import { MonoLabel } from "@/components/ui";
 import {
   deriveAttention,
   useGitlabOpenMRs,
+  useGithubOpenPulls,
   useJiraTickets,
 } from "@/features/integrations";
 import { useMyEngagementConfig } from "@/features/auth";
 
 export function AttentionBand() {
-  const { data: openMRs } = useGitlabOpenMRs();
+  const { data: glOpen } = useGitlabOpenMRs();
+  const { data: ghOpen } = useGithubOpenPulls();
   const { data: tickets } = useJiraTickets();
   const { config: engagementCfg } = useMyEngagementConfig();
+  // Union both providers' open items so a GitHub-only user gets stale-PR
+  // nudges too (mirror of the GitLab MR path). Tag each with its source
+  // so deriveAttention picks the right field names + ref notation.
+  const openItems = [
+    ...(glOpen || []).map((m) => ({ ...m, source: "gitlab" })),
+    ...(ghOpen?.items || []).map((p) => ({ ...p, source: "github" })),
+  ];
   const items = deriveAttention({
-    openMRs: openMRs || [],
+    openMRs: openItems,
     tickets: tickets?.issues || [],
     // Per-user Jira base — eSpace devs get eSpace's Jira host,
     // Crealogix devs get Crealogix's. Env fallback for early mount.

--- a/apps/web/src/features/goal-widgets/widgets/code-rubric-widget.jsx
+++ b/apps/web/src/features/goal-widgets/widgets/code-rubric-widget.jsx
@@ -181,8 +181,9 @@ export function CodeRubricWidget({ spec, goal, variant = "light", className, onR
           <EmptyNote variant={variant}>
             {isRateLimit ? (
               <>
-                GitHub rate limit hit — 30 search requests/minute per user.
-                Wait ~60 seconds and press <strong>Retry</strong>.
+                Provider rate limit hit — the grader pauses and retries
+                automatically; wait a moment and press <strong>Retry</strong>{" "}
+                if it stalls.
                 <br />
                 <span
                   style={{

--- a/apps/web/src/features/integrations/metrics/attention.js
+++ b/apps/web/src/features/integrations/metrics/attention.js
@@ -1,10 +1,16 @@
 import { DAY_MS } from "@/lib/date";
 
 /**
- * Derive "needs your attention" items from open MRs + Jira tickets.
+ * Derive "needs your attention" items from open PRs/MRs + Jira tickets.
  *
- * - **Stale PR**: open MR where the last update was > 3 days ago.
+ * - **Stale PR/MR**: open item whose last update was > 3 days ago.
  * - **Old ticket**: In-Progress/Blocked Jira ticket with no status change in > 7 days.
+ *
+ * Provider-agnostic: each open item may be a GitLab MR or a GitHub PR.
+ * The two carry different field names (`web_url`/`html_url`,
+ * `iid`/`number`, `user_notes_count`/`comments`), so we read both with a
+ * fallback; `item.source` ("gitlab"|"github") picks the `!`/`#` ref
+ * notation (attention-band tags each item with its source).
  *
  * Returns an array of compact `{ id, kind, severity, ref, title, detail, href }`
  * records, capped at `limit`.
@@ -14,18 +20,26 @@ export function deriveAttention({ openMRs = [], tickets = [], jiraBaseUrl, limit
   const items = [];
 
   for (const mr of openMRs) {
-    const updated = new Date(mr.updated_at).getTime();
+    const updatedAt = mr.updated_at ?? mr.updatedAt;
+    const updated = updatedAt ? new Date(updatedAt).getTime() : NaN;
     const ageDays = (now - updated) / DAY_MS;
+    if (!Number.isFinite(ageDays)) continue; // no/invalid timestamp → skip
     if (ageDays >= 3) {
+      const number = mr.iid ?? mr.number;
+      const comments = mr.user_notes_count ?? mr.comments ?? 0;
+      const url = mr.web_url ?? mr.html_url;
+      const refPrefix = mr.source === "github" ? "#" : "!";
       items.push({
-        id: `mr-${mr.id}`,
+        // Source-prefixed so a GitLab MR id and a GitHub PR id can't
+        // collide on the React key.
+        id: `${mr.source || "mr"}-${mr.id}`,
         kind: "stale-pr",
         severity: ageDays >= 6 ? "high" : "med",
-        ref: `!${mr.iid}`,
+        ref: `${refPrefix}${number}`,
         title: mr.title,
-        detail: `${Math.round(ageDays)}d since last update${mr.user_notes_count ? ` · ${mr.user_notes_count} comments` : ""}`,
+        detail: `${Math.round(ageDays)}d since last update${comments ? ` · ${comments} comments` : ""}`,
         action: "Respond",
-        href: mr.web_url,
+        href: url,
       });
     }
   }


### PR DESCRIPTION
Provider-symmetry audit follow-up to the GitLab-parity work (#145, #146). I swept every provider-specific (non-combined) hook consumer to find one-sided wiring in *either* direction.

## Found + fixed: one inverse gap
The **attention band** derived stale-PR nudges from `useGitlabOpenMRs` **only** — a GitHub-only user never saw their stale open PRs flagged (mirror of the bug fixed for GitLab earlier).
- `attention-band` now unions GitLab open MRs + GitHub open PRs (tagged with `source`), matching what `prs-tile` already does.
- `deriveAttention` reads both field shapes with a fallback (`web_url`/`html_url`, `iid`/`number`, `user_notes_count`/`comments`) and picks the `!`/`#` ref by source; ids are source-prefixed (no React-key collision). Added a guard so a missing/invalid timestamp is skipped, not treated as epoch-old → falsely "stale".
- `code-rubric-widget`: the rate-limit hint hardcoded *"GitHub rate limit — 30 search req/min"* → now provider-neutral (grading hits both providers + auto-retries).

## Audit result (what I checked)
| Surface | Status |
|---|---|
| merged PRs/MRs, events, heatmap/activity/commits/reviews | already combined ✅ |
| review timing | combined in #145 ✅ |
| grading / CODE_RUBRIC | combined in #146 ✅ |
| open PRs/MRs + review requests — **prs-tile** | already both ✅ |
| open PRs — **attention-band** | **was GitLab-only → fixed here** |

## One known remaining asymmetry (out of scope here)
CI metrics (DEPLOY_FREQUENCY / LEAD_TIME / BUILD_PASS_RATE) support `provider: jenkins | github_actions` but there's **no GitLab-pipelines source**. That's a *new integration* to add, not a "make existing GitHub components show GitLab data" gap — flagging it rather than silently leaving it.

## Test plan
- [x] `npm run build:web` clean
- [ ] GitHub-only account with a 4+ day-old open PR → appears in the attention band as a stale-PR nudge with `#`-ref
- [ ] GitLab-only + mixed accounts → unchanged behavior, `!`-ref for MRs