### PR TITLE
fix(checkin): only flag COUNTER/SCALE cells as unfilled (2.2 over-flagging)

### DIFF
--- a/apps/web/src/features/checkin/grid-page.jsx
+++ b/apps/web/src/features/checkin/grid-page.jsx
@@ -33,12 +33,7 @@ import { synthesiseWeek } from "@/features/snapshots";
 import { isoDaysAgo } from "@/lib/date";
 import { SPEC_KINDS } from "@/features/goal-specs";
 import { useCheckinGridRange } from "./use-checkin-grid-range";
-import {
-  GridRow,
-  RowCopyButton,
-  MANUAL_GRID_WIDGETS,
-  hasEntryInWindow,
-} from "./grid-row";
+import { GridRow, RowCopyButton, isCellUnfilled } from "./grid-row";
 import {
   buildSubGoal,
   buildSubSpec,
@@ -105,30 +100,27 @@ export function CheckinGridPage() {
   }, [weeks, goals, specs, mrs, events, tickets, hasSpecs]);
 
   // ── "Jump to next gap" (item 2.2) ──────────────────────────────────
-  // The manual goals whose per-week cells can be unfilled. Auto goals
-  // read from integration data and are never a "gap".
-  const manualGoalIds = useMemo(() => {
-    const ids = [];
+  // (goalId, widget) for every non-L1 goal — `isCellUnfilled` decides
+  // per widget whether an empty week is actually a gap (only COUNTER /
+  // SCALE), matching the per-cell dot exactly.
+  const checkinGoals = useMemo(() => {
+    const out = [];
     for (const group of groupedItems) {
       for (const item of group.items) {
         if (item.goal.kind === "L1") continue;
-        if (MANUAL_GRID_WIDGETS.has(item.spec.widget)) ids.push(item.goal.id);
+        out.push({ id: item.goal.id, widget: item.spec.widget });
       }
     }
-    return ids;
+    return out;
   }, [groupedItems]);
 
   const scrollRef = useRef(null);
   const onJumpToGap = useCallback(() => {
-    if (manualGoalIds.length === 0) {
-      toast.info("No manual goals to fill in this range.");
-      return;
-    }
     const inputs = readInputs();
     for (let i = 0; i < weeks.length; i++) {
       const wk = weeks[i];
-      const gap = manualGoalIds.some(
-        (id) => !hasEntryInWindow(inputs[id] || [], wk.start, wk.end),
+      const gap = checkinGoals.some((g) =>
+        isCellUnfilled(g.widget, inputs[g.id] || [], wk.start, wk.end),
       );
       if (gap) {
         const el = scrollRef.current;
@@ -142,7 +134,7 @@ export function CheckinGridPage() {
       }
     }
     toast.success("No unfilled weeks in this range 🎉");
-  }, [weeks, manualGoalIds]);
+  }, [weeks, checkinGoals]);
 
   if (!hasGoals) {
     return <EmptyState title="No goals to track yet" body="Add goals first." />;

--- a/apps/web/src/features/checkin/grid-row.jsx
+++ b/apps/web/src/features/checkin/grid-row.jsx
@@ -37,29 +37,37 @@ import {
 } from "./grid-cells";
 import { CodeRubricGridRow } from "./code-rubric-row";
 
-/**
- * Manual widgets whose (goal, week) cell is "filled" only once the user
- * logs an input for that week. Auto widgets read from integration data
- * and are never flagged unfilled. Exported so the grid page can compute
- * which week columns still have gaps for the "jump to next gap" control.
- */
-export const MANUAL_GRID_WIDGETS = new Set([
-  SPEC_KINDS.COUNTER,
-  SPEC_KINDS.SCALE,
-  SPEC_KINDS.MILESTONE,
-  SPEC_KINDS.FREE_TEXT,
-  SPEC_KINDS.DATE_LOG,
-  SPEC_KINDS.BEFORE_AFTER,
-  SPEC_KINDS.INCIDENT_LOG,
-  SPEC_KINDS.RECURRING_MILESTONE,
-]);
-
 /** True when at least one goal-input entry falls inside the week window. */
 export function hasEntryInWindow(entries, start, end) {
   if (!Array.isArray(entries)) return false;
   const s = start.getTime();
   const e = end.getTime();
   return entries.some((x) => x && x.ts >= s && x.ts < e);
+}
+
+/**
+ * Whether a (goal, week) cell should be flagged "not filled yet".
+ *
+ * ONLY per-week entry widgets carry a real weekly gap:
+ *   - COUNTER / SCALE → unfilled when there's no entry IN this week.
+ *
+ * Every other widget has a legitimate empty / zero / cumulative state
+ * and is NEVER flagged:
+ *   - INCIDENT_LOG, DATE_LOG → 0 = "nothing happened", a valid answer.
+ *   - MILESTONE, BEFORE_AFTER → cumulative current-state; a checklist at
+ *     0/3 or 2/3 is a deliberate state, not a gap, and the value carries
+ *     forward across weeks (so an in-week entry isn't expected).
+ *   - RECURRING_MILESTONE → period-shared (rendered as a spanned cell).
+ *   - AUTO widgets → value comes from integration data.
+ *
+ * Exported so the grid page's "jump to next gap" uses the same rule as
+ * the per-cell dot.
+ */
+export function isCellUnfilled(widget, entries, start, end) {
+  if (widget !== SPEC_KINDS.COUNTER && widget !== SPEC_KINDS.SCALE) {
+    return false;
+  }
+  return !hasEntryInWindow(entries, start, end);
 }
 
 export function GridRow({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCount }) {
@@ -99,8 +107,6 @@ export function GridRow({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCou
     );
   }
 
-  const isManual = MANUAL_GRID_WIDGETS.has(spec.widget);
-
   return (
     <>
       <RowLabel goal={goal} spec={spec} />
@@ -113,7 +119,7 @@ export function GridRow({ goal, spec, weeks, mrsByWeek, eventsByWeek, ticketsCou
           mrsThisWeek={mrsByWeek.get(wk.weekLabel) || []}
           eventsThisWeek={eventsByWeek.get(wk.weekLabel) || []}
           ticketsCount={ticketsCount}
-          empty={isManual && !hasEntryInWindow(entries, wk.start, wk.end)}
+          empty={isCellUnfilled(spec.widget, entries, wk.start, wk.end)}
         />
       ))}
     </>


### PR DESCRIPTION
The unfilled-cell indicator was over-flagging (reported with screenshots):

1. **Incidents at 0** flagged — but 0 incidents is a valid, complete answer.
2. **Milestones the user wants at 0** flagged — should be keepable at 0.
3. **Milestones with selections** (2/3, 3/3) still flagged — a bug: a milestone toggled in an early week *displays* its state in later weeks (cumulative) but has no entry in those windows, so every later week got a false dot.

**Fix:** replaced the blanket "any manual widget with no in-window entry" check with `isCellUnfilled(widget, …)` that only flags **COUNTER** and **SCALE** — the widgets where a per-week value is genuinely expected and absence means "not filled." Everything else (incident-log, date-log, milestone, before-after, recurring, and all auto widgets) has a legitimate empty/zero/cumulative state and is **never flagged**. The grid's "Next gap" jump uses the same rule, so dots + jump stay in sync.

## Test plan
- [x] `npm run build:web` clean
- [ ] Incident-log row: no dots (even at 0)
- [ ] Milestone row with 2/3 or 0/3: no dots
- [ ] Counter/scale row with no entry for a week: dot shows; entering a value clears it; "Next gap" lands on it