### PR TITLE
feat(checkin): unfilled-cell indicator + jump-to-next-gap (2.2)

### DIFF
--- a/apps/web/src/features/checkin/grid-page.jsx
+++ b/apps/web/src/features/checkin/grid-page.jsx
@@ -17,9 +17,9 @@
  * header (top). Scrolls in both directions when content overflows.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { Save, ChevronLeft, ChevronRight } from "lucide-react";
+import { Save, ChevronLeft, ChevronRight, Crosshair } from "lucide-react";
 import { useGoals } from "@/features/goals";
 import { useGoalSpecs } from "@/features/goal-specs";
 import { useGoalWidgetItems } from "@/features/goal-widgets";
@@ -33,7 +33,12 @@ import { synthesiseWeek } from "@/features/snapshots";
 import { isoDaysAgo } from "@/lib/date";
 import { SPEC_KINDS } from "@/features/goal-specs";
 import { useCheckinGridRange } from "./use-checkin-grid-range";
-import { GridRow, RowCopyButton } from "./grid-row";
+import {
+  GridRow,
+  RowCopyButton,
+  MANUAL_GRID_WIDGETS,
+  hasEntryInWindow,
+} from "./grid-row";
 import {
   buildSubGoal,
   buildSubSpec,
@@ -99,6 +104,46 @@ export function CheckinGridPage() {
     }
   }, [weeks, goals, specs, mrs, events, tickets, hasSpecs]);
 
+  // ── "Jump to next gap" (item 2.2) ──────────────────────────────────
+  // The manual goals whose per-week cells can be unfilled. Auto goals
+  // read from integration data and are never a "gap".
+  const manualGoalIds = useMemo(() => {
+    const ids = [];
+    for (const group of groupedItems) {
+      for (const item of group.items) {
+        if (item.goal.kind === "L1") continue;
+        if (MANUAL_GRID_WIDGETS.has(item.spec.widget)) ids.push(item.goal.id);
+      }
+    }
+    return ids;
+  }, [groupedItems]);
+
+  const scrollRef = useRef(null);
+  const onJumpToGap = useCallback(() => {
+    if (manualGoalIds.length === 0) {
+      toast.info("No manual goals to fill in this range.");
+      return;
+    }
+    const inputs = readInputs();
+    for (let i = 0; i < weeks.length; i++) {
+      const wk = weeks[i];
+      const gap = manualGoalIds.some(
+        (id) => !hasEntryInWindow(inputs[id] || [], wk.start, wk.end),
+      );
+      if (gap) {
+        const el = scrollRef.current;
+        if (el) {
+          el.scrollTo({
+            left: Math.max(0, LABEL_COL + i * CELL_COL - 48),
+            behavior: "smooth",
+          });
+        }
+        return;
+      }
+    }
+    toast.success("No unfilled weeks in this range 🎉");
+  }, [weeks, manualGoalIds]);
+
   if (!hasGoals) {
     return <EmptyState title="No goals to track yet" body="Add goals first." />;
   }
