### PR TITLE
feat(goals): AI goal-tier grader endpoint + cached hook (AI-tier ph.2)

### DIFF
--- a/apps/api/src/modules/ai/controller.ts
+++ b/apps/api/src/modules/ai/controller.ts
@@ -20,7 +20,7 @@ import {
 } from "../../lib/rate-limit.js";
 import { HttpError } from "../../middleware/error-handler.js";
 import { selectProvider } from "./provider.js";
-import { chatSchema, gradePrSchema } from "./schemas.js";
+import { chatSchema, gradePrSchema, gradeGoalTierSchema } from "./schemas.js";
 
 const COMMENT_CHAR_LIMIT = 12_000;
 const PR_BODY_CHAR_LIMIT = 4_000;
@@ -306,6 +306,136 @@ export async function gradePrHandler(
       provider: provider.id,
       usage: data.usage,
     });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── POST /api/v1/ai/grade-goal-tier ─────────────────────────────────
+
+const GOAL_TIER_SYSTEM_PROMPT = [
+  "You assess which ACHIEVEMENT TIER a developer is at for ONE performance",
+  "goal, based on the goal's tier criteria and the developer's current data.",
+  "",
+  "INPUT:",
+  "  - The goal title",
+  "  - Four tier criteria: notAchieved / achieved / overAchieved / roleModel",
+  "  - The developer's CURRENT DATA for the goal (metrics, counts, readings)",
+  "",
+  "TASK: pick the single HIGHEST tier whose criteria the current data meets.",
+  "  - Tiers are cumulative: roleModel implies overAchieved implies achieved.",
+  "  - Evaluate bottom-up. If the data doesn't clearly meet 'achieved', the",
+  "    tier is 'not_achieved'.",
+  "  - Only credit a tier whose criterion you can actually verify from the",
+  "    data. If a criterion is qualitative and the data can't confirm it, do",
+  "    NOT credit that tier — say so in the reasoning and lower confidence.",
+  "",
+  "OUTPUT: ONE JSON object, no prose, no markdown:",
+  "  {",
+  '    "tier":       "not_achieved" | "achieved" | "over_achieved" | "role_model",',
+  '    "reasoning":  <one sentence — which criteria the data met or missed>,',
+  '    "confidence": "high" | "medium" | "low"',
+  "  }",
+  "  Use 'low' confidence when the data is sparse or the criteria aren't",
+  "  directly measurable from what's provided.",
+].join("\n");
+
+function buildTierUserPrompt(
+  goalTitle: string,
+  tiers: {
+    notAchieved?: string | null;
+    achieved?: string | null;
+    overAchieved?: string | null;
+    roleModel?: string | null;
+  },
+  currentData: string,
+): string {
+  const line = (label: string, v?: string | null) =>
+    `  ${label}: ${v && v.trim() ? v.trim() : "(not defined)"}`;
+  return [
+    `Goal: ${goalTitle || "(untitled)"}`,
+    "",
+    "Achievement tiers:",
+    line("Not achieved", tiers.notAchieved),
+    line("Achieved", tiers.achieved),
+    line("Over achieved", tiers.overAchieved),
+    line("Role model", tiers.roleModel),
+    "",
+    "Developer's current data:",
+    currentData && currentData.trim() ? currentData.trim() : "(no data available yet)",
+    "",
+    "Which tier is the developer at? Respond with a single JSON object.",
+  ].join("\n");
+}
+
+const VALID_TIERS = [
+  "not_achieved",
+  "achieved",
+  "over_achieved",
+  "role_model",
+];
+const VALID_CONFIDENCE = ["high", "medium", "low"];
+
+export async function gradeGoalTierHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const session = req.session;
+    if (!session) {
+      throw new HttpError(401, "unauthenticated", "Login required.");
+    }
+    const payload = gradeGoalTierSchema.parse(req.body);
+    const provider = selectProvider({
+      request: req,
+      bodyProvider: payload.provider ?? null,
+    });
+
+    const userPrompt = buildTierUserPrompt(
+      payload.goalTitle,
+      payload.tiers,
+      payload.currentData,
+    );
+
+    const upstream = await callProvider(provider, {
+      model: provider.model,
+      temperature: 0.1,
+      response_format: { type: "json_object" },
+      messages: [
+        { role: "system", content: GOAL_TIER_SYSTEM_PROMPT },
+        { role: "user", content: userPrompt },
+      ],
+    });
+
+    const data = upstream.data as CompletionResponse;
+    const content = data.choices?.[0]?.message?.content ?? "";
+    let parsed: { tier?: unknown; reasoning?: unknown; confidence?: unknown };
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      throw new HttpError(
+        502,
+        "ai_provider_bad_response",
+        `${provider.label} returned non-JSON content: ${content.slice(0, 200)}`,
+      );
+    }
+
+    const verdict = {
+      tier:
+        typeof parsed?.tier === "string" && VALID_TIERS.includes(parsed.tier)
+          ? parsed.tier
+          : "not_achieved",
+      reasoning:
+        typeof parsed?.reasoning === "string" ? parsed.reasoning.trim() : "",
+      confidence:
+        typeof parsed?.confidence === "string" &&
+        VALID_CONFIDENCE.includes(parsed.confidence)
+          ? parsed.confidence
+          : "low",
+    };
+
+    res.json({ verdict, model: data.model, provider: provider.id });
   } catch (err) {
     next(err);
   }

