### PR TITLE
feat(goals): classifier emits structured achievement tiers (AI-tier ph.1)

### DIFF
--- a/apps/api/src/modules/ai/classifier/mistral-classifier.ts
+++ b/apps/api/src/modules/ai/classifier/mistral-classifier.ts
@@ -380,6 +380,31 @@ function buildSystemPrompt(): string {
     "    ticket\" is closer to LINKAGE than CODE_RUBRIC. Use the answers",
     "    as the strongest signal.",
     "",
+    "═══ ACHIEVEMENT TIERS (required) ═════════════════════════════════",
+    "",
+    "Every goal MUST include a `tiers` object with FOUR short, MEASURABLE",
+    "criteria — one per achievement level — so an AI grader can later",
+    "score where the developer stands:",
+    "  {",
+    '    "notAchieved":  <falls short of the bar>,',
+    '    "achieved":     <the baseline target is met>,',
+    '    "overAchieved": <clearly beyond the target>,',
+    '    "roleModel":    <exemplary; drives the team / fully automated>',
+    "  }",
+    "Rules:",
+    "  - Tie each tier to the widget's metric where one exists, in the",
+    "    SAME unit as the source/manual target. e.g. MERGED_COUNT with",
+    '    target >=8 → notAchieved "<8 merged", achieved ">=8 merged",',
+    '    overAchieved ">=12 merged", roleModel ">=16 merged, zero reverts".',
+    "  - If the goal's rubric/description already spells out the tiers (Not",
+    "    Achieved / Achieved / Over / Role Model), NORMALISE them into this",
+    "    shape and keep the user's thresholds verbatim.",
+    "  - Compound/qualitative goals (SLA %, RTO/RPO, DR drills): phrase",
+    "    each tier as a checkable condition — the grader reads the user's",
+    "    logged data + metrics against it.",
+    "  - Keep each <=160 chars. Use null for a tier you truly can't state;",
+    "    null the whole object only when the goal has no meaningful levels.",
+    "",
     "═══ OUTPUT SCHEMA ════════════════════════════════════════════════",
     "",
     "Return ONE JSON object. No prose, no markdown, no code fences. Shape:",
@@ -392,7 +417,8 @@ function buildSystemPrompt(): string {
     '    "context":     {...} | null,',
     '    "delegated":   {...} | null,',
     '    "untrackable": {...} | null,',
-    '    "scorecard":   {...} | null',
+    '    "scorecard":   {...} | null,',
+    '    "tiers":       { "notAchieved", "achieved", "overAchieved", "roleModel" }',
     "  }",
     "",
     "`scorecard` shape (REQUIRED when widget is SCORECARD):",
@@ -850,6 +876,10 @@ async function* classifyOneGoal(
     // scorecard payload still fails validation because the candidate
     // object drops the block before validateSpec sees it.
     scorecard: obj.scorecard ?? null,
+    // Phase G: the four AI-gradeable achievement tiers (see prompt +
+    // shared validator). Distilled by the classifier from the goal's
+    // rubric; the goal-tier grader (Phase 2) scores the dev against them.
+    tiers: obj.tiers ?? null,
     // Phase F: top-level firstReviewOnly for standalone CODE_RUBRIC.
     // Component-level firstReviewOnly lives inside scorecard.components
     // and is threaded by the shared validator.

--- a/apps/api/src/modules/ai/classifier/spec-schema.ts
+++ b/apps/api/src/modules/ai/classifier/spec-schema.ts
@@ -48,6 +48,7 @@ export const SPEC_RESPONSE_SCHEMA = {
       "untrackable",
       "scorecard",
       "firstReviewOnly",
+      "tiers",
     ],
     properties: {
       kind: {
@@ -356,6 +357,28 @@ export const SPEC_RESPONSE_SCHEMA = {
           "weighted-averaged into the tile's headline. Each component " +
           "is itself a (widget, kind, source, manual) tuple — its " +
           "validation runs server-side via the shared validator.",
+      },
+      tiers: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: ["notAchieved", "achieved", "overAchieved", "roleModel"],
+        properties: {
+          notAchieved: { type: ["string", "null"] },
+          achieved: { type: ["string", "null"] },
+          overAchieved: { type: ["string", "null"] },
+          roleModel: { type: ["string", "null"] },
+        },
+        description:
+          "The four achievement levels an AI grader later scores this " +
+          "goal against. Distil them from the goal's rubric/description, " +
+          "and make each MEASURABLE against the chosen widget's metric " +
+          "where one exists (e.g. for MERGED_COUNT target >=8: " +
+          "notAchieved '<8 merged', achieved '>=8 merged', overAchieved " +
+          "'>=12 merged', roleModel '>=16 merged with zero reverts'). " +
+          "If the rubric already states tiers, normalise them into this " +
+          "shape and keep the user's thresholds. Keep each <=160 chars. " +
+          "Use null for a tier you genuinely can't express; null the " +
+          "whole object only for goals with no meaningful levels.",
       },
     },
   },

--- a/packages/shared/src/goal-specs/types.d.ts
+++ b/packages/shared/src/goal-specs/types.d.ts
@@ -173,6 +173,20 @@ export interface SpecUntrackable {
 }
 
 /**
+ * Phase G: the four achievement-level criteria an AI grader scores the
+ * goal against. The classifier distils these from the goal's freeform
+ * `rubric`, aligned to the widget's metric where one exists. Each is a
+ * short, ideally measurable criterion; any can be null when a tier
+ * wasn't expressible.
+ */
+export interface SpecTiers {
+  notAchieved: string | null;
+  achieved: string | null;
+  overAchieved: string | null;
+  roleModel: string | null;
+}
+
+/**
  * One sub-spec inside a SCORECARD spec.
  *
  * Carries the same `widget`+`kind`+`source`+`manual` shape as a
@@ -213,5 +227,10 @@ export interface ValidatedSpec {
   untrackable: SpecUntrackable | null;
   /** Phase E: only set when widget === "SCORECARD". */
   scorecard: SpecScorecard | null;
+  /**
+   * Phase G: AI-gradeable achievement tiers distilled from the goal's
+   * rubric. null when the goal has no gradeable tiers.
+   */
+  tiers: SpecTiers | null;
   classifiedAt: number;
 }

--- a/packages/shared/src/goal-specs/validator.js
+++ b/packages/shared/src/goal-specs/validator.js
@@ -188,6 +188,38 @@ function validateUntrackable(untrackable, errors) {
   return { reason: untrackable.reason.trim() };
 }
 
+/**
+ * Validate a `tiers` block — the four achievement levels an AI grader
+ * scores the goal against:
+ *   { notAchieved, achieved, overAchieved, roleModel }
+ *
+ * Each is a short, ideally MEASURABLE criterion the classifier distils
+ * from the goal's freeform `rubric` and aligns to the widget's metric.
+ * All four are optional strings; blanks normalise to null. The whole
+ * block collapses to null when nothing usable was produced (older specs,
+ * or genuinely un-gradeable goals) so consumers branch on `tiers == null`
+ * rather than four nulls. Permissive — never pushes into `errors`.
+ */
+function validateTiers(tiers) {
+  if (!isObject(tiers)) return null;
+  const pick = (v) => (isNonEmptyString(v) ? v.trim() : null);
+  const out = {
+    notAchieved: pick(tiers.notAchieved),
+    achieved: pick(tiers.achieved),
+    overAchieved: pick(tiers.overAchieved),
+    roleModel: pick(tiers.roleModel),
+  };
+  if (
+    out.notAchieved == null &&
+    out.achieved == null &&
+    out.overAchieved == null &&
+    out.roleModel == null
+  ) {
+    return null;
+  }
+  return out;
+}
+
 function validateDelegated(delegated, errors) {
   if (delegated == null) return null;
   if (!isObject(delegated)) {
@@ -501,6 +533,7 @@ export function validateSpec(obj) {
 
   const context = validateContext(obj.context, errors);
   const delegated = validateDelegated(obj.delegated, errors);
+  const tiers = validateTiers(obj.tiers);
 
   if (errors.length > 0) return { ok: false, errors };
 
@@ -517,6 +550,7 @@ export function validateSpec(obj) {
     delegated,
     untrackable,
     scorecard,
+    tiers,
     // Phase F: top-level firstReviewOnly applies to standalone
     // CODE_RUBRIC specs. Optional boolean, false-by-default — kept
     // as undefined when not set so older specs serialise identically.
@@ -551,6 +585,7 @@ export function buildSpec({
   delegated = null,
   untrackable = null,
   scorecard = null,
+  tiers = null,
   classifiedAt = Date.now(),
 }) {
   return validateSpec({
@@ -566,6 +601,7 @@ export function buildSpec({
     delegated,
     untrackable,
     scorecard,
+    tiers,
     classifiedAt,
   });
 }


### PR DESCRIPTION
Phase 1 of AI-graded goal tiers. Establishes the dependency the user flagged: the analyzer must emit goals whose criteria are structured into the four levels so they're gradeable.

Every classified goal now carries a `tiers` block on its spec:
```
tiers: { notAchieved, achieved, overAchieved, roleModel } | null
```
Each is a short, measurable criterion the classifier distils from the goal's freeform `rubric`, aligned to the widget's metric where one exists (e.g. MERGED_COUNT target ≥8 → achieved "≥8 merged", over "≥12", role model "≥16, zero reverts"). Compound/qualitative goals (SLA, RTO/RPO, DR drills) get checkable conditions.

## Changes
- **`shared/goal-specs`** — `validateTiers` (permissive; all-null collapses to null), threaded through `validateSpec` + `buildSpec`; `SpecTiers` type + `tiers` on `ValidatedSpec`.
- **classifier `spec-schema.ts`** — `tiers` added to the strict `json_schema` (nullable object, 4 nullable string fields) + `required`.
- **classifier prompt** — new "ACHIEVEMENT TIERS (required)" section + the field in the output shape; the candidate threads `obj.tiers`.

Additive + nullable → existing specs validate unchanged (`tiers=null`) until re-analyzed. Mongo `goal_specs.spec` is a loose object, so no DB-schema change.

## Still to come
- **Phase 2:** `POST /ai/grade-goal-tier` + cached API-direct tier-verdict store + `useGoalTier` hook.
- **Phase 3:** UI — 4-tier ladder + current tier on the goals tree (section 1) and the AI widgets (section 2).

## Test plan
- [x] `npm run typecheck:api` + `npm run build:web` clean
- [ ] Re-analyze a goal → spec carries 4 `tiers` aligned to its metric/rubric
- [ ] Old (un-re-analyzed) specs still load (`tiers: null`)