@@ -122,10 +167,14 @@ export function CheckinGridPage() {
         onPresetLastN={presetLastN}
         onShift={(dir) => shiftRange(weeks, dir, setRange)}
         onSaveAll={onSaveAll}
+        onJumpToGap={onJumpToGap}
         saving={saving}
       />
 
-      <div className="overflow-x-auto rounded-md border border-border">
+      <div
+        ref={scrollRef}
+        className="overflow-x-auto rounded-md border border-border"
+      >
         <div className="grid" style={{ gridTemplateColumns }}>
           {/* corner */}
           <div
@@ -333,6 +382,7 @@ function Toolbar({
   onPresetLastN,
   onShift,
   onSaveAll,
+  onJumpToGap,
   saving,
 }) {
   return (
@@ -358,6 +408,16 @@ function Toolbar({
         <Preset onClick={() => onPresetLastN(4)}>4w</Preset>
         <Preset onClick={() => onPresetLastN(8)}>8w</Preset>
         <Preset onClick={() => onPresetLastN(12)}>12w</Preset>
+        <button
+          type="button"
+          onClick={onJumpToGap}
+          title="Scroll to the next week with unfilled manual fields"
+          className="ml-1 flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[10px] uppercase tracking-[0.5px] text-muted-fg hover:bg-accent-dim/60 hover:text-fg"
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          <Crosshair size={12} />
+          Next gap
+        </button>
         <button
           type="button"
           onClick={onSaveAll}

--- a/apps/web/src/features/checkin/grid-row.jsx
+++ b/apps/web/src/features/checkin/grid-row.jsx
@@ -37,7 +37,37 @@ import {
 } from "./grid-cells";
 import { CodeRubricGridRow } from "./code-rubric-row";
 
+/**
+ * Manual widgets whose (goal, week) cell is "filled" only once the user
+ * logs an input for that week. Auto widgets read from integration data
+ * and are never flagged unfilled. Exported so the grid page can compute
+ * which week columns still have gaps for the "jump to next gap" control.
+ */
+export const MANUAL_GRID_WIDGETS = new Set([
+  SPEC_KINDS.COUNTER,
+  SPEC_KINDS.SCALE,
+  SPEC_KINDS.MILESTONE,
+  SPEC_KINDS.FREE_TEXT,
+  SPEC_KINDS.DATE_LOG,
+  SPEC_KINDS.BEFORE_AFTER,
+  SPEC_KINDS.INCIDENT_LOG,
+  SPEC_KINDS.RECURRING_MILESTONE,
+]);
+
+/** True when at least one goal-input entry falls inside the week window. */
+export function hasEntryInWindow(entries, start, end) {
+  if (!Array.isArray(entries)) return false;
+  const s = start.getTime();
+  const e = end.getTime();
+  return entries.some((x) => x && x.ts >= s && x.ts < e);
+}
+
 export function GridRow({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCount }) {
+  // Row-level goal-inputs read powers the "unfilled" indicator on manual
+  // cells. Called unconditionally (before the CODE_RUBRIC early return)
+  // to satisfy the rules of hooks; unused for auto / rubric rows.
+  const { entries } = useGoalInputs(goal?.id);
+
   // CODE_RUBRIC needs row-level state: one useGradedPrs hook call per
   // row (a fetch per cell would hammer the GitHub search API). Delegate
   // the whole row to the dedicated component which owns its label, its
@@ -45,6 +75,8 @@ export function GridRow({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCou
   if (spec.widget === SPEC_KINDS.CODE_RUBRIC) {
     return <CodeRubricGridRow goal={goal} spec={spec} weeks={weeks} />;
   }
+
+  const isManual = MANUAL_GRID_WIDGETS.has(spec.widget);
 
   return (
     <>
@@ -58,6 +90,7 @@ export function GridRow({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCou
           mrsThisWeek={mrsByWeek.get(wk.weekLabel) || []}
           eventsThisWeek={eventsByWeek.get(wk.weekLabel) || []}
           ticketsCount={ticketsCount}
+          empty={isManual && !hasEntryInWindow(entries, wk.start, wk.end)}
         />
       ))}
     </>
@@ -95,12 +128,26 @@ function GridCell({
   mrsThisWeek,
   eventsThisWeek,
   ticketsCount,
+  empty,
 }) {
   return (
     <div
-      className="flex items-center justify-center border-b border-r border-border bg-bg/40 px-2 py-1.5"
-      style={{ minHeight: 52 }}
+      className="relative flex items-center justify-center border-b border-r border-border bg-bg/40 px-2 py-1.5"
+      style={{
+        minHeight: 52,
+        // Faint amber wash + a corner dot mark a manual cell with no
+        // input for this week yet (item 2.2). Inline so it renders
+        // regardless of whether an `amber` Tailwind token is defined.
+        ...(empty ? { background: "rgba(245, 158, 11, 0.06)" } : {}),
+      }}
     >
+      {empty ? (
+        <span
+          className="pointer-events-none absolute right-1 top-1 h-1.5 w-1.5 rounded-full"
+          style={{ background: "#f59e0b" }}
+          title="Not filled for this week yet"
+        />
+      ) : null}
       <CellFor
         widget={spec.widget}
         goal={goal}


### PR DESCRIPTION
Catch-up grid now shows which (goal, week) cells still need filling, and lets you jump straight to the gaps.

- **Unfilled indicator** — manual cells (counter / scale / milestone / free-text / date-log / before-after / incident / recurring) with no goal-input in the week window get a faint amber wash + a corner dot. Auto cells read from integration data and are never flagged. Driven by a row-level `useGoalInputs` read, so the dot clears live as you fill a cell.
- **"Next gap" toolbar button** — scrolls the grid to the first week column that has any unfilled manual cell (computed from `readInputs()` on click); toasts when the range is fully filled.

`MANUAL_GRID_WIDGETS` + `hasEntryInWindow` are exported from `grid-row` so the page computes gaps without duplicating the widget list.

## Test plan
- [x] `npm run build:web` clean
- [ ] Empty manual cells show the amber dot/wash; filling one clears it immediately
- [ ] "Next gap" scrolls to the first week with an unfilled manual cell; full range → success toast