### PR TITLE
fix(perf): gate each section on its tiles' actual data hooks

### DIFF
--- a/apps/web/src/features/dashboard/sections/glance-section.jsx
+++ b/apps/web/src/features/dashboard/sections/glance-section.jsx
@@ -4,7 +4,7 @@ import { Section } from "../scroll-shell";
 import { AttentionBand } from "../attention-band";
 import { TicketsTile, PRsTile } from "../tiles";
 import { Loading } from "@/components/ui";
-import { usePerfSources } from "../use-section-ready";
+import { useGlanceReady } from "../use-section-ready";
 
 /**
  * SECTION 03 — At a glance & on your plate
@@ -16,7 +16,7 @@ import { usePerfSources } from "../use-section-ready";
  *     [Tickets (kanban) 7×3] [Open PRs + commits 5×3]
  */
 export function GlanceSection() {
-  const { integrationsReady } = usePerfSources();
+  const ready = useGlanceReady();
   return (
     <Section
       id="sec-glance"

--- a/apps/web/src/features/dashboard/sections/overview-section.jsx
+++ b/apps/web/src/features/dashboard/sections/overview-section.jsx
@@ -11,7 +11,7 @@ import {
   SinceLastVisitTile,
 } from "../tiles";
 import { Loading } from "@/components/ui";
-import { usePerfSources } from "../use-section-ready";
+import { useOverviewReady } from "../use-section-ready";
 
 /**
  * SECTION 01 — Overview
@@ -28,8 +28,7 @@ export function OverviewSection() {
   // Reveal the whole section at once — one helix over the section until the
   // goal-compliance data AND the integration metrics behind the four cards
   // have all settled, so no card flashes its own loading → empty → data.
-  const { integrationsReady, goalsReady } = usePerfSources();
-  const ready = integrationsReady && goalsReady;
+  const ready = useOverviewReady();
 
   return (
     <Section

--- a/apps/web/src/features/dashboard/sections/review-timing-section.jsx
+++ b/apps/web/src/features/dashboard/sections/review-timing-section.jsx
@@ -3,7 +3,7 @@
 import { Section } from "../scroll-shell";
 import { ReviewTimingTile } from "../tiles";
 import { Loading } from "@/components/ui";
-import { usePerfSources } from "../use-section-ready";
+import { useReviewTimingReady } from "../use-section-ready";
 
 /**
  * SECTION 02 — Review timing
@@ -26,7 +26,7 @@ import { usePerfSources } from "../use-section-ready";
  * scroll-snap makes it feel like a focused analytical view.
  */
 export function ReviewTimingSection() {
-  const { integrationsReady } = usePerfSources();
+  const ready = useReviewTimingReady();
   return (
     <Section
       id="sec-review-timing"
@@ -35,7 +35,7 @@ export function ReviewTimingSection() {
       subtitle="TTFR · ATTNR · idle"
       railLabel="reviews"
     >
-      {!integrationsReady ? (
+      {!ready ? (
         <Loading
           loader="helix"
           size="2xl"

--- a/apps/web/src/features/dashboard/sections/trend-section.jsx
+++ b/apps/web/src/features/dashboard/sections/trend-section.jsx
@@ -8,7 +8,7 @@ import {
   TurnaroundTile,
 } from "../tiles";
 import { Loading } from "@/components/ui";
-import { usePerfSources } from "../use-section-ready";
+import { useTrendReady } from "../use-section-ready";
 
 /**
  * SECTION 04 — Trends & breakdowns
@@ -31,8 +31,7 @@ import { usePerfSources } from "../use-section-ready";
  * "drill-in" view — the only place a wide x-axis really helps.
  */
 export function TrendSection() {
-  const { integrationsReady, snapshotsReady } = usePerfSources();
-  const ready = integrationsReady && snapshotsReady;
+  const ready = useTrendReady();
   return (
     <Section
       id="sec-trend"

--- a/apps/web/src/features/dashboard/use-section-ready.js
+++ b/apps/web/src/features/dashboard/use-section-ready.js
@@ -1,44 +1,61 @@
 "use client";
 
 /**
- * Readiness of the data sources behind the performance-page sections.
+ * Per-section readiness for the performance page. Each section shows one
+ * big loader until EVERY card it contains has its data, then reveals at
+ * once — so no card flashes its own loading → empty → data.
  *
- * Each section shows ONE big loader until every card it contains has its
- * data, then reveals all at once (instead of each card flashing its own
- * loading → empty → data). This hook computes the shared "is that source
- * loaded yet?" flags; each section ANDs the ones it actually uses.
- *
- *   integrationsReady — combined merged PRs + events for the active date
- *                       range have settled (false only during the FIRST
- *                       fetch; a disconnected provider is `true` instantly
- *                       because its SWR key is null → never stuck).
- *   snapshotsReady    — the snapshot stream has hydrated.
- *   goalsReady        — goals + specs + inputs have hydrated (the goal
- *                       compliance tile).
- *
- * The combined hooks are called with the SAME `since` the tiles use, so
- * SWR's dedupe means this shares their in-flight fetch — no extra request.
+ * Each hook gates on the EXACT data hooks that section's tiles call (same
+ * args → SWR dedupe shares the tiles' in-flight fetch; no extra request).
+ * Gating on the wrong hook is what made a section reveal early — e.g. the
+ * review-timing tile does per-PR fetching AFTER the merged list, so it
+ * must gate on `usePrReviewTimings`, not raw merged. A disconnected
+ * provider reports ready instantly (its SWR key is null), so a user with
+ * no integrations never sits on a stuck loader.
  */
 
 import {
   useCombinedMergedSince,
   useCombinedEventsSince,
+  usePrReviewTimings,
+  useJiraTickets,
+  useGitlabOpenMRs,
+  useGitlabReviewRequests,
+  useGithubOpenPulls,
+  useGithubReviewRequests,
 } from "@/features/integrations";
-import { useSnapshots, useComplianceSummary } from "@/features/snapshots";
+import { useComplianceSummary } from "@/features/snapshots";
 import { useDateRange } from "./date-range";
 
-export function usePerfSources() {
+/** Overview — goal compliance + merged-PR metrics (merged / rounds / linkage). */
+export function useOverviewReady() {
   const { range } = useDateRange();
-  const since = range?.fetchSince;
-
-  const merged = useCombinedMergedSince(since);
-  const events = useCombinedEventsSince(since);
-  const { fetched: snapshotsReady } = useSnapshots();
   const { ready: goalsReady } = useComplianceSummary();
+  const { isLoading: merged } = useCombinedMergedSince(range?.fetchSince);
+  return goalsReady && !merged;
+}
 
-  return {
-    integrationsReady: !merged.isLoading && !events.isLoading,
-    snapshotsReady,
-    goalsReady,
-  };
+/** Review timing — the dedicated per-PR review-timing fetch. */
+export function useReviewTimingReady() {
+  const { range } = useDateRange();
+  const { isLoading } = usePrReviewTimings(range?.fetchSince);
+  return !isLoading;
+}
+
+/** Glance — Jira tickets + open PRs/MRs + review requests. */
+export function useGlanceReady() {
+  const { isLoading: tickets } = useJiraTickets();
+  const { isLoading: glOpen } = useGitlabOpenMRs();
+  const { isLoading: ghOpen } = useGithubOpenPulls();
+  const { isLoading: glReq } = useGitlabReviewRequests();
+  const { isLoading: ghReq } = useGithubReviewRequests();
+  return !tickets && !glOpen && !ghOpen && !glReq && !ghReq;
+}
+
+/** Trends — merged-PR + event metrics (heatmap/activity/reviews=events, turnaround=merged). */
+export function useTrendReady() {
+  const { range } = useDateRange();
+  const { isLoading: merged } = useCombinedMergedSince(range?.fetchSince);
+  const { isLoading: events } = useCombinedEventsSince(range?.fetchSince);
+  return !merged && !events;
 }


### PR DESCRIPTION
## Bug
The section helix revealed **before** the cards finished — Review timing showed "● Loading review timings…", `0/0 PRs reviewed`, and `•••` placeholders *under a revealed section*.

## Cause
The shared `usePerfSources` gate guessed **combined merged + events**, but each section's tiles use *different* hooks. Review timing's `ReviewTimingTile` uses **`usePrReviewTimings`**, which does **per-PR fetching AFTER** the merged list resolves — so `merged` was "done" while the tile was still fetching each PR's review timeline. Gating on too-few / wrong hooks reveals early.

## Fix
Per-section readiness hooks that call the **exact** hooks each section's tiles call (same args → SWR dedupe shares the in-flight fetch, no extra request):

| Section | Gated on |
|---|---|
| Overview | goal compliance + `useCombinedMergedSince` |
| Review timing | `usePrReviewTimings` ← the fix |
| Glance | `useJiraTickets` + open MRs/PRs + review requests |
| Trends | `useCombinedMergedSince` + `useCombinedEventsSince` |

A disconnected provider still reports ready instantly (null SWR key) → no stuck loader.

## Verification
- `npm run build:web` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)