--- a/apps/api/src/modules/ai/routes.ts
+++ b/apps/api/src/modules/ai/routes.ts
@@ -12,13 +12,20 @@
 
 import { Router } from "express";
 import { requireAuth } from "../../middleware/require-auth.js";
-import { chatHandler, gradePrHandler } from "./controller.js";
+import {
+  chatHandler,
+  gradePrHandler,
+  gradeGoalTierHandler,
+} from "./controller.js";
 import { classifyGoalsHandler } from "./classify-controller.js";
 
 export const aiRouter: Router = Router();
 
 aiRouter.post("/chat", requireAuth(), chatHandler);
 aiRouter.post("/grade-pr", requireAuth(), gradePrHandler);
+// Score which achievement tier a developer is at for one goal, given the
+// goal's classifier-distilled tier criteria + its current metric data.
+aiRouter.post("/grade-goal-tier", requireAuth(), gradeGoalTierHandler);
 // /classify-goals — NDJSON stream (one AnalysisEvent per line).
 // Auth runs as middleware; once headers flush, the handler owns the
 // response and never throws into express's error handler.

--- a/apps/api/src/modules/ai/schemas.ts
+++ b/apps/api/src/modules/ai/schemas.ts
@@ -49,3 +49,26 @@ export const gradePrSchema = z.object({
   provider,
 });
 export type GradePrInput = z.infer<typeof gradePrSchema>;
+
+// ─── goal achievement-tier grading ───────────────────────────────────
+
+const tierCriterion = z.string().max(600).nullable().optional();
+
+/**
+ * Score which achievement tier a developer is at for one goal. The four
+ * tier criteria come from the goal spec (classifier-distilled); the
+ * `currentData` is a compact, caller-assembled summary of the goal's
+ * live metrics / readings the model compares against the criteria.
+ */
+export const gradeGoalTierSchema = z.object({
+  goalTitle: z.string().max(500).default(""),
+  tiers: z.object({
+    notAchieved: tierCriterion,
+    achieved: tierCriterion,
+    overAchieved: tierCriterion,
+    roleModel: tierCriterion,
+  }),
+  currentData: z.string().max(8_000).default(""),
+  provider,
+});
+export type GradeGoalTierInput = z.infer<typeof gradeGoalTierSchema>;

--- a/apps/web/src/features/auth/clear-user-storage.js
+++ b/apps/web/src/features/auth/clear-user-storage.js
@@ -58,6 +58,7 @@ const USER_SCOPED_KEYS = Object.freeze([
   "espace-devhub:active-hub-pick",
   "espace-devhub:migrate-completed-by-user",
   "espace-devhub:review-timing-cache",
+  "espace-devhub:goal-tiers",
   "eshub:qa:config:v1",
 ]);
 

