### PR TITLE
fix(checkin): responsive header/grid + theme native form controls (2.1, 2.3)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -68,6 +68,21 @@
   box-sizing: border-box;
 }
 
+/* Native form controls + focus rings follow the cobalt accent rather
+   than the browser/OS default blue. Without this, checkboxes, number-
+   input spinners, selects and the focus ring on text fields (most
+   visible in the form-heavy check-in editors) render in a stock blue
+   that clashes with --accent. */
+:root {
+  accent-color: var(--accent);
+}
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 0;
+}
+
 html,
 body {
   background: var(--bg);

--- a/apps/web/src/features/checkin/checkin-page.jsx
+++ b/apps/web/src/features/checkin/checkin-page.jsx
@@ -136,7 +136,7 @@ export function CheckinPage() {
   return (
     <div className="flex flex-col gap-4 px-6 py-5">
       {/* Sticky header */}
-      <div className="sticky top-[64px] z-10 -mx-6 flex items-center justify-between gap-3 border-b border-border bg-bg/85 px-6 py-3 backdrop-blur-md">
+      <div className="sticky top-[64px] z-10 -mx-6 flex flex-wrap items-center justify-between gap-3 border-b border-border bg-bg/85 px-6 py-3 backdrop-blur-md">
         <div className="flex items-center gap-3">
           <div>
             <h1 className="text-[15px] font-semibold text-fg">Weekly check-in</h1>
@@ -148,7 +148,7 @@ export function CheckinPage() {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <WeekNavigator
             activeLabel={activeLabel}
             rangeStart={range.start}

--- a/apps/web/src/features/checkin/grid-page.jsx
+++ b/apps/web/src/features/checkin/grid-page.jsx
@@ -114,7 +114,7 @@ export function CheckinGridPage() {
   const gridTemplateColumns = `${LABEL_COL}px repeat(${weeks.length}, ${CELL_COL}px) ${ACTION_COL}px`;
 
   return (
-    <div className="flex flex-col gap-3 px-6 py-4">
+    <div className="flex min-w-0 flex-col gap-3 px-6 py-4">
       <Toolbar
         fromLabel={fromLabel}
         toLabel={toLabel}


### PR DESCRIPTION
Two presentational check-in fixes (the lower-risk half of the check-in punch-list).

## 2.3 — off-theme blue
The check-in editors are form-heavy (`<select>`, `<input type=number|url>`, `<textarea>`). Those render the **browser default blue** accent + focus ring, which clashes with the cobalt `--accent` (#1D4ED8). `globals.css` now:
- sets `accent-color: var(--accent)` on `:root` (themes checkbox/radio/number-spinner/etc.)
- routes `input/select/textarea :focus-visible` outlines through `--accent`

So every stray blue collapses to the single theme accent.

## 2.1 — responsiveness / overflow
- **Single-week header** didn't wrap — title + week-navigator + grid link + save overflowed on narrow widths. Added `flex-wrap` to the header and the right-hand control cluster.
- **Catch-up grid** gained `min-w-0` so its fixed-width columns scroll *inside* the `overflow-x-auto` box rather than blowing out the page width (classic flex `min-width:auto` overflow).

## Still to come (feature-heavier, next PR)
- 2.2 jump-to-next-unfilled-week + an unfilled-field indicator
- 2.4 quarterly/monthly cell grouping/spanning in the grid

## Test plan
- [x] `npm run build:web` clean
- [ ] Check-in editors: focus rings + native controls are cobalt, not stock blue
- [ ] Narrow viewport: single-week header wraps; catch-up grid scrolls horizontally within its box (no page-level overflow)