### PR TITLE
feat(ui): dot-loader loading states + kill the empty-state flash

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "@api/nim": "file:.api/apis/nim",
+    "@dot-loaders/core": "^0.1.0",
+    "@dot-loaders/presets": "^0.1.0",
+    "@dot-loaders/react": "^0.1.0",
     "@espace-devhub/api": "*",
     "@espace-devhub/shared": "*",
     "@radix-ui/react-avatar": "^1.1.10",
@@ -48,6 +51,5 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.7.3",
     "xlsx": "^0.18.5"
-  },
-  "devDependencies": {}
+  }
 }

--- a/apps/web/src/components/ui/index.js
+++ b/apps/web/src/components/ui/index.js
@@ -19,3 +19,4 @@ export { LineSpark } from "./line-spark";
 export { StarGlyph } from "./star-glyph";
 export { Stat } from "./stat";
 export { TileState } from "./tile-state";
+export { Loader, Loading } from "./loader";

--- a/apps/web/src/components/ui/loader.jsx
+++ b/apps/web/src/components/ui/loader.jsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * <Loader /> — the project's single loading glyph, wrapping @dot-loaders
+ * (braille / dot-grid animations). One component, one prop to pick the
+ * animation, sized by token. Inherits `currentColor`, so it adapts to
+ * whatever surface it sits on (white-on-indigo tiles, dark cards, muted
+ * footers) unless you pass `color`.
+ *
+ *   <Loader loader="dna-helix" size="lg" label="Loading goals" />
+ *
+ * `loader` is any @dot-loaders preset id:
+ *   dna-helix · scan · checkerboard · helix · scanline-grid · spiral ·
+ *   pulse · pulse-soft · diagonal-swipe · sand · braille-wave   (+ more)
+ *
+ * Animation respects prefers-reduced-motion automatically. If the library
+ * ever throws (bad id, render fault) it degrades to three pulsing dots —
+ * a loader must never crash the surface it sits on.
+ *
+ * <Loading /> is the centered fill for a whole page / section / panel
+ * (big signature loader + optional caption).
+ */
+
+import { Component } from "react";
+import { Loader as DotLoader } from "@dot-loaders/react";
+import { curatedLoaders } from "@dot-loaders/presets";
+import { registerLoaders, listRegisteredLoaders } from "@dot-loaders/core";
+import { cn } from "@/lib/cn";
+
+// Importing `curatedLoaders` runs the presets module, which registers the
+// curated set into @dot-loaders/core's registry (the same instance the
+// React component reads). This gated call is belt-and-suspenders in case a
+// bundler ever tree-shakes that side effect away.
+if (listRegisteredLoaders().length === 0) {
+  try {
+    registerLoaders(curatedLoaders);
+  } catch {
+    /* already registered — ignore */
+  }
+}
+
+// size → svg-grid cell metrics (dot loaders) + font-size (text loaders) +
+// fallback dot diameter. Both renderer knobs are set so a preset using
+// either renderer is sized correctly; the unused one is ignored.
+const SIZES = {
+  xs: { fontSize: 12, cellSize: 2, gap: 1, dot: 4 },
+  sm: { fontSize: 15, cellSize: 2.5, gap: 1, dot: 5 },
+  md: { fontSize: 22, cellSize: 3, gap: 1.5, dot: 6 },
+  lg: { fontSize: 32, cellSize: 4, gap: 2, dot: 8 },
+  xl: { fontSize: 46, cellSize: 6, gap: 2.5, dot: 10 },
+};
+
+/** Pure-CSS fallback: three pulsing dots in currentColor. */
+function DotFallback({ size = "md", label = "Loading", className, style }) {
+  const sz = SIZES[size] || SIZES.md;
+  return (
+    <span
+      role="status"
+      aria-label={label}
+      className={cn("inline-flex items-center", className)}
+      style={{ gap: sz.dot * 0.6, color: "currentColor", ...style }}
+    >
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          aria-hidden="true"
+          className="inline-block rounded-full motion-safe:animate-pulse"
+          style={{
+            width: sz.dot,
+            height: sz.dot,
+            background: "currentColor",
+            animationDelay: `${i * 160}ms`,
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+class LoaderBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { failed: false };
+  }
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  render() {
+    return this.state.failed ? this.props.fallback : this.props.children;
+  }
+}
+
+export function Loader({
+  loader = "pulse",
+  size = "md",
+  color,
+  label = "Loading",
+  speed,
+  className = "",
+  style,
+}) {
+  const sz = SIZES[size] || SIZES.md;
+  return (
+    <LoaderBoundary
+      fallback={
+        <DotFallback size={size} label={label} className={className} style={{ color, ...style }} />
+      }
+    >
+      <DotLoader
+        loader={loader}
+        {...(speed != null ? { speed } : {})}
+        rendererOptions={{ cellSize: sz.cellSize, gap: sz.gap }}
+        fallbackLabel={label}
+        aria-label={label}
+        className={className}
+        style={{
+          fontSize: sz.fontSize,
+          color: color || "currentColor",
+          lineHeight: 1,
+          ...style,
+        }}
+      />
+    </LoaderBoundary>
+  );
+}
+
+/**
+ * Centered loading fill for a whole page / section / panel. Use while a
+ * data store is still hydrating so the empty state never flashes first.
+ *
+ *   if (!fetched) return <Loading loader="dna-helix" label="Loading goals…" />;
+ */
+export function Loading({
+  loader = "dna-helix",
+  size = "xl",
+  label,
+  color = "var(--muted-fg)",
+  className,
+}) {
+  return (
+    <div
+      className={cn(
+        "flex w-full flex-1 flex-col items-center justify-center gap-3 py-10",
+        className,
+      )}
+      role="status"
+      aria-live="polite"
+      style={{ color }}
+    >
+      <Loader loader={loader} size={size} label={label || "Loading"} />
+      {label ? (
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            letterSpacing: "0.3px",
+            color: "var(--muted-fg)",
+          }}
+        >
+          {label}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/tile-state.jsx
+++ b/apps/web/src/components/ui/tile-state.jsx
@@ -25,29 +25,46 @@
  */
 
 import { cn } from "@/lib/cn";
+import { Loader } from "./loader";
+
+// Loading glyph per silhouette — a tile's loading affordance matches the
+// shape of the content it's standing in for. All are dot-loaders so the
+// "data is coming" beat reads consistently across the whole grid.
+const LOADING_LOADER = {
+  stat: "pulse",
+  list: "diagonal-swipe",
+  chart: "scanline-grid",
+  kanban: "checkerboard",
+};
 
 export function TileState({
   kind = "loading",
   message,
   sub,
-  // `silhouette` lets a tile match the new placeholder shape to its actual
-  // content. Defaults to "stat" — one big number + 1 line of meta, which
-  // covers most overview tiles.
+  // `silhouette` lets a tile match the placeholder to its actual content.
+  // Defaults to "stat" — one big number + 1 line of meta, which covers
+  // most overview tiles.
   silhouette = "stat",
+  // Optional explicit dot-loader id, overriding the silhouette default.
+  loader,
   className,
 }) {
   if (kind === "loading") {
     return (
       <div
         className={cn(
-          "flex h-full min-h-0 w-full flex-1 flex-col gap-2.5 motion-safe:animate-pulse",
+          "flex h-full min-h-0 w-full flex-1 items-center justify-center text-muted-fg",
           className,
         )}
         role="status"
         aria-live="polite"
         aria-label={message || "Loading"}
       >
-        <Skeleton silhouette={silhouette} />
+        <Loader
+          loader={loader || LOADING_LOADER[silhouette] || "pulse-soft"}
+          size={silhouette === "chart" || silhouette === "kanban" ? "lg" : "md"}
+          label={message || "Loading"}
+        />
       </div>
     );
   }
@@ -94,72 +111,5 @@ export function TileState({
         </div>
       ) : null}
     </div>
-  );
-}
-
-function Skeleton({ silhouette }) {
-  // Each silhouette is a small JSX recipe — easy to extend (add "table",
-  // "kanban", etc. as they're needed). Heights and gaps mirror the tile
-  // chrome's `padding: 18` so the placeholder stays inside the bordered box.
-  switch (silhouette) {
-    case "list":
-      return (
-        <>
-          <Bar w="55%" h={10} />
-          <Bar w="92%" h={8} />
-          <Bar w="86%" h={8} />
-          <Bar w="72%" h={8} />
-          <Bar w="60%" h={8} />
-        </>
-      );
-    case "chart":
-      return (
-        <>
-          <Bar w="40%" h={10} />
-          <Bar w="100%" h={56} />
-          <Bar w="60%" h={8} />
-        </>
-      );
-    case "kanban":
-      return (
-        <div className="grid h-full min-h-0 grid-cols-3 gap-2.5">
-          <Column />
-          <Column />
-          <Column />
-        </div>
-      );
-    case "stat":
-    default:
-      return (
-        <>
-          <Bar w="40%" h={10} />
-          <Bar w="55%" h={28} />
-          <Bar w="70%" h={8} />
-        </>
-      );
-  }
-}
-
-function Column() {
-  return (
-    <div className="flex h-full min-h-0 flex-col gap-1.5">
-      <Bar w="60%" h={9} />
-      <Bar w="100%" h={18} />
-      <Bar w="100%" h={18} />
-      <Bar w="100%" h={18} />
-    </div>
-  );
-}
-
-function Bar({ w, h }) {
-  return (
-    <div
-      style={{
-        width: w,
-        height: h,
-        background: "var(--border)",
-        borderRadius: 4,
-      }}
-    />
   );
 }

--- a/apps/web/src/features/dashboard/sections/goal-tracking-section.jsx
+++ b/apps/web/src/features/dashboard/sections/goal-tracking-section.jsx
@@ -9,6 +9,7 @@ import {
 } from "@/features/goal-widgets";
 import { useAnalyst, ANALYST_MODES } from "@/features/analyst";
 import { removeSpec } from "@/features/goal-specs";
+import { Loading } from "@/components/ui";
 
 /**
  * GOALS TAB · SECTION 02 — Goal tracking (AI-classified).
@@ -30,8 +31,14 @@ import { removeSpec } from "@/features/goal-specs";
  */
 export function GoalTrackingSection() {
   const { requestOpen } = useAnalyst();
-  const { groupedItems, hasGoals, hasSpecs, lastAnalyzedAt, unclassifiedGoals } =
-    useGoalWidgetItems();
+  const {
+    groupedItems,
+    hasGoals,
+    hasSpecs,
+    lastAnalyzedAt,
+    unclassifiedGoals,
+    ready,
+  } = useGoalWidgetItems();
 
   // Annotate each item with an `onRetry` so the per-widget error path can
   // re-classify just that goal — wipes the spec and reopens the analyst.
@@ -65,7 +72,9 @@ export function GoalTrackingSection() {
         requestOpen={requestOpen}
       />
 
-      {!hasGoals ? (
+      {!ready ? (
+        <Loading loader="dna-helix" size="lg" label="Loading goals…" />
+      ) : !hasGoals ? (
         <EmptyState
           title="Add goals to start tracking"
           body="You haven't added any L1 or L2 goals yet. Paste them into Settings and the analyst will turn each into a live widget here."

--- a/apps/web/src/features/dashboard/tiles/goal-compliance-tile.jsx
+++ b/apps/web/src/features/dashboard/tiles/goal-compliance-tile.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { BentoTile } from "@/components/ui";
+import { BentoTile, TileState } from "@/components/ui";
 import { useComplianceSummary } from "@/features/snapshots";
 import { useHubLink } from "@/features/hubs";
 
@@ -12,7 +12,7 @@ import { useHubLink } from "@/features/hubs";
  * + Settings).
  */
 export function GoalComplianceTile() {
-  const { met, assessable, pct } = useComplianceSummary();
+  const { met, assessable, pct, ready } = useComplianceSummary();
   const link = useHubLink();
   const hasData = assessable > 0;
 
@@ -20,7 +20,7 @@ export function GoalComplianceTile() {
     <BentoTile
       col="span 3"
       row="span 2"
-      label={`Goal compliance${hasData ? ` · ${assessable} tracked` : ""}`}
+      label={`Goal compliance${ready && hasData ? ` · ${assessable} tracked` : ""}`}
       right={
         <Link
           href={link("/goals")}
@@ -31,7 +31,9 @@ export function GoalComplianceTile() {
         </Link>
       }
     >
-      {!hasData ? (
+      {!ready ? (
+        <TileState kind="loading" silhouette="stat" message="Loading compliance…" />
+      ) : !hasData ? (
         <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
           <div className="text-[13px] font-semibold text-fg">
             Nothing to track yet

--- a/apps/web/src/features/dashboard/tiles/goals-tile.jsx
+++ b/apps/web/src/features/dashboard/tiles/goals-tile.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { BentoTile, Pill } from "@/components/ui";
+import { BentoTile, Pill, TileState } from "@/components/ui";
 import { useGoals } from "@/features/goals";
 import { useGoalSpecs } from "@/features/goal-specs";
 import { GoalTierBadge } from "@/features/goal-tiers";
@@ -15,9 +15,25 @@ import { useHubLink } from "@/features/hubs";
  * tab where the tree editor lives.
  */
 export function GoalsTile() {
-  const { goals, total, weights } = useGoals();
+  const { goals, total, weights, fetched } = useGoals();
   const { getSpec } = useGoalSpecs();
   const link = useHubLink();
+
+  // Still hydrating → show a loader, never the "Map your goals" empty
+  // state (that flashed on every first paint before the fetch settled).
+  if (!fetched) {
+    return (
+      <BentoTile
+        col="span 12"
+        row="span 4"
+        label="Performance goals"
+        title="Your performance goals"
+        titleSize={18}
+      >
+        <TileState kind="loading" silhouette="kanban" message="Loading goals…" />
+      </BentoTile>
+    );
+  }
 
   if (total.l1s === 0) {
     return (

--- a/apps/web/src/features/goal-inputs/use-goal-inputs.js
+++ b/apps/web/src/features/goal-inputs/use-goal-inputs.js
@@ -75,6 +75,8 @@ export function useGoalInputs(goalId) {
     append,
     remove,
     clear,
+    // Hydration flag for empty-state gating (`!fetched → loader`).
+    fetched: getInputsState().fetched,
   };
 }
 

--- a/apps/web/src/features/goal-specs/use-goal-specs.js
+++ b/apps/web/src/features/goal-specs/use-goal-specs.js
@@ -52,6 +52,11 @@ export function useGoalSpecs() {
   const isClassified = useCallback((goalId) => parsed.has(goalId), [parsed]);
   const getSpec = useCallback((goalId) => parsed.get(goalId), [parsed]);
 
+  // Hydration flags for empty-state gating (`!fetched → loader`). Read
+  // fresh each render; the useSyncExternalStore subscription re-runs the
+  // component when the store settles.
+  const specsState = getSpecsState();
+
   return {
     specs: parsed,
     rawSpecs: rawSpecs || {},
@@ -59,5 +64,7 @@ export function useGoalSpecs() {
     count: parsed.size,
     isClassified,
     getSpec,
+    fetched: specsState.fetched,
+    loading: specsState.loading,
   };
 }

--- a/apps/web/src/features/goal-widgets/use-goal-widget-items.js
+++ b/apps/web/src/features/goal-widgets/use-goal-widget-items.js
@@ -29,8 +29,8 @@ function flattenGoals(tree) {
 }
 
 export function useGoalWidgetItems() {
-  const { goals } = useGoals();
-  const { specs, lastAnalyzedAt } = useGoalSpecs();
+  const { goals, fetched: goalsFetched } = useGoals();
+  const { specs, lastAnalyzedAt, fetched: specsFetched } = useGoalSpecs();
 
   const items = useMemo(() => {
     const flat = flattenGoals(goals);
@@ -113,5 +113,8 @@ export function useGoalWidgetItems() {
     hasGoals,
     hasSpecs: items.length > 0,
     lastAnalyzedAt,
+    // True once goals + specs have both hydrated — gate empty/CTA states on
+    // this so "Add goals" / "Analyze" never flash before the first load.
+    ready: goalsFetched && specsFetched,
   };
 }

--- a/apps/web/src/features/goals/use-goals.js
+++ b/apps/web/src/features/goals/use-goals.js
@@ -78,6 +78,10 @@ export function useGoals() {
     total: { l1s: totalL1, l2s: totalL2 },
     weights: { total: weightSum, remaining: Math.max(0, 100 - weightSum) },
     loading: stateSnapshot.loading,
+    // `fetched` flips true once the first load settles (even on an empty
+    // server). Consumers gate their empty state on this so it never
+    // flashes before hydration: `!fetched → loader`.
+    fetched: stateSnapshot.fetched,
     error: stateSnapshot.error,
   };
 }

--- a/apps/web/src/features/snapshots/use-compliance-summary.js
+++ b/apps/web/src/features/snapshots/use-compliance-summary.js
@@ -29,6 +29,7 @@ import { useGoalSpecs, SPEC_KINDS } from "@/features/goal-specs";
 import {
   useAllGoalInputs,
   readInputs,
+  getInputsState,
   computeCompliance,
 } from "@/features/goal-inputs";
 
@@ -124,11 +125,14 @@ function liveStanding(spec, entries, snapshots, goalId) {
 
 export function useComplianceSummary() {
   const { snapshots } = useSnapshots();
-  const { goals } = useGoals();
-  const { specs } = useGoalSpecs();
+  const { goals, fetched: goalsFetched } = useGoals();
+  const { specs, fetched: specsFetched } = useGoalSpecs();
   // Subscribe to the inputs store tick so the summary recomputes when the
   // user logs/ticks anything (and so the one-shot hydration fires).
   const inputsTick = useAllGoalInputs();
+  // `ready` gates the tile's empty state: until goals + specs + inputs have
+  // all hydrated, "0 tracked" would be a hydration artefact, not the truth.
+  const ready = goalsFetched && specsFetched && getInputsState().fetched;
 
   return useMemo(() => {
     const byGoal = readInputs() || {};
@@ -150,8 +154,9 @@ export function useComplianceSummary() {
     return {
       met,
       assessable,
+      ready,
       pct: assessable > 0 ? Math.round((met / assessable) * 100) : null,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [snapshots, goals, specs, inputsTick]);
+  }, [snapshots, goals, specs, inputsTick, ready]);
 }

--- a/apps/web/src/features/snapshots/use-snapshots.js
+++ b/apps/web/src/features/snapshots/use-snapshots.js
@@ -54,7 +54,10 @@ export function useSnapshots() {
     void fetchSnapshots();
   }, [user, sessionLoading]);
 
-  return { snapshots: readSnapshots() };
+  // `fetched` flips true once the first load settles (even with zero
+  // snapshots), so consumers can gate empty-state vs loader.
+  const s = getSnapshotsState();
+  return { snapshots: readSnapshots(), fetched: s.fetched, loading: s.loading };
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@api/nim": "file:.api/apis/nim",
+        "@dot-loaders/core": "^0.1.0",
+        "@dot-loaders/presets": "^0.1.0",
+        "@dot-loaders/react": "^0.1.0",
         "@espace-devhub/api": "*",
         "@espace-devhub/shared": "*",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -154,6 +157,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dot-loaders/core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@dot-loaders/core/-/core-0.1.0.tgz",
+      "integrity": "sha512-0SzDzZ53ax4fLLneSuDaXsAPV+5ORB59ABfIjLzyTOT7GYYCxsBbXUuzieqW1Bm9O3JPWLbWDcBmpWp3D1FN7g==",
+      "license": "MIT"
+    },
+    "node_modules/@dot-loaders/presets": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@dot-loaders/presets/-/presets-0.1.0.tgz",
+      "integrity": "sha512-BqXsqz4TMCeCO8gWBizkvBsHkNHIa/TEuP0OtTNlFIuhREeumPkpA7X7ATsGZ4fXjuLeN342aMciXtk8zldbYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dot-loaders/core": "0.1.0"
+      }
+    },
+    "node_modules/@dot-loaders/react": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@dot-loaders/react/-/react-0.1.0.tgz",
+      "integrity": "sha512-iN3yCRA6Vwf3z2/dsqQiA0PCS4XBsezxJk7RJp87ezSk4VLm1hGQN9Fy2p5rtJr036KzVMCLmwLNDKOZ7/45XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dot-loaders/core": "0.1.0",
+        "@dot-loaders/presets": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@emnapi/core": {


### PR DESCRIPTION
Fixes the project-wide **"loader → empty → data" flash**: API-direct stores start with `data=[]` + `fetched=false`, so any consumer that renders its empty state on `length === 0` paints "no data" on the first frame, before the fetch settles. The fix is to surface `fetched` and show a loader until it flips true — using the **@dot-loaders** library you picked.

## Loader infra
- **`<Loader loader="dna-helix" size color label />`** — wraps `@dot-loaders/react`. Size tokens map to `cellSize`/font-size, `currentColor` theming, idempotent preset registration, `prefers-reduced-motion` respected, and a 3-dot CSS fallback behind an error boundary so a bad id can never crash a surface.
- **`<Loading>`** — centered fill for page/section/panel initial loads (big signature loader + caption).
- **`TileState kind="loading"`** now renders a dot-loader chosen by silhouette — so every tile already gating on a loading flag upgrades for free:

| silhouette | loader |
|---|---|
| stat | pulse |
| list | diagonal-swipe |
| chart | scanline-grid |
| kanban | checkerboard |
| page/section | dna-helix (via `<Loading>`) |

## Hydration flags
`useGoals` / `useGoalSpecs` / `useSnapshots` / `useGoalInputs` now return `fetched`; `useGoalWidgetItems` + `useComplianceSummary` expose `ready`.

## Surfaces gated (this wave)
- **GoalsTile** — no more "Map your L1/L2 goals" flash
- **GoalComplianceTile** — no more "Nothing to track yet" flash
- **GoalTrackingSection** — no more "Add goals" / "Analyze" CTA flash

## Scope note
This is the **foundation + the goal surfaces** (the ones in the reported screenshots). Remaining pages — evidence, snapshots, reviews, users, check-in — follow the identical one-line pattern (`if (!fetched) return <Loading/>`) and are a quick follow-up once the look is confirmed.

## Verification
- `npm run build:web` ✓ (all routes compiled; dot-loaders SSRs fine under turbopack)

## Dependencies
Adds `@dot-loaders/core`, `@dot-loaders/react`, `@dot-loaders/presets` (React ≥18; we're on 19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)