--- a/apps/web/src/features/goal-tiers/goal-tier-store.js
+++ b/apps/web/src/features/goal-tiers/goal-tier-store.js
@@ -1,0 +1,149 @@
+"use client";
+
+/**
+ * AI goal-tier verdict cache (Phase 2).
+ *
+ * Caches the result of `POST /api/v1/ai/grade-goal-tier` per goal,
+ * keyed by a `key` the hook computes from (day + hash of tiers + current
+ * data). We re-grade at most once per day per goal — or sooner when the
+ * tiers or the goal's live data change. localStorage-backed so it
+ * survives reloads; reset on auth transition.
+ *
+ * NOT server-persisted: a tier verdict is a cheap derived read of the
+ * goal's tiers + current metrics, so a per-device daily cache is enough
+ * (mirrors the review-timing cache, not the grading-verdicts
+ * collection). The AI call is the expensive part — caching avoids
+ * re-spending tokens on every page view.
+ */
+
+import { fetchWithRateLimitRetry } from "@/lib/rate-limit";
+
+const STORAGE_KEY = "espace-devhub:goal-tiers";
+const CHANGE_EVENT = "goal-tiers:change";
+
+/** { [goalId]: { tier, reasoning, confidence, key } } */
+let state = {};
+let tick = 0;
+let loaded = false;
+const inflight = new Set();
+
+function load() {
+  if (loaded || typeof window === "undefined") return;
+  loaded = true;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    if (parsed && typeof parsed === "object") state = parsed;
+  } catch {
+    /* ignore corrupt cache */
+  }
+}
+
+function persist() {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    /* quota / disabled — fine, recomputes next load */
+  }
+}
+
+function notify() {
+  tick += 1;
+  if (typeof window === "undefined") return;
+  try {
+    window.dispatchEvent(new Event(CHANGE_EVENT));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function subscribeGoalTiers(cb) {
+  if (typeof window === "undefined") return () => {};
+  const handler = () => cb();
+  window.addEventListener(CHANGE_EVENT, handler);
+  return () => window.removeEventListener(CHANGE_EVENT, handler);
+}
+export function getGoalTiersSnapshot() {
+  return tick;
+}
+export function getGoalTiersServerSnapshot() {
+  return 0;
+}
+
+/** Current cached verdict for a goal (any key), or null. */
+export function readGoalTier(goalId) {
+  load();
+  return (goalId && state[goalId]) || null;
+}
+
+/**
+ * Grade a goal's tier unless we already have a fresh verdict for `key`.
+ * Idempotent: skips when the stored verdict matches `key` or a grade is
+ * already in flight for the goal. `force` re-grades regardless. On a
+ * rate-limit / error the prior verdict is left intact (no failure cached).
+ */
+export async function gradeGoalTier({
+  goalId,
+  goalTitle,
+  tiers,
+  currentData,
+  key,
+  aiProvider,
+  force = false,
+}) {
+  load();
+  if (!goalId || !tiers || !key) return;
+  if (!force) {
+    const existing = state[goalId];
+    if (existing && existing.key === key) return;
+    if (inflight.has(goalId)) return;
+  }
+  inflight.add(goalId);
+  try {
+    const res = await fetchWithRateLimitRetry(
+      "/api/v1/ai/grade-goal-tier",
+      {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "x-ai-provider": aiProvider || "mistral",
+        },
+        body: JSON.stringify({
+          goalTitle: goalTitle || "",
+          tiers,
+          currentData: currentData || "",
+          provider: aiProvider || undefined,
+        }),
+      },
+      { provider: "ai" },
+    );
+    const body = await res.json().catch(() => ({}));
+    if (res.ok && body?.verdict?.tier) {
+      state = { ...state, [goalId]: { ...body.verdict, key } };
+      persist();
+      notify();
+    }
+  } catch {
+    /* network / abort — keep any prior verdict */
+  } finally {
+    inflight.delete(goalId);
+  }
+}
+
+export function resetGoalTiers() {
+  state = {};
+  loaded = true;
+  notify();
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("auth:user-storage-cleared", resetGoalTiers);
+}

--- a/apps/web/src/features/goal-tiers/index.js
+++ b/apps/web/src/features/goal-tiers/index.js
@@ -1,0 +1,8 @@
+// Public surface of the goal-tiers feature (AI achievement-tier grading).
+export {
+  useGoalTier,
+  TIER_ORDER,
+  TIER_LABELS,
+  TIER_FIELD,
+} from "./use-goal-tier";
+export { readGoalTier, resetGoalTiers } from "./goal-tier-store";

--- a/apps/web/src/features/goal-tiers/use-goal-tier.js
+++ b/apps/web/src/features/goal-tiers/use-goal-tier.js
@@ -1,0 +1,140 @@
+"use client";
+
+/**
+ * AI tier verdict for one goal.
+ *
+ * Reads the goal's classifier-distilled tiers (`spec.tiers`) + the
+ * latest snapshot reading for the goal, grades once per day (cached in
+ * goal-tier-store), and returns the current verdict reactively.
+ *
+ *   const { hasTiers, verdict, loading, regrade } = useGoalTier(goalId, spec);
+ *   verdict = { tier: "not_achieved"|"achieved"|"over_achieved"|"role_model",
+ *               reasoning, confidence } | null
+ */
+
+import { useEffect, useMemo, useSyncExternalStore } from "react";
+import { useSnapshots } from "@/features/snapshots";
+import { getAiProvider } from "@/features/analyst/use-ai-provider";
+import {
+  gradeGoalTier,
+  getGoalTiersServerSnapshot,
+  getGoalTiersSnapshot,
+  readGoalTier,
+  subscribeGoalTiers,
+} from "./goal-tier-store";
+
+function todayStamp() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function hashStr(s) {
+  let h = 0;
+  for (let i = 0; i < s.length; i += 1) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}
+
+/** Most recent snapshot reading for a goal (snapshots are newest-first). */
+function latestReadingFor(snapshots, goalId) {
+  if (!Array.isArray(snapshots) || !goalId) return null;
+  for (const s of snapshots) {
+    const r = s?.goalReadings?.[goalId];
+    if (r) return r;
+  }
+  return null;
+}
+
+/** Compact, model-friendly summary of a goal's current reading. */
+function readingToText(reading) {
+  if (!reading || typeof reading !== "object") return "";
+  const bits = [];
+  if (reading.cumulative != null) bits.push(`current value: ${reading.cumulative}`);
+  if (reading.weekContribution != null)
+    bits.push(`this period: ${reading.weekContribution}`);
+  if (reading.target && reading.target.value != null) {
+    bits.push(`target: ${reading.target.op || ""} ${reading.target.value}`.trim());
+  }
+  if (reading.windowMet != null)
+    bits.push(`target met: ${reading.windowMet ? "yes" : "no"}`);
+  if (reading.onPace != null) bits.push(`on pace: ${reading.onPace ? "yes" : "no"}`);
+  if (reading.cadenceWindow) bits.push(`window: ${reading.cadenceWindow}`);
+  return bits.join("; ");
+}
+
+export function useGoalTier(goalId, spec) {
+  // Re-render when a verdict lands in the store.
+  useSyncExternalStore(
+    subscribeGoalTiers,
+    getGoalTiersSnapshot,
+    getGoalTiersServerSnapshot,
+  );
+  const { snapshots } = useSnapshots();
+  const tiers = spec?.tiers || null;
+
+  const currentData = useMemo(
+    () => readingToText(latestReadingFor(snapshots, goalId)),
+    [snapshots, goalId],
+  );
+
+  // Cache key: a new day OR changed tiers/data busts it and re-grades.
+  const key = useMemo(
+    () =>
+      tiers
+        ? `${todayStamp()}:${hashStr(JSON.stringify(tiers) + "|" + currentData)}`
+        : null,
+    [tiers, currentData],
+  );
+
+  useEffect(() => {
+    if (!goalId || !tiers || !key) return;
+    void gradeGoalTier({
+      goalId,
+      goalTitle: spec?.title,
+      tiers,
+      currentData,
+      key,
+      aiProvider: getAiProvider(),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [goalId, key]);
+
+  const stored = readGoalTier(goalId);
+  const verdict = stored && stored.key === key ? stored : null;
+
+  return {
+    hasTiers: !!tiers,
+    tiers,
+    verdict,
+    loading: !!tiers && !verdict,
+    regrade: () =>
+      gradeGoalTier({
+        goalId,
+        goalTitle: spec?.title,
+        tiers,
+        currentData,
+        key,
+        aiProvider: getAiProvider(),
+        force: true,
+      }),
+  };
+}
+
+/** The ordered tier ladder + display labels — shared with the UI (Phase 3). */
+export const TIER_ORDER = [
+  "not_achieved",
+  "achieved",
+  "over_achieved",
+  "role_model",
+];
+export const TIER_LABELS = {
+  not_achieved: "Not achieved",
+  achieved: "Achieved",
+  over_achieved: "Over achieved",
+  role_model: "Role model",
+};
+/** Map a tier id → the spec.tiers field that holds its criterion. */
+export const TIER_FIELD = {
+  not_achieved: "notAchieved",
+  achieved: "achieved",
+  over_achieved: "overAchieved",
+  role_model: "roleModel",
+};


### PR DESCRIPTION
Phase 2 of AI-graded goal tiers — the grading engine (Phase 1 added the `tiers` on specs; Phase 3 will wire the UI).

## Backend
- **`POST /api/v1/ai/grade-goal-tier`** — input `{ goalTitle, tiers, currentData }`; output `{ tier: not_achieved|achieved|over_achieved|role_model, reasoning, confidence }`. Same `callProvider` plumbing as `grade-pr` (json_object, temp 0.1, provider-neutral). Picks the highest tier whose criteria the data can verify; defaults to `not_achieved` + `low` confidence when criteria aren't measurable from the data.

## Frontend — new `features/goal-tiers`
- **`goal-tier-store`** — per-device daily cache (localStorage) keyed by `(day + hash(tiers + current data))`, so it re-grades at most once/day or when tiers/data change. Rate-limit-aware fetch; failures don't poison the cache; resets on auth transition (key added to `clear-user-storage`).
- **`useGoalTier(goalId, spec)`** — assembles `currentData` from the latest snapshot reading for the goal, triggers the cached grade, returns the verdict reactively. Exports `TIER_ORDER` / `TIER_LABELS` / `TIER_FIELD` for the UI.

Not server-persisted by design — a tier verdict is a cheap derived read, so the daily client cache (like the review-timing cache) is enough.

## Test plan
- [x] `typecheck:api` + `build:web` clean
- [ ] (after Phase 3) goal with tiers → verdict appears; re-grade button forces a fresh call; same-day reload hits cache