### PR TITLE
fix(perf): Glance crash — stale integrationsReady reference

### DIFF
--- a/apps/web/src/features/dashboard/sections/glance-section.jsx
+++ b/apps/web/src/features/dashboard/sections/glance-section.jsx
@@ -25,7 +25,7 @@ export function GlanceSection() {
       subtitle="Nudges · tickets · open PRs"
       railLabel="glance"
     >
-      {!integrationsReady ? (
+      {!ready ? (
         <Loading
           loader="helix"
           size="2xl"


### PR DESCRIPTION
Hotfix: the section-ready refactor (#163) renamed the Glance gate to `ready` (useGlanceReady) but left the JSX as `!integrationsReady` → **"ReferenceError: integrationsReady is not defined"** crashing the performance page. Not caught at build (Next 16 has no lint/no-undef). Gate now reads `ready`.

Verified: `npm run build:web` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)