### PR TITLE
fix(goals): make re-analyze reliably apply + stop tiers caching "no data"

### DIFF
--- a/apps/web/src/features/goal-tiers/use-goal-tier.js
+++ b/apps/web/src/features/goal-tiers/use-goal-tier.js
@@ -14,7 +14,7 @@
 
 import { useEffect, useMemo, useSyncExternalStore } from "react";
 import { useSnapshots } from "@/features/snapshots";
-import { useGoalInputs } from "@/features/goal-inputs";
+import { useGoalInputs, getInputsState } from "@/features/goal-inputs";
 import { SPEC_KINDS } from "@/features/goal-specs";
 import { getAiProvider } from "@/features/analyst/use-ai-provider";
 import {
@@ -145,6 +145,9 @@ export function useGoalTier(goalId, spec) {
   );
   const { snapshots } = useSnapshots();
   const { entries } = useGoalInputs(goalId);
+  // useGoalInputs subscribes to the inputs store tick, so this re-reads on
+  // hydration — used below to defer grading until the live data is loaded.
+  const inputsHydrated = getInputsState().fetched;
   const tiers = spec?.tiers || null;
 
   // Grade against the goal's LIVE state — the same goal-inputs the widget
@@ -168,6 +171,11 @@ export function useGoalTier(goalId, spec) {
 
   useEffect(() => {
     if (!goalId || !tiers || !key) return;
+    // Defer grading until goal-inputs have hydrated. Otherwise the first
+    // render (entries=[]) grades against empty data and caches a throwaway
+    // "no data" verdict. `inputsHydrated` is a dep, so when it flips true
+    // the grade fires — even for auto widgets whose `key` didn't change.
+    if (!inputsHydrated) return;
     void gradeGoalTier({
       goalId,
       goalTitle: spec?.title,
@@ -177,7 +185,7 @@ export function useGoalTier(goalId, spec) {
       aiProvider: getAiProvider(),
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [goalId, key]);
+  }, [goalId, key, inputsHydrated]);
 
   const stored = readGoalTier(goalId);
   const verdict = stored && stored.key === key ? stored : null;

--- a/apps/web/src/features/goal-widgets/goal-widget.jsx
+++ b/apps/web/src/features/goal-widgets/goal-widget.jsx
@@ -30,7 +30,7 @@ import { resolveWidget } from "./registry";
 import { DelegatedCard } from "./state-shells/delegated-card";
 import { UntrackableCard } from "./state-shells/untrackable-card";
 import { ContextCollector } from "./state-shells/context-collector";
-import { useIsContextComplete } from "@/features/goal-context";
+import { useIsContextComplete, readContextFor } from "@/features/goal-context";
 import { saveSpec } from "@/features/goal-specs";
 // Import directly (not via @/features/analyst) to keep the dep edge
 // goal-widgets → analyst one-way at the module level. analyst-page.jsx
@@ -152,6 +152,12 @@ export function GoalWidget({ spec, goal, variant = "light", className, onRetry }
     onEditContext: spec.context?.questions?.length
       ? () => setForceEditContext(true)
       : null,
+    // Direct, reliable re-analyze for ANY classified widget — re-runs the
+    // classifier with the goal's full description + saved context answers
+    // and writes the new spec immediately (no Review-pane buffer, no
+    // context.required gate). Returns the promise so WidgetShell can show
+    // a busy state + toast the result.
+    onReanalyze: () => runReclassify(spec, goal),
   };
 
   return (
@@ -224,11 +230,76 @@ async function runReclassify(spec, goal, contextAnswers) {
     goal: {
       id: spec.goalId,
       title: goal?.title || spec.title || "(untitled)",
-      description: goal?.rubric || goal?.description || "",
+      // Ship the SAME rich description bulk analysis builds (Category /
+      // Priority / Weightage / Window + Context + Rubric), not a bare
+      // rubric — otherwise the model loses the signal it needs to
+      // re-scope team-worded tiers down to the individual.
+      description: buildReclassifyDescription(goal),
       parentL1Title: goal?.parentL1Title,
       kind: goal?.kind || "L2",
     },
-    contextAnswers,
+    // Prefer freshly-edited pairs (from the ContextCollector); otherwise
+    // read the goal's saved context answers so a per-widget re-analyze
+    // still feeds the user's definitions to the classifier.
+    contextAnswers: contextAnswers ?? savedContextPairs(spec),
   });
   saveSpec(result);
+}
+
+/**
+ * Build the rich, multi-section description the classifier expects —
+ * mirrors the analyst's buildL2Description so a single-goal re-analyze
+ * gets identical context to a full run. Inlined (not imported from the
+ * analyst feature) to keep the goal-widgets → analyst dep edge one-way.
+ */
+function buildReclassifyDescription(goal) {
+  if (!goal) return "";
+  const window =
+    goal.startDate || goal.dueDate
+      ? `${goal.startDate || "?"} → ${goal.dueDate || "?"}`
+      : "";
+  const metaPairs = [
+    ["Category", goal.category],
+    ["Priority", goal.priority],
+    ["Weightage", goal.weightage ? `${goal.weightage}%` : ""],
+    ["Window", window],
+  ]
+    .map(([k, v]) => [k, typeof v === "string" ? v.trim() : v])
+    .filter(([, v]) => v);
+  const sections = [];
+  if (metaPairs.length) sections.push(metaPairs.map(([k, v]) => `${k}: ${v}`).join("\n"));
+  const ctx = typeof goal.description === "string" ? goal.description.trim() : "";
+  if (ctx) sections.push(`Context:\n${ctx}`);
+  const rubric = typeof goal.rubric === "string" ? goal.rubric.trim() : "";
+  if (rubric) sections.push(`Rubric:\n${rubric}`);
+  return sections.join("\n\n") || rubric || ctx || "";
+}
+
+/**
+ * Serialise the goal's SAVED context answers into the {prompt, answer}
+ * pairs the classifier prompt renders. Used when re-analyzing without the
+ * ContextCollector open (the per-widget "re-analyze" chip) so the user's
+ * previously-defined truths still reach the model. Returns [] when the
+ * spec has no context questions.
+ */
+function savedContextPairs(spec) {
+  const questions = spec?.context?.questions || [];
+  if (!questions.length) return [];
+  const answers = readContextFor(spec.goalId) || {};
+  const out = [];
+  for (const q of questions) {
+    const raw = answers[q.id];
+    let answer = "";
+    if (q.kind === "list") {
+      answer = Array.isArray(raw)
+        ? raw.map((s) => String(s).trim()).filter(Boolean).join("\n")
+        : "";
+    } else if (q.kind === "number") {
+      answer = typeof raw === "number" && !Number.isNaN(raw) ? String(raw) : "";
+    } else {
+      answer = typeof raw === "string" ? raw.trim() : "";
+    }
+    if (answer) out.push({ prompt: q.prompt, answer });
+  }
+  return out;
 }

--- a/apps/web/src/features/goal-widgets/state-shells/context-collector.jsx
+++ b/apps/web/src/features/goal-widgets/state-shells/context-collector.jsx
@@ -68,16 +68,18 @@ export function ContextCollector({
     setReclassifyError(null);
     setBusy(true);
     try {
-      // Always commit the draft first so the spec switch doesn't
-      // strand the user's typed answers if they immediately edit
-      // again. The parent receives the SAME serialised Q/A pairs the
-      // server prompt will see, so the back-end + front-end stay
-      // in sync about what the model was actually asked.
-      const normalized = commit();
+      // Build the Q/A pairs from the DRAFT without persisting yet.
+      // Persisting (setAnswers) flips useIsContextComplete → true, which
+      // makes GoalWidget unmount this collector mid-await; deferring the
+      // commit until AFTER the classifier resolves keeps us mounted so the
+      // busy state + error banner stay reliable.
+      const normalized = normalizeAnswers(questions, draft);
       const pairs = buildAnswerPairs(questions, normalized);
       await onReclassify(pairs);
-      // Parent saved the new spec; widget body now renders whatever
-      // the classifier chose this time.
+      // Success: persist the answers, then hand off — the parent saved the
+      // new spec, so the widget body now renders whatever the classifier
+      // chose this time.
+      setAnswers(normalized);
       onSaved?.();
     } catch (err) {
       setReclassifyError(err?.message || String(err));
@@ -99,14 +101,18 @@ export function ContextCollector({
         className="flex h-full flex-col gap-3"
         onSubmit={(e) => {
           e.preventDefault();
-          commit();
-          // After persisting, hand control back to the parent. For
-          // GoalWidget this clears its `forceEditContext` override and
-          // the actual rubric / counter / scale widget takes the slot
-          // back. Without this the view stays pinned to the collector
-          // even after a successful save — which looks like "Save
-          // did nothing" to the user.
-          onSaved?.();
+          // When a reclassify path is wired (dashboard GoalWidget), saving
+          // your answers ALSO re-runs the classifier so the freshly-defined
+          // truths actually re-scope the spec/tiers — that's what "save"
+          // means here, and it's the whole point of answering. Without a
+          // reclassify path (e.g. the Review pane), just persist and hand
+          // control back so the real widget takes the slot.
+          if (onReclassify) {
+            void handleReclassify();
+          } else {
+            commit();
+            onSaved?.();
+          }
         }}
       >
         <div
@@ -160,38 +166,18 @@ export function ContextCollector({
               opacity: busy ? 0.55 : 1,
               cursor: busy ? "not-allowed" : "pointer",
             }}
+            title={
+              onReclassify
+                ? "Save your answers and re-run the AI classifier so it re-scopes this goal to your definitions (it may even pick a different widget)."
+                : undefined
+            }
           >
-            Save answers
+            {onReclassify
+              ? busy
+                ? "Saving & re-analyzing…"
+                : "Save & re-analyze"
+              : "Save answers"}
           </button>
-          {/* Re-analyze is an OPT-IN escalation — only rendered when the
-              parent (GoalWidget on the dashboard) supplies onReclassify.
-              The Review pane and other contexts that show this collector
-              without a reclassify path simply don't pass the prop, so
-              the button never appears. */}
-          {onReclassify ? (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={handleReclassify}
-              className="rounded-[var(--radius-sub)] px-3 py-1.5 font-bold uppercase transition-opacity"
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: 10.5,
-                letterSpacing: "0.5px",
-                background: "transparent",
-                color: variant === "light" ? "#ffffff" : "var(--fg)",
-                border:
-                  variant === "light"
-                    ? "1px solid rgba(255,255,255,0.55)"
-                    : "1px solid var(--border)",
-                opacity: busy ? 0.55 : 1,
-                cursor: busy ? "not-allowed" : "pointer",
-              }}
-              title="Re-run the AI classifier with your answers so it can pick a different widget if the answers point elsewhere."
-            >
-              {busy ? "Re-analyzing…" : "Re-analyze with these answers"}
-            </button>
-          ) : null}
         </div>
       </form>
     </WidgetShell>

--- a/apps/web/src/features/goal-widgets/widget-shell.jsx
+++ b/apps/web/src/features/goal-widgets/widget-shell.jsx
@@ -21,6 +21,7 @@
  */
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { useWidgetControls } from "./widget-controls-context";
 import { GoalTierLadder } from "@/features/goal-tiers";
 
@@ -59,10 +60,34 @@ export function WidgetShell({
 }) {
   const theme = VARIANT_STYLES[variant] || VARIANT_STYLES.light;
   const [showReason, setShowReason] = useState(false);
+  const [reanalyzing, setReanalyzing] = useState(false);
   // Optional user-controls injected by <GoalWidget>. Null handlers skip
   // rendering — widgets rendered outside the resolver (e.g. tests) still
   // work unchanged.
-  const { onMarkDelegated, onEditContext } = useWidgetControls();
+  const { onMarkDelegated, onEditContext, onReanalyze } = useWidgetControls();
+
+  // The footer "re-analyze" chip. Prefer the direct reclassify+save path
+  // (onReanalyze, injected by GoalWidget) so a single click re-runs the
+  // classifier and applies the new spec immediately — with a busy state
+  // and a success/failure toast. Falls back to onRetry (e.g. the analyst
+  // overlay) when no direct handler is wired.
+  async function handleReanalyze() {
+    if (reanalyzing) return;
+    if (!onReanalyze) {
+      onRetry?.();
+      return;
+    }
+    setReanalyzing(true);
+    try {
+      await onReanalyze();
+      toast.success("Re-analyzed — spec & tiers updated.");
+    } catch (err) {
+      toast.error(`Re-analyze failed: ${err?.message || err}`);
+    } finally {
+      setReanalyzing(false);
+    }
+  }
+  const canReanalyze = !!(onReanalyze || onRetry);
 
   return (
     <div
@@ -117,7 +142,7 @@ export function WidgetShell({
           they stand against not-achieved / achieved / over / role-model. */}
       {spec?.tiers ? <GoalTierLadder spec={spec} variant={variant} /> : null}
 
-      {(spec?.reasoning || onRetry || footer || onMarkDelegated || onEditContext) ? (
+      {(spec?.reasoning || onRetry || onReanalyze || footer || onMarkDelegated || onEditContext) ? (
         <div
           className="mt-3 flex items-center justify-between gap-2 border-t pt-2"
           style={{ borderColor: theme.divider }}
@@ -140,9 +165,9 @@ export function WidgetShell({
             ) : null}
             {footer}
           </div>
-          {onRetry ? (
-            <FooterChip theme={theme} onClick={onRetry}>
-              re-analyze
+          {canReanalyze ? (
+            <FooterChip theme={theme} onClick={handleReanalyze}>
+              {reanalyzing ? "re-analyzing…" : "re-analyze"}
             </FooterChip>
           ) : null}
         </div>


### PR DESCRIPTION
Follow-up to #158. The investigation found the grading code is correct — but two things made the tiers *look* broken: **re-analyze rarely applied** (so the fabricated team-scoped tiers persisted), and a **first-render race** could cache a throwaway "no data" verdict.

## Re-analyze — now reliable + full-context
Root causes (all confirmed in code by a parallel trace):
1. **"Save answers" never re-classified** — only a secondary button did. Saving just swapped the *old* spec back.
2. **No re-analyze affordance** at all for goals without a `context.required` block (most team-scoped ones).
3. **Analyst re-analyze buffers** into a Review pane — easy to not commit, and the old spec was already dropped.
4. **Single-goal re-analyze sent a degraded prompt** (bare rubric, no context answers) → tiers stayed team-scoped even when it ran.

Fixes:
- **"Save & re-analyze"** — the ContextCollector's primary button now saves *and* re-runs the classifier (when a reclassify path is wired).
- **Per-widget "re-analyze" chip** — every classified widget gets a direct `onReanalyze` that re-runs the classifier and `saveSpec()`s immediately (no `context.required` gate, no Review buffer). Busy state + success/failure toast.
- **Rich prompt on single-goal re-analyze** — ships the same Category/Priority/Weightage/Window + Context + Rubric block bulk analysis builds, plus the goal's **saved context answers**, so the individual-scope rule from #158 can actually re-scope team-worded tiers.
- **Unmount race fixed** — defer persisting answers until after the classifier resolves, so the collector isn't torn down mid-await (was making success/error feedback flaky).

## Grading — no throwaway verdict
- `useGoalTier` defers grading until **goal-inputs hydrate** (`inputsHydrated` dep). The first render (`entries=[]`) no longer grades against empty data and caches a "no data" verdict. Auto widgets still grade once inputs load.

## Files
- `apps/web/src/features/goal-tiers/use-goal-tier.js`
- `apps/web/src/features/goal-widgets/goal-widget.jsx`
- `apps/web/src/features/goal-widgets/widget-shell.jsx`
- `apps/web/src/features/goal-widgets/state-shells/context-collector.jsx`

## Verification
- `npm run build:web` ✓ (all routes compiled)

## Note
The original grading fix (#158) was correct; the user was seeing a stale Vercel bundle / cached `espace-devhub:goal-tiers` localStorage verdict. After this deploys: hard-reload once. Re-analyzing a goal now applies immediately and re-scopes its tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)