### PR TITLE
feat(goals): show AI achievement tier on the goal tree + widgets (AI-tier ph.3)

### DIFF
--- a/apps/web/src/features/dashboard/tiles/goals-tile.jsx
+++ b/apps/web/src/features/dashboard/tiles/goals-tile.jsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { BentoTile, Pill } from "@/components/ui";
 import { useGoals } from "@/features/goals";
+import { useGoalSpecs } from "@/features/goal-specs";
+import { GoalTierBadge } from "@/features/goal-tiers";
 import { useHubLink } from "@/features/hubs";
 
 /**
@@ -14,6 +16,7 @@ import { useHubLink } from "@/features/hubs";
  */
 export function GoalsTile() {
   const { goals, total, weights } = useGoals();
+  const { getSpec } = useGoalSpecs();
   const link = useHubLink();
 
   if (total.l1s === 0) {
@@ -61,14 +64,14 @@ export function GoalsTile() {
     >
       <div className="grid h-full auto-cols-fr grid-flow-col gap-3 overflow-x-auto overflow-y-hidden pr-1">
         {goals.l1s.map((l1, i) => (
-          <L1Column key={l1.id} l1={l1} index={i} />
+          <L1Column key={l1.id} l1={l1} index={i} getSpec={getSpec} />
         ))}
       </div>
     </BentoTile>
   );
 }
 
-function L1Column({ l1, index }) {
+function L1Column({ l1, index, getSpec }) {
   // L2 weightage sum — shown on the L1 column so the user sees at a glance
   // whether their L2 weights roll up correctly (should typically sum to
   // 100% within an L1, mirroring Zoho's KRA weightage semantics).
@@ -119,7 +122,7 @@ function L1Column({ l1, index }) {
           </div>
           <ul className="flex-1 space-y-1 overflow-y-auto pr-0.5">
             {l1.l2s.slice(0, 6).map((l2) => (
-              <L2Row key={l2.id} l2={l2} />
+              <L2Row key={l2.id} l2={l2} getSpec={getSpec} />
             ))}
             {l1.l2s.length > 6 ? (
               <li
@@ -151,7 +154,8 @@ const PRIORITY_TONE = {
   low: "muted",
 };
 
-function L2Row({ l2 }) {
+function L2Row({ l2, getSpec }) {
+  const spec = getSpec?.(l2.id);
   return (
     <li
       className="grid grid-cols-[1fr_auto] items-start gap-2 rounded-[var(--radius-sub)] border border-border bg-card px-2 py-1.5"
@@ -164,6 +168,9 @@ function L2Row({ l2 }) {
         <L2MetaLine l2={l2} />
       </div>
       <div className="flex shrink-0 items-center gap-1">
+        {/* AI achievement tier — only renders once the goal's been
+            re-analyzed with the four tiers (else nothing). */}
+        <GoalTierBadge goalId={l2.id} spec={spec} />
         {Number(l2.weightage) > 0 ? (
           <Pill tone="muted">{l2.weightage}%</Pill>
         ) : null}

--- a/apps/web/src/features/goal-tiers/goal-tier-ui.jsx
+++ b/apps/web/src/features/goal-tiers/goal-tier-ui.jsx
@@ -1,0 +1,160 @@
+"use client";
+
+/**
+ * Achievement-tier UI (Phase 3): a compact badge for dense lists (the
+ * goal tree) and a full ladder for widget tiles. Both read the AI
+ * verdict via `useGoalTier`; render nothing when the goal has no tiers
+ * (not re-analyzed since tiers landed).
+ */
+
+import { useGoalTier, TIER_ORDER, TIER_LABELS, TIER_FIELD } from "./use-goal-tier";
+
+const TIER_COLOR = {
+  not_achieved: "#b91c1c", // bad
+  achieved: "#1D4ED8", // accent
+  over_achieved: "#00c48a", // accent-2
+  role_model: "#f59e0b", // amber — exemplary
+};
+const TIER_SHORT = {
+  not_achieved: "Not met",
+  achieved: "Achieved",
+  over_achieved: "Over",
+  role_model: "Role model",
+};
+
+/**
+ * One-line tier chip for the goal tree's L2 rows. Solid colored pill +
+ * a tooltip carrying the AI's reasoning. Shows a muted "tier…" while the
+ * first grade is in flight, and nothing at all when the goal has no
+ * tiers yet.
+ */
+export function GoalTierBadge({ goalId, spec }) {
+  const { hasTiers, verdict, loading } = useGoalTier(goalId, spec);
+  if (!hasTiers) return null;
+  if (!verdict) {
+    return loading ? (
+      <span
+        className="shrink-0 uppercase tracking-[0.3px] text-dim-fg"
+        style={{ fontFamily: "var(--font-mono)", fontSize: 9 }}
+        title="Grading achievement tier…"
+      >
+        tier…
+      </span>
+    ) : null;
+  }
+  const color = TIER_COLOR[verdict.tier] || "var(--muted-fg)";
+  const title =
+    `${TIER_LABELS[verdict.tier]}` +
+    (verdict.reasoning ? ` — ${verdict.reasoning}` : "") +
+    (verdict.confidence === "low" ? " (low confidence)" : "");
+  return (
+    <span
+      className="inline-flex shrink-0 items-center rounded-[var(--radius-pill)] px-1.5 py-px font-bold uppercase tracking-[0.3px]"
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 9,
+        color: "#ffffff",
+        background: color,
+      }}
+      title={title}
+    >
+      {TIER_SHORT[verdict.tier]}
+    </span>
+  );
+}
+
+/**
+ * Full four-rung ladder for a widget tile. Highlights the rung the dev
+ * is currently at ("← you"), dims rungs above it, and shows the AI's
+ * one-line reasoning. Theme-aware via `variant` ("light" inverse tiles /
+ * "dark" white tiles).
+ */
+export function GoalTierLadder({ spec, variant = "light" }) {
+  const { hasTiers, tiers, verdict, loading } = useGoalTier(spec?.goalId, spec);
+  if (!hasTiers) return null;
+
+  const current = verdict?.tier || null;
+  const reachedIdx = current ? TIER_ORDER.indexOf(current) : -1;
+  const isLight = variant === "light";
+  const muted = isLight ? "rgba(255,255,255,0.62)" : "var(--muted-fg)";
+  const dim = isLight ? "rgba(255,255,255,0.40)" : "var(--dim-fg)";
+  const fg = isLight ? "#ffffff" : "var(--fg)";
+  const surface = isLight ? "rgba(255,255,255,0.08)" : "var(--card-alt)";
+
+  return (
+    <div
+      className="mt-3 rounded-[var(--radius-sub)] p-2"
+      style={{ background: surface }}
+    >
+      <div
+        className="mb-1.5 uppercase tracking-[0.5px]"
+        style={{ fontFamily: "var(--font-mono)", fontSize: 9.5, color: muted }}
+      >
+        Achievement tier{loading && !verdict ? " · grading…" : ""}
+      </div>
+      <div className="flex flex-col gap-1">
+        {TIER_ORDER.map((t, i) => {
+          const criterion = tiers[TIER_FIELD[t]];
+          const isCurrent = t === current;
+          const reached = reachedIdx >= 0 && i <= reachedIdx;
+          const color = TIER_COLOR[t];
+          return (
+            <div
+              key={t}
+              className="flex items-start gap-1.5"
+              style={{ opacity: reached || isCurrent ? 1 : 0.5 }}
+            >
+              <span
+                className="mt-[3px] h-1.5 w-1.5 shrink-0 rounded-full"
+                style={{
+                  background: reached ? color : "transparent",
+                  border: `1px solid ${color}`,
+                }}
+              />
+              <span
+                className="shrink-0 font-bold uppercase"
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 9,
+                  letterSpacing: "0.3px",
+                  color: isCurrent ? color : muted,
+                  width: 64,
+                }}
+              >
+                {TIER_LABELS[t]}
+              </span>
+              <span
+                className="min-w-0 flex-1"
+                style={{ fontSize: 10.5, lineHeight: 1.35, color: isCurrent ? fg : muted }}
+              >
+                {criterion || <span style={{ color: dim }}>—</span>}
+              </span>
+              {isCurrent ? (
+                <span
+                  className="shrink-0 uppercase"
+                  style={{ fontFamily: "var(--font-mono)", fontSize: 8.5, color }}
+                >
+                  ← you
+                </span>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+      {verdict?.reasoning ? (
+        <div
+          className="mt-1.5"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 9.5,
+            color: muted,
+            lineHeight: 1.4,
+          }}
+        >
+          {verdict.reasoning}
+          {verdict.confidence === "low" ? " · low confidence" : ""}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/goal-tiers/index.js
+++ b/apps/web/src/features/goal-tiers/index.js
@@ -6,3 +6,4 @@ export {
   TIER_FIELD,
 } from "./use-goal-tier";
 export { readGoalTier, resetGoalTiers } from "./goal-tier-store";
+export { GoalTierBadge, GoalTierLadder } from "./goal-tier-ui";

--- a/apps/web/src/features/goal-widgets/widget-shell.jsx
+++ b/apps/web/src/features/goal-widgets/widget-shell.jsx
@@ -22,6 +22,7 @@
 
 import { useState } from "react";
 import { useWidgetControls } from "./widget-controls-context";
+import { GoalTierLadder } from "@/features/goal-tiers";
 
 const VARIANT_STYLES = {
   light: {
@@ -110,6 +111,11 @@ export function WidgetShell({
       ) : null}
 
       <div className="flex min-h-0 flex-1 flex-col">{children}</div>
+
+      {/* Achievement-tier ladder (AI-graded). Renders only once the goal
+          has been re-analyzed with the four `tiers` — shows the dev where
+          they stand against not-achieved / achieved / over / role-model. */}
+      {spec?.tiers ? <GoalTierLadder spec={spec} variant={variant} /> : null}
 
       {(spec?.reasoning || onRetry || footer || onMarkDelegated || onEditContext) ? (
         <div


### PR DESCRIPTION
Phase 3 (final) of AI-graded goal tiers — the UI that makes it clear where the developer stands.

- **`goal-tier-ui`** — `GoalTierBadge` (compact solid pill + reasoning tooltip, for dense rows) and `GoalTierLadder` (4-rung ladder: current rung highlighted "← you", dimmed rungs above, + the AI's one-line reasoning; theme-aware light/dark). Both render nothing until a goal has `tiers` (i.e. been re-analyzed).
- **Section 1 (goal tree, `GoalsTile`):** each L2 row shows its tier badge (specs threaded via `useGoalSpecs.getSpec`).
- **Section 2 (AI widgets, `WidgetShell`):** every widget with tiers renders the ladder below its body — uniform across all widget kinds.

Colors: not-achieved = bad, achieved = accent, over = accent-2, role-model = amber. Grading is the cached once-daily call from Phase 2 (rate-limit-aware), so the tree's N badges cost at most N AI calls/day.

## Completes the feature
ph.1 (classifier emits `tiers`) → ph.2 (grader endpoint + cached hook) → **ph.3 (UI)**.

⚠️ Existing goals read `tiers: null` until **re-analyzed** — run the Analyst so the classifier produces tiers, then the badges/ladders populate.

## Test plan
- [x] `npm run build:web` clean
- [ ] Re-analyze goals → L2 rows show tier badges; widgets show the ladder with "← you" + reasoning
- [ ] Un-re-analyzed goals show nothing (no tiers) — no errors