### PR TITLE
fix(dashboard): count ALL goals live in the Goal compliance tile

### DIFF
--- a/apps/web/src/features/dashboard/tiles/goal-compliance-tile.jsx
+++ b/apps/web/src/features/dashboard/tiles/goal-compliance-tile.jsx
@@ -34,11 +34,11 @@ export function GoalComplianceTile() {
       {!hasData ? (
         <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
           <div className="text-[13px] font-semibold text-fg">
-            No closed windows yet
+            Nothing to track yet
           </div>
           <div className="max-w-[200px] text-[11px] leading-[1.45] text-muted-fg">
-            Weekly snapshots build your goal-compliance read — check back
-            after the first capture.
+            Classify a goal and log progress against it — on-pace goals show
+            up here right away.
           </div>
         </div>
       ) : (

--- a/apps/web/src/features/goal-inputs/compliance.js
+++ b/apps/web/src/features/goal-inputs/compliance.js
@@ -106,18 +106,24 @@ export function computeCompliance(entries, target, cadence) {
 
   let contribution = 0;
   let metWindows = 0;
-  for (const sum of buckets) {
+  // Whether the MOST RECENT window (the current, still-open cadence
+  // period) hit its target — the "are you on pace right now?" signal the
+  // live compliance summary reads, distinct from the lifetime average.
+  let latestWindowMet = false;
+  for (let i = 0; i < buckets.length; i += 1) {
+    const sum = buckets[i];
     let weight;
+    let hit = false;
     if (op === ">=") {
       // Cap at 1.0 — over-logging this window doesn't carry to the next.
       weight = t > 0 ? Math.min(sum, t) / t : 0;
-      if (sum >= t) metWindows += 1;
+      hit = sum >= t;
     } else if (op === "<=") {
       // At-or-below = full credit. Over-target = penalty proportional to
       // overshoot, but bounded so going wildly over doesn't go negative.
       if (sum <= t) {
         weight = 1;
-        metWindows += 1;
+        hit = true;
       } else {
         weight = t / sum; // (0, 1) since sum > t > 0 in this branch
       }
@@ -125,13 +131,14 @@ export function computeCompliance(entries, target, cadence) {
       // Within ±10% counts as hitting. Closer = better but binary
       // beyond that (don't try to be clever).
       const within = Math.abs(sum - t) / Math.max(1, Math.abs(t));
-      const hit = within <= 0.1;
+      hit = within <= 0.1;
       weight = hit ? 1 : 0;
-      if (hit) metWindows += 1;
     } else {
       weight = 0;
     }
+    if (hit) metWindows += 1;
     contribution += weight;
+    if (i === buckets.length - 1) latestWindowMet = hit;
   }
 
   const ratio = contribution / windowCount;
@@ -141,6 +148,7 @@ export function computeCompliance(entries, target, cadence) {
     pct,
     metWindows,
     totalWindows: windowCount,
+    latestWindowMet,
     targetOp: op,
     targetValue: t,
     cadence,

--- a/apps/web/src/features/snapshots/use-compliance-summary.js
+++ b/apps/web/src/features/snapshots/use-compliance-summary.js
@@ -1,27 +1,39 @@
 "use client";
 
 /**
- * Aggregate goal-compliance across every tracked goal in the snapshot
- * stream — the data behind the Overview "Goal compliance" tile.
+ * Aggregate goal-compliance across EVERY classified goal — the data behind
+ * the Overview "Goal compliance" tile.
  *
  * Returns `{ met, assessable, pct }`:
- *   - assessable: goals with a boolean compliance signal (excludes
- *     delegated goals, goals with no target, and goals with no readings
- *     yet — none of which can be judged on-pace).
+ *   - assessable: classified, non-delegated, non-untrackable goals we can
+ *     judge an on-pace standing for. A goal is excluded only when its
+ *     standing is genuinely indeterminate (a reflection/free-text goal, an
+ *     un-graded rubric, an auto goal with no snapshot reading yet).
  *   - met: assessable goals currently on pace / meeting target.
  *   - pct: round(met / assessable * 100), or null when nothing is
  *     assessable yet.
  *
- * Per-goal standing prefers the IN-PROGRESS window's `onPace`/`windowMet`
- * (the current cycle's standing); when a goal has only closed history it
- * falls back to the most recent closed window's `windowMet`.
+ * Standing is computed from LIVE data — the same goal-inputs the widgets
+ * render — so manual goals (milestone, recurring-milestone, incident,
+ * counter, scale, before/after) are counted immediately, with no snapshot
+ * or backfill required. AUTO widgets (merged-count, turnaround, …) fall
+ * back to their latest snapshot reading, since judging those live would
+ * need a full integration fetch here.
  */
 
 import { useMemo } from "react";
 import { useSnapshots } from "./use-snapshots";
 import { goalCompliance } from "./compliance";
+import { useGoals } from "@/features/goals";
+import { useGoalSpecs, SPEC_KINDS } from "@/features/goal-specs";
+import {
+  useAllGoalInputs,
+  readInputs,
+  computeCompliance,
+} from "@/features/goal-inputs";
 
-function currentStanding(c) {
+/** Snapshot-derived standing (the historical weekly-window read). */
+function snapshotStanding(c) {
   if (!c) return null;
   if (c.inProgress) {
     if (c.inProgress.onPace != null) return c.inProgress.onPace === true;
@@ -37,26 +49,109 @@ function currentStanding(c) {
   return null;
 }
 
+/** value `op` target → boolean. Defaults to ">=" semantics. */
+function cmpTarget(value, target) {
+  const t = target.value;
+  if (target.op === "<=") return value <= t;
+  if (target.op === "=") return Math.abs(value - t) <= 0.1 * Math.max(1, Math.abs(t));
+  return value >= t;
+}
+
+/**
+ * Current on-pace standing for ONE goal from live data.
+ *   true  → on pace / meeting target
+ *   false → behind / breached
+ *   null  → can't be judged (excluded from the denominator)
+ */
+function liveStanding(spec, entries, snapshots, goalId) {
+  if (!spec || spec.delegated?.delegated || spec.untrackable) return null;
+  const list = Array.isArray(entries) ? entries : [];
+  const latest = list.length ? list[list.length - 1] : null;
+
+  switch (spec.widget) {
+    // Checklists — on pace when the latest period is fully ticked.
+    case SPEC_KINDS.MILESTONE:
+    case SPEC_KINDS.RECURRING_MILESTONE: {
+      const items = latest?.value?.items;
+      if (!Array.isArray(items) || items.length === 0) return null;
+      return items.every((it) => it && it.done);
+    }
+    // Current-state rating — strong at the target (or 4/5 by default).
+    case SPEC_KINDS.SCALE: {
+      const v =
+        latest && Number.isFinite(Number(latest.value))
+          ? Number(latest.value)
+          : null;
+      if (v == null) return null;
+      const t = spec.manual?.target;
+      return t && Number.isFinite(t.value) ? cmpTarget(v, t) : v >= 4;
+    }
+    // Cadence-bucketed sum — is THIS window meeting target?
+    case SPEC_KINDS.COUNTER: {
+      const c = computeCompliance(list, spec.manual?.target, spec.manual?.cadence);
+      return c ? c.latestWindowMet : null;
+    }
+    // Frequency log — count this window's entries against the target.
+    case SPEC_KINDS.DATE_LOG: {
+      const t = spec.manual?.target;
+      if (!t) return null;
+      const counted = list.map((e) => ({ ts: e.ts, value: 1 }));
+      const c = computeCompliance(counted, t, spec.manual?.cadence);
+      return c ? c.latestWindowMet : null;
+    }
+    // Lower-is-better — on pace when at/under target, or (no target) zero.
+    case SPEC_KINDS.INCIDENT_LOG: {
+      const count = list.filter((e) => e && e.value != null).length;
+      const t = spec.manual?.target;
+      return t && Number.isFinite(t.value) ? cmpTarget(count, t) : count === 0;
+    }
+    // Improvement — current beats baseline (lower-is-better default, same
+    // assumption capture-readings makes).
+    case SPEC_KINDS.BEFORE_AFTER: {
+      const b = Number(latest?.value?.baseline);
+      const cur = Number(latest?.value?.current);
+      if (!Number.isFinite(b) || !Number.isFinite(cur)) return null;
+      return cur < b;
+    }
+    // Reflection notes have no on-pace notion.
+    case SPEC_KINDS.FREE_TEXT:
+      return null;
+    // Auto widgets + code-rubric + scorecard: latest snapshot reading.
+    default:
+      return snapshotStanding(goalCompliance(snapshots, goalId));
+  }
+}
+
 export function useComplianceSummary() {
   const { snapshots } = useSnapshots();
+  const { goals } = useGoals();
+  const { specs } = useGoalSpecs();
+  // Subscribe to the inputs store tick so the summary recomputes when the
+  // user logs/ticks anything (and so the one-shot hydration fires).
+  const inputsTick = useAllGoalInputs();
+
   return useMemo(() => {
-    const ids = new Set();
-    for (const s of snapshots) {
-      const readings = s?.goalReadings;
-      if (readings) for (const id of Object.keys(readings)) ids.add(id);
-    }
+    const byGoal = readInputs() || {};
     let met = 0;
     let assessable = 0;
-    for (const id of ids) {
-      const standing = currentStanding(goalCompliance(snapshots, id));
-      if (standing == null) continue;
-      assessable += 1;
-      if (standing) met += 1;
+    const seen = new Set();
+    for (const l1 of goals?.l1s || []) {
+      for (const g of [l1, ...(l1.l2s || [])]) {
+        if (!g?.id || seen.has(g.id)) continue;
+        seen.add(g.id);
+        const spec = specs.get(g.id);
+        if (!spec) continue;
+        const standing = liveStanding(spec, byGoal[g.id] || [], snapshots, g.id);
+        if (standing == null) continue;
+        assessable += 1;
+        if (standing) met += 1;
+      }
     }
     return {
       met,
       assessable,
       pct: assessable > 0 ? Math.round((met / assessable) * 100) : null,
     };
-  }, [snapshots]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snapshots, goals, specs, inputsTick]);
 }


### PR DESCRIPTION
## Problem
The Overview "Goal compliance" tile showed **"1 TRACKED · 1/1 on pace"** even with many classified goals (recurring-milestone, incident, scale, RTO…).

`useComplianceSummary` only counted goals that had a **snapshot reading with a boolean standing**, and `capture-readings.js` returns `null` for recurring-milestone, incident-log, scorecard, and the CI widgets. So those goal types were *invisible* to the tile — only a scale goal (which does get a snapshot reading) qualified → "1/1". Same `capture-readings` gap that bit the tier grader.

## Fix — count all goals, judged live
Reworked `useComplianceSummary` to iterate **every** classified, non-delegated, non-untrackable goal and compute its on-pace standing from **live `goal-inputs`** (the same data the widgets render) — no snapshot or backfill required:

| Widget | Standing |
|---|---|
| milestone / recurring-milestone | latest checklist fully ticked |
| scale | latest rating ≥ target (or ≥ 4/5) |
| counter | current cadence window meets target |
| date-log | current window's log count meets target |
| incident-log | at/under target, or zero when no target (lower-is-better) |
| before/after | current beats baseline |
| free-text | not pace-assessable → excluded |
| auto (merged/turnaround/…), code-rubric, scorecard | latest **snapshot** reading (judging live needs an integration fetch) |

Supporting change: `computeCompliance` now returns `latestWindowMet` (did the current cadence window hit target?) so counter/date-log get a "right now" signal rather than a lifetime average.

Also retired the stale *"No closed windows yet — weekly snapshots build your read"* empty state, which no longer matches the live model.

## Result
The user's recurring-milestone + incident goals are now counted immediately. "Tracked" reflects all pace-assessable goals, not just the one with a snapshot reading.

## Files
- `apps/web/src/features/snapshots/use-compliance-summary.js`
- `apps/web/src/features/goal-inputs/compliance.js`
- `apps/web/src/features/dashboard/tiles/goal-compliance-tile.jsx`

## Verification
- `npm run build:web` ✓ (all routes compiled)

## Note
Auto widgets (merged-count, turnaround, etc.) still read their **latest snapshot** for standing — judging those live would require a full GitHub/GitLab/Jira fetch in the tile. Manual goals (the ones that were missing) are fully live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)