### PR TITLE
feat(dashboard): goal-compliance tile, drop LIVE badge, daily review-timing cache

### DIFF
--- a/apps/web/src/components/shell/header.jsx
+++ b/apps/web/src/components/shell/header.jsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LogoMark } from "./logo-mark";
 import { AnalystActivator } from "@/features/analyst";
-import { useIntegrations } from "@/features/integrations";
 import { UserChip } from "@/features/auth";
 import { CompanionIndicator } from "@/features/companion";
 import { useActiveHub, HubSwitcher } from "@/features/hubs";
@@ -71,8 +70,6 @@ const VERSION = "v0.3.1";
 
 export function Header() {
   const pathname = usePathname();
-  const { connectedProviders } = useIntegrations();
-  const isLive = connectedProviders.length > 0;
   const hub = useActiveHub();
 
   // Build the hub-prefixed link for each nav slot. Without an active
@@ -137,21 +134,6 @@ export function Header() {
         </nav>
       </div>
       <div className="flex items-center gap-3.5">
-        <div
-          className="flex items-center gap-1.5 text-[11px] text-muted-fg"
-          style={{ fontFamily: "var(--font-mono)" }}
-        >
-          <span
-            className="block h-1.5 w-1.5 rounded-full"
-            style={{
-              background: isLive ? "var(--accent-2)" : "var(--dim-fg)",
-              boxShadow: isLive ? "0 0 0 3px rgba(0,196,138,0.2)" : "none",
-            }}
-          />
-          {isLive
-            ? `LIVE · ${connectedProviders.length} integration${connectedProviders.length === 1 ? "" : "s"}`
-            : "NOT CONNECTED"}
-        </div>
         {/* Inverse-themed activator — opens the accent-ground analyst page. */}
         <AnalystActivator />
         {/* Companion-routing indicator — self-hides when the user has

--- a/apps/web/src/features/auth/clear-user-storage.js
+++ b/apps/web/src/features/auth/clear-user-storage.js
@@ -57,6 +57,7 @@ const USER_SCOPED_KEYS = Object.freeze([
   "espace-devhub:last-review-date",
   "espace-devhub:active-hub-pick",
   "espace-devhub:migrate-completed-by-user",
+  "espace-devhub:review-timing-cache",
   "eshub:qa:config:v1",
 ]);
 

--- a/apps/web/src/features/dashboard/sections/overview-section.jsx
+++ b/apps/web/src/features/dashboard/sections/overview-section.jsx
@@ -4,7 +4,7 @@ import { Section } from "../scroll-shell";
 import { Hero } from "../hero";
 import { DateRangeToolbar } from "../date-range";
 import {
-  IntegrationsTile,
+  GoalComplianceTile,
   MergedTile,
   RoundsTile,
   LinkageTile,
@@ -18,7 +18,7 @@ import {
  *   hero (grid, 2-col: headline + 280x180 signal)
  *   date range toolbar
  *   glance grid: 12-col, 150px auto-rows, 2 rows total
- *     [Integrations 3×2] [Merged 4×2] [Rounds 2×2] [Linkage 3×2]
+ *     [Goal compliance 3×2] [Merged 4×2] [Rounds 2×2] [Linkage 3×2]
  *
  * No `.sec-head` per mock — Hero is the top of the page.
  */
@@ -52,7 +52,7 @@ export function OverviewSection() {
         className="grid min-h-0 flex-1 grid-cols-12 gap-3.5"
         style={{ gridAutoRows: "minmax(0, 1fr)" }}
       >
-        <IntegrationsTile />
+        <GoalComplianceTile />
         <MergedTile />
         <RoundsTile />
         <LinkageTile />

--- a/apps/web/src/features/dashboard/tiles/goal-compliance-tile.jsx
+++ b/apps/web/src/features/dashboard/tiles/goal-compliance-tile.jsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+import { BentoTile } from "@/components/ui";
+import { useComplianceSummary } from "@/features/snapshots";
+import { useHubLink } from "@/features/hubs";
+
+/**
+ * Overview glance-grid tile: how many tracked goals are currently on
+ * pace, rolled up from the snapshot compliance stream. Replaces the old
+ * Integrations status card (connection state already lives in the header
+ * + Settings).
+ */
+export function GoalComplianceTile() {
+  const { met, assessable, pct } = useComplianceSummary();
+  const link = useHubLink();
+  const hasData = assessable > 0;
+
+  return (
+    <BentoTile
+      col="span 3"
+      row="span 2"
+      label={`Goal compliance${hasData ? ` · ${assessable} tracked` : ""}`}
+      right={
+        <Link
+          href={link("/goals")}
+          className="text-[10px] uppercase tracking-[0.4px] text-muted-fg hover:text-fg"
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          View goals ↗
+        </Link>
+      }
+    >
+      {!hasData ? (
+        <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
+          <div className="text-[13px] font-semibold text-fg">
+            No closed windows yet
+          </div>
+          <div className="max-w-[200px] text-[11px] leading-[1.45] text-muted-fg">
+            Weekly snapshots build your goal-compliance read — check back
+            after the first capture.
+          </div>
+        </div>
+      ) : (
+        <div className="mt-1 flex h-full flex-col justify-center gap-3">
+          <div className="flex items-baseline gap-2">
+            <span
+              className="font-bold text-fg"
+              style={{
+                fontFamily: "var(--font-display)",
+                fontSize: 32,
+                lineHeight: 1,
+              }}
+            >
+              {met}/{assessable}
+            </span>
+            <span
+              className="uppercase tracking-[0.4px] text-muted-fg"
+              style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+            >
+              goals on pace
+            </span>
+          </div>
+          <div>
+            <div
+              className="mb-1 flex items-center justify-between uppercase tracking-[0.4px] text-muted-fg"
+              style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}
+            >
+              <span>On target</span>
+              <span className="font-bold text-accent">{pct}%</span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-card-alt">
+              <div
+                className="h-full rounded-full bg-accent transition-[width]"
+                style={{ width: `${pct ?? 0}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </BentoTile>
+  );
+}

--- a/apps/web/src/features/dashboard/tiles/index.js
+++ b/apps/web/src/features/dashboard/tiles/index.js
@@ -1,4 +1,5 @@
 export { IntegrationsTile } from "./integrations-tile";
+export { GoalComplianceTile } from "./goal-compliance-tile";
 export { MergedTile } from "./merged-tile";
 export { RoundsTile } from "./rounds-tile";
 export { LinkageTile } from "./linkage-tile";

--- a/apps/web/src/features/integrations/hooks/use-pr-review-timings.js
+++ b/apps/web/src/features/integrations/hooks/use-pr-review-timings.js
@@ -30,6 +30,51 @@ import { computePrReviewTiming } from "../metrics/review-timing";
 
 const CONCURRENCY = 4;
 
+// Once-a-day persistent cache. The per-PR/MR detail fetches are the
+// expensive part (one round-trip per item); merged items never change,
+// so we cache the computed timings keyed by (day, item-set) and only
+// refetch when the calendar day rolls over or the item set changes.
+const CACHE_KEY = "espace-devhub:review-timing-cache";
+// Cap the persisted payload so a heavy author's full comment set can't
+// blow the ~5MB localStorage budget — over the cap we just skip
+// persisting (SWR's in-memory cache still serves the session; the next
+// day refetches).
+const MAX_CACHE_BYTES = 2_000_000;
+
+function todayStamp() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function readTimingCache(day, idsKey) {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw);
+    if (
+      parsed?.day === day &&
+      parsed?.idsKey === idsKey &&
+      Array.isArray(parsed.data)
+    ) {
+      return parsed.data;
+    }
+  } catch {
+    /* corrupt / unavailable — treat as a miss */
+  }
+  return undefined;
+}
+
+function writeTimingCache(day, idsKey, data) {
+  if (typeof window === "undefined") return;
+  try {
+    const payload = JSON.stringify({ day, idsKey, data });
+    if (payload.length > MAX_CACHE_BYTES) return;
+    localStorage.setItem(CACHE_KEY, payload);
+  } catch {
+    /* quota / disabled — fine, the section just refetches next load */
+  }
+}
+
 export function usePrReviewTimings(since) {
   const { data: prs, isLoading: listLoading, error: listError } =
     useCombinedMergedSince(since);
@@ -42,7 +87,13 @@ export function usePrReviewTimings(since) {
     .filter(Boolean)
     .sort()
     .join(",");
-  const swrKey = idsKey ? `pr-review-timings:${idsKey}` : null;
+  // Day-stamped key + a localStorage fallback give the section a cache
+  // that revalidates at most ONCE per day: same day + same item set →
+  // served from cache (even across reloads); a new day (or a changed
+  // item set) busts the key and refetches once.
+  const day = todayStamp();
+  const swrKey = idsKey ? `pr-review-timings:${day}:${idsKey}` : null;
+  const cached = swrKey ? readTimingCache(day, idsKey) : undefined;
 
   const swr = useSWR(
     swrKey,
@@ -141,13 +192,19 @@ export function usePrReviewTimings(since) {
         const bm = b.pr.mergedAt ? Date.parse(b.pr.mergedAt) : 0;
         return bm - am;
       });
+      writeTimingCache(day, idsKey, out);
       return out;
     },
     {
       revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      // Don't refetch while we have data (in-memory or the day-stamped
+      // localStorage fallback) — the day-stamped key is what forces the
+      // once-daily refresh.
+      revalidateIfStale: false,
       shouldRetryOnError: false,
-      // PR/MR comments don't move once merged — cache for 5 min.
-      dedupingInterval: 5 * 60_000,
+      dedupingInterval: 24 * 60 * 60_000,
+      ...(cached ? { fallbackData: cached } : {}),
     },
   );
 

--- a/apps/web/src/features/snapshots/index.js
+++ b/apps/web/src/features/snapshots/index.js
@@ -26,6 +26,7 @@ export { useAutoSnapshot } from "./use-auto-snapshot";
 export { captureGoalReadings } from "./capture-readings";
 export { goalCompliance } from "./compliance";
 export { useSnapshotCompliance } from "./use-snapshot-compliance";
+export { useComplianceSummary } from "./use-compliance-summary";
 export { useBackfill } from "./use-backfill";
 export { synthesiseWeek } from "./synthesise-week";
 export { BackfillBanner } from "./backfill-banner";

--- a/apps/web/src/features/snapshots/use-compliance-summary.js
+++ b/apps/web/src/features/snapshots/use-compliance-summary.js
@@ -1,0 +1,62 @@
+"use client";
+
+/**
+ * Aggregate goal-compliance across every tracked goal in the snapshot
+ * stream — the data behind the Overview "Goal compliance" tile.
+ *
+ * Returns `{ met, assessable, pct }`:
+ *   - assessable: goals with a boolean compliance signal (excludes
+ *     delegated goals, goals with no target, and goals with no readings
+ *     yet — none of which can be judged on-pace).
+ *   - met: assessable goals currently on pace / meeting target.
+ *   - pct: round(met / assessable * 100), or null when nothing is
+ *     assessable yet.
+ *
+ * Per-goal standing prefers the IN-PROGRESS window's `onPace`/`windowMet`
+ * (the current cycle's standing); when a goal has only closed history it
+ * falls back to the most recent closed window's `windowMet`.
+ */
+
+import { useMemo } from "react";
+import { useSnapshots } from "./use-snapshots";
+import { goalCompliance } from "./compliance";
+
+function currentStanding(c) {
+  if (!c) return null;
+  if (c.inProgress) {
+    if (c.inProgress.onPace != null) return c.inProgress.onPace === true;
+    if (c.inProgress.windowMet != null) return c.inProgress.windowMet === true;
+  }
+  // windows are newest-first → first closed window with a boolean is the
+  // most recent authoritative reading.
+  for (const w of c.windows || []) {
+    if (w.closed && w.reading?.windowMet != null) {
+      return w.reading.windowMet === true;
+    }
+  }
+  return null;
+}
+
+export function useComplianceSummary() {
+  const { snapshots } = useSnapshots();
+  return useMemo(() => {
+    const ids = new Set();
+    for (const s of snapshots) {
+      const readings = s?.goalReadings;
+      if (readings) for (const id of Object.keys(readings)) ids.add(id);
+    }
+    let met = 0;
+    let assessable = 0;
+    for (const id of ids) {
+      const standing = currentStanding(goalCompliance(snapshots, id));
+      if (standing == null) continue;
+      assessable += 1;
+      if (standing) met += 1;
+    }
+    return {
+      met,
+      assessable,
+      pct: assessable > 0 ? Math.round((met / assessable) * 100) : null,
+    };
+  }, [snapshots]);
+}


### PR DESCRIPTION
Performance-page polish (3 requested items).

1. **Integrations card → Goal Compliance tile.** Connection status already lives in the header + Settings, so the Overview card was redundant. New `useComplianceSummary` aggregates the snapshot compliance engine (`goalCompliance`) into **"N / M goals on pace"** + an on-target % bar. "Assessable" excludes delegated / no-target / no-history goals; empty state until the first window closes.
2. **Removed the `LIVE · N integrations` header badge** (and its now-unused state + `useIntegrations` import).
3. **Once-daily review-timing cache.** `usePrReviewTimings` now uses a day-stamped SWR key + a size-guarded `localStorage` fallback (`revalidateIfStale:false`) — served from cache across reloads, refetches at most once per day (or when the PR/MR set changes). Cache key added to the auth-transition wipe.

## Test plan
- [x] `npm run build:web` clean
- [ ] Overview shows the Goal Compliance tile (was Integrations); header has no LIVE badge
- [ ] Review-timing tile/page loads from cache on a same-day reload (no refetch); new day refetches once