### PR TITLE
feat(perf): section-level helix loaders on the performance page

### DIFF
--- a/apps/web/src/components/ui/loader.jsx
+++ b/apps/web/src/components/ui/loader.jsx
@@ -48,6 +48,7 @@ const SIZES = {
   md: { fontSize: 22, cellSize: 3, gap: 1.5, dot: 6 },
   lg: { fontSize: 32, cellSize: 4, gap: 2, dot: 8 },
   xl: { fontSize: 46, cellSize: 6, gap: 2.5, dot: 10 },
+  "2xl": { fontSize: 66, cellSize: 9, gap: 3, dot: 14 },
 };
 
 /** Pure-CSS fallback: three pulsing dots in currentColor. */

--- a/apps/web/src/features/dashboard/sections/glance-section.jsx
+++ b/apps/web/src/features/dashboard/sections/glance-section.jsx
@@ -3,6 +3,8 @@
 import { Section } from "../scroll-shell";
 import { AttentionBand } from "../attention-band";
 import { TicketsTile, PRsTile } from "../tiles";
+import { Loading } from "@/components/ui";
+import { usePerfSources } from "../use-section-ready";
 
 /**
  * SECTION 03 — At a glance & on your plate
@@ -14,6 +16,7 @@ import { TicketsTile, PRsTile } from "../tiles";
  *     [Tickets (kanban) 7×3] [Open PRs + commits 5×3]
  */
 export function GlanceSection() {
+  const { integrationsReady } = usePerfSources();
   return (
     <Section
       id="sec-glance"
@@ -22,21 +25,32 @@ export function GlanceSection() {
       subtitle="Nudges · tickets · open PRs"
       railLabel="glance"
     >
-      {/* AttentionBand has its own `px-10 pb-5` padding (it pre-dates the
-          section shell). The `-mx-10` wrapper lets the band's inner `px-10`
-          align content back to the section's inner padding edge instead of
-          doubling it. `pb-5` is harmless because the Section's `gap: 18px`
-          dominates. */}
-      <div className="-mx-10">
-        <AttentionBand />
-      </div>
-      <div
-        className="grid min-h-0 flex-1 grid-cols-12 gap-3.5"
-        style={{ gridAutoRows: "minmax(0, 1fr)" }}
-      >
-        <TicketsTile />
-        <PRsTile />
-      </div>
+      {!integrationsReady ? (
+        <Loading
+          loader="helix"
+          size="2xl"
+          color="var(--accent)"
+          label="Loading your plate…"
+        />
+      ) : (
+        <>
+          {/* AttentionBand has its own `px-10 pb-5` padding (it pre-dates the
+              section shell). The `-mx-10` wrapper lets the band's inner `px-10`
+              align content back to the section's inner padding edge instead of
+              doubling it. `pb-5` is harmless because the Section's `gap: 18px`
+              dominates. */}
+          <div className="-mx-10">
+            <AttentionBand />
+          </div>
+          <div
+            className="grid min-h-0 flex-1 grid-cols-12 gap-3.5"
+            style={{ gridAutoRows: "minmax(0, 1fr)" }}
+          >
+            <TicketsTile />
+            <PRsTile />
+          </div>
+        </>
+      )}
     </Section>
   );
 }

--- a/apps/web/src/features/dashboard/sections/overview-section.jsx
+++ b/apps/web/src/features/dashboard/sections/overview-section.jsx
@@ -10,6 +10,8 @@ import {
   LinkageTile,
   SinceLastVisitTile,
 } from "../tiles";
+import { Loading } from "@/components/ui";
+import { usePerfSources } from "../use-section-ready";
 
 /**
  * SECTION 01 — Overview
@@ -23,6 +25,12 @@ import {
  * No `.sec-head` per mock — Hero is the top of the page.
  */
 export function OverviewSection() {
+  // Reveal the whole section at once — one helix over the section until the
+  // goal-compliance data AND the integration metrics behind the four cards
+  // have all settled, so no card flashes its own loading → empty → data.
+  const { integrationsReady, goalsReady } = usePerfSources();
+  const ready = integrationsReady && goalsReady;
+
   return (
     <Section
       id="sec-overview"
@@ -31,6 +39,10 @@ export function OverviewSection() {
       railLabel="overview"
       showHead={false}
     >
+      {!ready ? (
+        <Loading loader="helix" size="2xl" color="var(--accent)" label="Loading overview…" />
+      ) : (
+      <>
       <Hero />
       {/* "Since last visit" — quietly omits when the user has nothing new
           to see (first visit / same-session reload). It's a 1-line strip
@@ -57,6 +69,8 @@ export function OverviewSection() {
         <RoundsTile />
         <LinkageTile />
       </div>
+      </>
+      )}
     </Section>
   );
 }

--- a/apps/web/src/features/dashboard/sections/review-timing-section.jsx
+++ b/apps/web/src/features/dashboard/sections/review-timing-section.jsx
@@ -2,6 +2,8 @@
 
 import { Section } from "../scroll-shell";
 import { ReviewTimingTile } from "../tiles";
+import { Loading } from "@/components/ui";
+import { usePerfSources } from "../use-section-ready";
 
 /**
  * SECTION 02 — Review timing
@@ -24,6 +26,7 @@ import { ReviewTimingTile } from "../tiles";
  * scroll-snap makes it feel like a focused analytical view.
  */
 export function ReviewTimingSection() {
+  const { integrationsReady } = usePerfSources();
   return (
     <Section
       id="sec-review-timing"
@@ -32,12 +35,21 @@ export function ReviewTimingSection() {
       subtitle="TTFR · ATTNR · idle"
       railLabel="reviews"
     >
-      <div
-        className="grid min-h-0 flex-1 grid-cols-12 gap-3.5"
-        style={{ gridAutoRows: "minmax(0, 1fr)" }}
-      >
-        <ReviewTimingTile />
-      </div>
+      {!integrationsReady ? (
+        <Loading
+          loader="helix"
+          size="2xl"
+          color="var(--accent)"
+          label="Loading review timing…"
+        />
+      ) : (
+        <div
+          className="grid min-h-0 flex-1 grid-cols-12 gap-3.5"
+          style={{ gridAutoRows: "minmax(0, 1fr)" }}
+        >
+          <ReviewTimingTile />
+        </div>
+      )}
     </Section>
   );
 }

--- a/apps/web/src/features/dashboard/sections/trend-section.jsx
+++ b/apps/web/src/features/dashboard/sections/trend-section.jsx
@@ -7,6 +7,8 @@ import {
   ReviewsTile,
   TurnaroundTile,
 } from "../tiles";
+import { Loading } from "@/components/ui";
+import { usePerfSources } from "../use-section-ready";
 
 /**
  * SECTION 04 — Trends & breakdowns
@@ -29,6 +31,8 @@ import {
  * "drill-in" view — the only place a wide x-axis really helps.
  */
 export function TrendSection() {
+  const { integrationsReady, snapshotsReady } = usePerfSources();
+  const ready = integrationsReady && snapshotsReady;
   return (
     <Section
       id="sec-trend"
@@ -37,15 +41,24 @@ export function TrendSection() {
       subtitle="Signal over time"
       railLabel="trend"
     >
-      <div
-        className="grid min-h-0 flex-1 grid-cols-12 gap-3.5"
-        style={{ gridAutoRows: "minmax(0, 1fr)" }}
-      >
-        <HeatmapTile />
-        <TurnaroundTile />
-        <ReviewsTile />
-        <ActivityTile />
-      </div>
+      {!ready ? (
+        <Loading
+          loader="helix"
+          size="2xl"
+          color="var(--accent)"
+          label="Loading trends…"
+        />
+      ) : (
+        <div
+          className="grid min-h-0 flex-1 grid-cols-12 gap-3.5"
+          style={{ gridAutoRows: "minmax(0, 1fr)" }}
+        >
+          <HeatmapTile />
+          <TurnaroundTile />
+          <ReviewsTile />
+          <ActivityTile />
+        </div>
+      )}
     </Section>
   );
 }

--- a/apps/web/src/features/dashboard/use-section-ready.js
+++ b/apps/web/src/features/dashboard/use-section-ready.js
@@ -1,0 +1,44 @@
+"use client";
+
+/**
+ * Readiness of the data sources behind the performance-page sections.
+ *
+ * Each section shows ONE big loader until every card it contains has its
+ * data, then reveals all at once (instead of each card flashing its own
+ * loading → empty → data). This hook computes the shared "is that source
+ * loaded yet?" flags; each section ANDs the ones it actually uses.
+ *
+ *   integrationsReady — combined merged PRs + events for the active date
+ *                       range have settled (false only during the FIRST
+ *                       fetch; a disconnected provider is `true` instantly
+ *                       because its SWR key is null → never stuck).
+ *   snapshotsReady    — the snapshot stream has hydrated.
+ *   goalsReady        — goals + specs + inputs have hydrated (the goal
+ *                       compliance tile).
+ *
+ * The combined hooks are called with the SAME `since` the tiles use, so
+ * SWR's dedupe means this shares their in-flight fetch — no extra request.
+ */
+
+import {
+  useCombinedMergedSince,
+  useCombinedEventsSince,
+} from "@/features/integrations";
+import { useSnapshots, useComplianceSummary } from "@/features/snapshots";
+import { useDateRange } from "./date-range";
+
+export function usePerfSources() {
+  const { range } = useDateRange();
+  const since = range?.fetchSince;
+
+  const merged = useCombinedMergedSince(since);
+  const events = useCombinedEventsSince(since);
+  const { fetched: snapshotsReady } = useSnapshots();
+  const { ready: goalsReady } = useComplianceSummary();
+
+  return {
+    integrationsReady: !merged.isLoading && !events.isLoading,
+    snapshotsReady,
+    goalsReady,
+  };
+}


### PR DESCRIPTION
Per request: on the **performance page**, load by **section**, not by card. Each section now shows **one big helix loader** (theme-accent colored, with a caption) over the whole section until *every* card's data has settled, then the section reveals at once — no more four cards each flashing loading → empty → data.

## How
- **`usePerfSources()`** — shared readiness for the sections' data:
  - `integrationsReady` — combined merged PRs + events for the active date range have settled. Calls the combined hooks with the **same `since`** the tiles use, so SWR dedupe shares their in-flight fetch (zero extra requests), and a **disconnected** provider reports ready instantly (null SWR key → never stuck on a loader).
  - `snapshotsReady`, `goalsReady` — store hydration flags.
- **Section gates:**
  - Overview → `goals && integrations` (the 4 cards: compliance + merged + rounds + linkage)
  - Review-timing → `integrations`
  - Glance → `integrations`
  - Trend → `integrations && snapshots`
- **`<Loader>` gains `size="2xl"`** for the section centerpiece; section loaders use `loader="helix"`, `size="2xl"`, `color="var(--accent)"` — bigger, with text under it, following the theme color.

## Result
The Overview section (and every other perf section) holds a single big helix until its data is in, then the whole section appears together.

## Verification
- `npm run build:web` ✓

## Note
This is scoped to the **performance page** sections, as asked. The goals-tab surfaces keep their per-tile loaders from #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)