### PR TITLE
Point companion release publishing at eSpace-Hubs, not eSpaceDev

### DIFF
--- a/apps/desktop/DISTRIBUTING.md
+++ b/apps/desktop/DISTRIBUTING.md
@@ -33,7 +33,7 @@ notification once it's ready.
 
 ## Secrets — what to set and where
 
-Settings → Secrets and variables → Actions, on the `nova-sudo/eSpaceDev`
+Settings → Secrets and variables → Actions, on the `nova-sudo/eSpace-Hubs`
 repo. All optional — without them the build still completes, just
 unsigned/un-notarized.
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -14,7 +14,11 @@
 #
 # That triggers .github/workflows/release-desktop.yml which builds on
 # every platform, signs (if certs available via secrets), and publishes
-# to https://github.com/nova-sudo/eSpaceDev/releases.
+# to https://github.com/nova-sudo/eSpace-Hubs/releases. Publishing to
+# this repo (rather than a separate one) matters: the workflow
+# authenticates with the default GITHUB_TOKEN, which GitHub Actions
+# only scopes to the repo the workflow runs in — publishing anywhere
+# else needs a real cross-repo PAT secret instead.
 #
 # Signing precedence (all OPTIONAL — unsigned build is the fallback):
 #   - Windows: env CSC_LINK + CSC_KEY_PASSWORD point at an Authenticode
@@ -55,7 +59,7 @@ files:
 publish:
   provider: github
   owner: nova-sudo
-  repo: eSpaceDev
+  repo: eSpace-Hubs
   # `releaseType: release` would auto-promote the draft on publish.
   # We keep `draft` so a human flips the toggle to "Published" once
   # they've smoke-tested the artifacts on each OS.

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -715,7 +715,7 @@ export function App() {
           onClick={(e) => {
             e.preventDefault();
             void companion.shell.openExternal(
-              "https://github.com/nova-sudo/eSpaceDev/blob/main/docs/RUN_LOCALLY.md",
+              "https://github.com/nova-sudo/eSpace-Hubs/blob/main/docs/RUN_LOCALLY.md",
             );
           }}
         >

--- a/apps/web/src/features/companion/companion-setup-guide.jsx
+++ b/apps/web/src/features/companion/companion-setup-guide.jsx
@@ -51,7 +51,7 @@ export function CompanionSetupGuide() {
               forwards requests through a Cloudflare Tunnel.
             </p>
             <a
-              href="https://github.com/nova-sudo/eSpaceDev/releases/latest"
+              href="https://github.com/nova-sudo/eSpace-Hubs/releases/latest"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-[var(--radius-sub)] px-3.5 py-2 text-[11px] font-normal uppercase tracking-[0.8px] transition-opacity hover:opacity-90"
@@ -73,7 +73,7 @@ export function CompanionSetupGuide() {
             >
               macOS/Linux builds are on the same{" "}
               <a
-                href="https://github.com/nova-sudo/eSpaceDev/releases/latest"
+                href="https://github.com/nova-sudo/eSpace-Hubs/releases/latest"
                 target="_blank"
                 rel="noopener noreferrer"
                 style={{ color: "var(--accent)" }}


### PR DESCRIPTION
## Summary

Follow-up to #204/#205. The new "Download for Windows" button in `CompanionSetupGuide` currently 404s — dug into why:

- `apps/desktop/electron-builder.yml` was configured to publish releases to `nova-sudo/eSpaceDev`, a repo separate from the one `release-desktop.yml` actually runs in (`nova-sudo/eSpace-Hubs`).
- `release-desktop.yml` authenticates with `secrets.GITHUB_TOKEN`, which GitHub Actions scopes only to the repo the workflow runs in. It has no write access to a different repo, so a cross-repo publish would fail even if someone cut a release — and per `apps/desktop/DISTRIBUTING.md`, cutting one is a manual `git tag desktop-v<version> && git push --follow-tags` step that's never actually been run.
- Repointing `electron-builder.yml`'s publish target at `eSpace-Hubs` means the existing default token is sufficient — no new PAT/secret needed.

Also fixes:
- The two download links in `CompanionSetupGuide` (Step 1), now pointing at `nova-sudo/eSpace-Hubs/releases/latest`.
- The companion app's "Setup guide" external link in `App.tsx`, which pointed at `eSpaceDev/blob/main/docs/RUN_LOCALLY.md` even though that doc lives in this repo.
- `DISTRIBUTING.md`'s reference to where release secrets get configured.

Left untouched: the `eSpaceDev` references in `docs/RUN_LOCALLY.md` and the `scripts/seed-jira*` scripts — those refer to an unrelated mock upstream repo used for local Jira/PR demo data, not the companion's release channel.

## Test plan

- [x] `tsc --noEmit` passes for `apps/desktop` renderer
- [x] Companion setup guide syntax-checked with esbuild
- [ ] Cut an actual `desktop-v*` tag and confirm `release-desktop.yml` successfully publishes a draft release to this repo (I can't do this myself — no write access to push tags/trigger releases beyond this PR, and it also requires a human to smoke-test + publish the draft per `DISTRIBUTING.md`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01G7gi61PAf8cmXtcAu4xs2s)_