### PR TITLE
Route Claude through the LiteLLM gateway instead of Bedrock

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -38,28 +38,44 @@ AI_PROVIDER=anthropic
 # you actually use; the API surfaces a clear 500 with the missing
 # env-var name when an unconfigured provider is requested.
 
-# Claude — native @anthropic-ai/* SDK path (NOT OpenAI-compatible). Two
-# backends, switched by ANTHROPIC_BEDROCK:
+# Claude — native @anthropic-ai/* SDK path (NOT OpenAI-compatible). Three
+# backends, switched by ANTHROPIC_BACKEND:
 #
-#   ANTHROPIC_BEDROCK unset/0  → DIRECT Anthropic API. Needs ANTHROPIC_API_KEY.
-#   ANTHROPIC_BEDROCK=1        → Amazon Bedrock. Needs AWS creds (below) and a
-#                               Bedrock model id in ANTHROPIC_MODEL.
-ANTHROPIC_BEDROCK=1
+#   litellm (default) → eSpace's LiteLLM gateway. Needs LITELLM_API_KEY.
+#   bedrock           → LEGACY direct Amazon Bedrock. Needs AWS creds (below)
+#                       and a Bedrock model id in ANTHROPIC_MODEL. Direct
+#                       Bedrock access is being switched off — use litellm.
+#   direct            → api.anthropic.com. Needs ANTHROPIC_API_KEY.
+ANTHROPIC_BACKEND=litellm
 
-# Direct API key (only used when ANTHROPIC_BEDROCK is unset/0):
+# ── LiteLLM gateway (ANTHROPIC_BACKEND=litellm)
+# The gateway speaks Anthropic's own /v1/messages API and holds the AWS
+# credentials on our behalf, so nothing here talks to Bedrock directly.
+# Your personal virtual key comes from the LiteLLM UI (Virtual Keys page)
+# and starts with `sk-`. Server-side only — never expose it to the browser.
+LITELLM_API_KEY=
+# Gateway origin. Note: NO trailing /v1 — the SDK appends /v1/messages.
+LITELLM_BASE_URL=https://litellm.espace.ws
+# Optional model override, same meaning as ANTHROPIC_MODEL (which wins if
+# both are set). Use the exact model name from the LiteLLM UI Models page.
+# LITELLM_MODEL=
+
+# ── Direct Anthropic API (ANTHROPIC_BACKEND=direct)
 ANTHROPIC_API_KEY=
 
-# AWS credentials for Bedrock (standard SDK chain — or use an IAM role and
-# leave these blank). Region defaults to us-east-1 when unset.
+# ── Amazon Bedrock, legacy (ANTHROPIC_BACKEND=bedrock)
+# Standard AWS SDK credential chain — or use an IAM role and leave these
+# blank. Region defaults to us-east-1 when unset.
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 # AWS_SESSION_TOKEN=   # only for temporary STS credentials
 
-# Model id. Default sonnet-4-6 (direct: claude-sonnet-4-6; Bedrock:
-# anthropic.claude-sonnet-4-6). On Bedrock SET THIS to your account's exact
-# id / inference-profile (often region-prefixed, e.g. us.anthropic.claude-
-# sonnet-4-6-...:0) — look it up in the Bedrock console.
+# Model id — backend-specific, defaults to sonnet-4-6 in each backend's own
+# naming (litellm/direct: claude-sonnet-4-6; bedrock: anthropic.claude-
+# sonnet-4-6). On LiteLLM set this to the exact name listed on the gateway's
+# Models page; on Bedrock to your account's inference-profile id (often
+# region-prefixed, e.g. us.anthropic.claude-sonnet-4-6-...:0).
 ANTHROPIC_MODEL=
 
 MISTRAL_API_KEY=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -58,7 +58,8 @@ LITELLM_API_KEY=
 LITELLM_BASE_URL=https://litellm.espace.ws
 # Optional model override, same meaning as ANTHROPIC_MODEL (which wins if
 # both are set). Use the exact model name from the LiteLLM UI Models page.
-# LITELLM_MODEL=
+# Defaults to claude-sonnet-5, the alias the eSpace gateway publishes.
+# LITELLM_MODEL=claude-sonnet-5
 
 # ── Direct Anthropic API (ANTHROPIC_BACKEND=direct)
 ANTHROPIC_API_KEY=
@@ -71,11 +72,12 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 # AWS_SESSION_TOKEN=   # only for temporary STS credentials
 
-# Model id — backend-specific, defaults to sonnet-4-6 in each backend's own
-# naming (litellm/direct: claude-sonnet-4-6; bedrock: anthropic.claude-
-# sonnet-4-6). On LiteLLM set this to the exact name listed on the gateway's
-# Models page; on Bedrock to your account's inference-profile id (often
-# region-prefixed, e.g. us.anthropic.claude-sonnet-4-6-...:0).
+# Model id — backend-specific, and each backend already has a working
+# default (litellm: claude-sonnet-5; direct: claude-sonnet-4-6; bedrock:
+# anthropic.claude-sonnet-4-6). Leave blank unless you want to pin
+# something else: on LiteLLM the exact name listed on the gateway's Models
+# page, on Bedrock your account's inference-profile id (often region-
+# prefixed, e.g. us.anthropic.claude-sonnet-4-6-...:0).
 ANTHROPIC_MODEL=
 
 MISTRAL_API_KEY=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "dev": "tsx watch --clear-screen=false src/server.ts",
     "build": "tsc -p tsconfig.build.json",
-    "test": "tsx --test src/modules/ai/extract/extract.test.ts src/modules/ai/compose-guards.test.ts src/modules/integrations/query-runner.test.ts src/modules/integrations/query-routes.test.ts",
+    "test": "tsx --test src/modules/ai/extract/extract.test.ts src/modules/ai/compose-guards.test.ts src/modules/ai/anthropic-backend.test.ts src/modules/integrations/query-runner.test.ts src/modules/integrations/query-routes.test.ts",
     "start": "node dist/server.js",
     "typecheck": "tsc -p tsconfig.json",
     "admin:create": "tsx scripts/admin-create.ts",

--- a/apps/api/src/modules/ai/anthropic-backend.test.ts
+++ b/apps/api/src/modules/ai/anthropic-backend.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Backend resolution for the Claude provider. The interesting cases are all
+ * about the LiteLLM migration: the gateway is the default, but environments
+ * that still carry the old ANTHROPIC_BEDROCK flag or a bare direct key must
+ * keep resolving the way they did before they were migrated.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+// anthropic.ts reaches the shared error handler, which pulls in the env
+// schema and aborts the process when the service-level vars are missing.
+// Nothing under test touches them, so satisfy the schema with placeholders
+// and import dynamically, after they are set.
+process.env.MONGO_URI ??= "mongodb://localhost:27017";
+process.env.SESSION_SECRET ??= "test-session-secret-0000000000000000";
+process.env.INTEGRATION_TOKEN_KEY ??= "test-integration-key-000000000000000";
+
+const { anthropicBackend, anthropicModel } = await import("./anthropic.js");
+
+const KEYS = [
+  "ANTHROPIC_BACKEND",
+  "ANTHROPIC_BEDROCK",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_MODEL",
+  "LITELLM_API_KEY",
+  "LITELLM_MODEL",
+] as const;
+
+/** Run `fn` with exactly `env` set on the relevant keys, then restore. */
+function withEnv(env: Partial<Record<(typeof KEYS)[number], string>>, fn: () => void) {
+  const saved = new Map(KEYS.map((k) => [k, process.env[k]]));
+  for (const k of KEYS) delete process.env[k];
+  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+  try {
+    fn();
+  } finally {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+test("defaults to the LiteLLM gateway", () => {
+  withEnv({}, () => assert.equal(anthropicBackend(), "litellm"));
+  withEnv({ LITELLM_API_KEY: "sk-x" }, () =>
+    assert.equal(anthropicBackend(), "litellm"),
+  );
+});
+
+test("ANTHROPIC_BACKEND wins over every fallback", () => {
+  withEnv({ ANTHROPIC_BACKEND: "direct", LITELLM_API_KEY: "sk-x" }, () =>
+    assert.equal(anthropicBackend(), "direct"),
+  );
+  withEnv({ ANTHROPIC_BACKEND: " LiteLLM ", ANTHROPIC_BEDROCK: "1" }, () =>
+    assert.equal(anthropicBackend(), "litellm"),
+  );
+  withEnv({ ANTHROPIC_BACKEND: "bedrock" }, () =>
+    assert.equal(anthropicBackend(), "bedrock"),
+  );
+});
+
+test("an unrecognised ANTHROPIC_BACKEND falls through, it does not throw", () => {
+  withEnv({ ANTHROPIC_BACKEND: "sagemaker" }, () =>
+    assert.equal(anthropicBackend(), "litellm"),
+  );
+});
+
+test("legacy ANTHROPIC_BEDROCK=1 still selects bedrock", () => {
+  for (const v of ["1", "true", "YES"]) {
+    withEnv({ ANTHROPIC_BEDROCK: v }, () =>
+      assert.equal(anthropicBackend(), "bedrock"),
+    );
+  }
+  withEnv({ ANTHROPIC_BEDROCK: "0" }, () =>
+    assert.equal(anthropicBackend(), "litellm"),
+  );
+});
+
+test("a lone direct key keeps an unmigrated env on api.anthropic.com", () => {
+  withEnv({ ANTHROPIC_API_KEY: "sk-ant-x" }, () =>
+    assert.equal(anthropicBackend(), "direct"),
+  );
+  // …but once a gateway key is present, the gateway wins.
+  withEnv({ ANTHROPIC_API_KEY: "sk-ant-x", LITELLM_API_KEY: "sk-x" }, () =>
+    assert.equal(anthropicBackend(), "litellm"),
+  );
+});
+
+test("model id follows the backend, and ANTHROPIC_MODEL always wins", () => {
+  withEnv({}, () => assert.equal(anthropicModel(), "claude-sonnet-4-6"));
+  withEnv({ ANTHROPIC_BEDROCK: "1" }, () =>
+    assert.equal(anthropicModel(), "anthropic.claude-sonnet-4-6"),
+  );
+  withEnv({ LITELLM_MODEL: "bedrock-sonnet" }, () =>
+    assert.equal(anthropicModel(), "bedrock-sonnet"),
+  );
+  withEnv({ LITELLM_MODEL: "bedrock-sonnet", ANTHROPIC_MODEL: "pinned" }, () =>
+    assert.equal(anthropicModel(), "pinned"),
+  );
+});

--- a/apps/api/src/modules/ai/anthropic-backend.test.ts
+++ b/apps/api/src/modules/ai/anthropic-backend.test.ts
@@ -89,14 +89,18 @@ test("a lone direct key keeps an unmigrated env on api.anthropic.com", () => {
 });
 
 test("model id follows the backend, and ANTHROPIC_MODEL always wins", () => {
-  withEnv({}, () => assert.equal(anthropicModel(), "claude-sonnet-4-6"));
+  // Gateway default is the alias LiteLLM publishes, not an Anthropic id.
+  withEnv({}, () => assert.equal(anthropicModel(), "claude-sonnet-5"));
+  withEnv({ ANTHROPIC_BACKEND: "direct" }, () =>
+    assert.equal(anthropicModel(), "claude-sonnet-4-6"),
+  );
   withEnv({ ANTHROPIC_BEDROCK: "1" }, () =>
     assert.equal(anthropicModel(), "anthropic.claude-sonnet-4-6"),
   );
-  withEnv({ LITELLM_MODEL: "bedrock-sonnet" }, () =>
-    assert.equal(anthropicModel(), "bedrock-sonnet"),
+  withEnv({ LITELLM_MODEL: "claude-opus-5" }, () =>
+    assert.equal(anthropicModel(), "claude-opus-5"),
   );
-  withEnv({ LITELLM_MODEL: "bedrock-sonnet", ANTHROPIC_MODEL: "pinned" }, () =>
+  withEnv({ LITELLM_MODEL: "claude-opus-5", ANTHROPIC_MODEL: "pinned" }, () =>
     assert.equal(anthropicModel(), "pinned"),
   );
 });

--- a/apps/api/src/modules/ai/anthropic.ts
+++ b/apps/api/src/modules/ai/anthropic.ts
@@ -88,16 +88,17 @@ function litellmBaseUrl(): string {
 }
 
 /**
- * Default model — Sonnet 4.6, strong + cost-sane (classification + grading
- * run one call per goal / per PR). Override via ANTHROPIC_MODEL.
+ * Default model — Sonnet, strong + cost-sane (classification + grading run
+ * one call per goal / per PR). Override via ANTHROPIC_MODEL.
  *
- * The id is backend-specific and the defaults below are only a starting
- * point:
- *   litellm  the model NAME as configured on the gateway — check the
- *            Models page in the LiteLLM UI and set ANTHROPIC_MODEL (or
- *            LITELLM_MODEL) to the exact string listed there.
+ * The id is backend-specific, so each backend carries its own default:
+ *   litellm  the model NAME as configured on the gateway, NOT an Anthropic
+ *            or Bedrock id. `claude-sonnet-5` is the alias eSpace's gateway
+ *            publishes; if the Models page in the LiteLLM UI ever lists
+ *            something else, set ANTHROPIC_MODEL (or LITELLM_MODEL).
  *   bedrock  region-/inference-profile-specific, carrying an `anthropic.`
- *            (often `us.anthropic.…:0`) prefix.
+ *            (often `us.anthropic.…:0`) prefix — best-effort only, set
+ *            ANTHROPIC_MODEL to your account's exact id.
  */
 export function anthropicModel(): string {
   if (process.env.ANTHROPIC_MODEL) return process.env.ANTHROPIC_MODEL;
@@ -105,7 +106,7 @@ export function anthropicModel(): string {
     case "bedrock":
       return "anthropic.claude-sonnet-4-6";
     case "litellm":
-      return process.env.LITELLM_MODEL || "claude-sonnet-4-6";
+      return process.env.LITELLM_MODEL || "claude-sonnet-5";
     default:
       return "claude-sonnet-4-6";
   }

--- a/apps/api/src/modules/ai/anthropic.ts
+++ b/apps/api/src/modules/ai/anthropic.ts
@@ -7,8 +7,11 @@
  * when the requested provider id is "anthropic".
  *
  * Config:
- *   ANTHROPIC_API_KEY   server-side key (required)
- *   ANTHROPIC_MODEL     optional model override (default: claude-opus-4-8)
+ *   ANTHROPIC_BACKEND   litellm (default) | bedrock | direct
+ *   LITELLM_API_KEY     virtual key for the LiteLLM gateway
+ *   LITELLM_BASE_URL    gateway origin (default: https://litellm.espace.ws)
+ *   ANTHROPIC_API_KEY   server-side key — direct backend only
+ *   ANTHROPIC_MODEL     optional model override
  *
  * System prompts go in the top-level `system` param (Claude separates them
  * from the user/assistant turn list); we never put a system role inside
@@ -36,28 +39,76 @@ export function isAnthropicId(id: string): boolean {
 }
 
 /**
- * Backend: Amazon Bedrock (AWS-managed Claude, AWS creds) vs the direct
- * Anthropic API (a single ANTHROPIC_API_KEY). Toggle with ANTHROPIC_BEDROCK.
- * Both speak the identical `messages.create` API — only the client and the
+ * Which backend serves Claude. All three speak the identical
+ * `messages.create` API — only the client, the credentials and the
  * model-id format differ.
+ *
+ *   litellm  eSpace's LiteLLM gateway. One virtual key, and the gateway
+ *            holds the AWS credentials. This is the supported path to
+ *            Bedrock — direct Bedrock access is being switched off.
+ *   bedrock  LEGACY. Talks to Amazon Bedrock directly with AWS creds.
+ *   direct   api.anthropic.com with an ANTHROPIC_API_KEY.
+ *
+ * Selected by ANTHROPIC_BACKEND. When that is unset we honour the older
+ * ANTHROPIC_BEDROCK flag so environments mid-migration keep working, then
+ * fall back to whichever credential is actually present.
  */
-function useBedrock(): boolean {
-  const v = (process.env.ANTHROPIC_BEDROCK || "").trim().toLowerCase();
-  return v === "1" || v === "true" || v === "yes";
+export type AnthropicBackend = "litellm" | "bedrock" | "direct";
+
+const LITELLM_DEFAULT_BASE_URL = "https://litellm.espace.ws";
+
+export function anthropicBackend(): AnthropicBackend {
+  const explicit = (process.env.ANTHROPIC_BACKEND || "").trim().toLowerCase();
+  if (explicit === "litellm" || explicit === "bedrock" || explicit === "direct") {
+    return explicit;
+  }
+
+  const legacyBedrock = (process.env.ANTHROPIC_BEDROCK || "").trim().toLowerCase();
+  if (legacyBedrock === "1" || legacyBedrock === "true" || legacyBedrock === "yes") {
+    return "bedrock";
+  }
+
+  // No explicit choice: a direct key with no gateway key means this env
+  // predates the migration and should keep talking to api.anthropic.com.
+  if (process.env.ANTHROPIC_API_KEY && !process.env.LITELLM_API_KEY) {
+    return "direct";
+  }
+  return "litellm";
+}
+
+/**
+ * Gateway origin. The Anthropic SDK appends `/v1/messages` itself, but the
+ * LiteLLM UI displays the OpenAI-style `…/v1` base URL, so a pasted value
+ * with `/v1` on the end is the likely mistake — trim it rather than issue
+ * every request against `/v1/v1/messages`.
+ */
+function litellmBaseUrl(): string {
+  const raw = (process.env.LITELLM_BASE_URL || LITELLM_DEFAULT_BASE_URL).trim();
+  return raw.replace(/\/+$/, "").replace(/\/v1$/, "");
 }
 
 /**
  * Default model — Sonnet 4.6, strong + cost-sane (classification + grading
  * run one call per goal / per PR). Override via ANTHROPIC_MODEL.
  *
- * Bedrock model ids are region-/inference-profile-specific and carry an
- * `anthropic.` (often `us.anthropic.…:0`) prefix, so on Bedrock you should
- * set ANTHROPIC_MODEL to YOUR account's exact id. The default below is a
- * best-effort starting point.
+ * The id is backend-specific and the defaults below are only a starting
+ * point:
+ *   litellm  the model NAME as configured on the gateway — check the
+ *            Models page in the LiteLLM UI and set ANTHROPIC_MODEL (or
+ *            LITELLM_MODEL) to the exact string listed there.
+ *   bedrock  region-/inference-profile-specific, carrying an `anthropic.`
+ *            (often `us.anthropic.…:0`) prefix.
  */
 export function anthropicModel(): string {
   if (process.env.ANTHROPIC_MODEL) return process.env.ANTHROPIC_MODEL;
-  return useBedrock() ? "anthropic.claude-sonnet-4-6" : "claude-sonnet-4-6";
+  switch (anthropicBackend()) {
+    case "bedrock":
+      return "anthropic.claude-sonnet-4-6";
+    case "litellm":
+      return process.env.LITELLM_MODEL || "claude-sonnet-4-6";
+    default:
+      return "claude-sonnet-4-6";
+  }
 }
 
 type AnyClient = Anthropic | AnthropicBedrock;
@@ -65,7 +116,30 @@ let client: AnyClient | null = null;
 
 function getClient(): AnyClient {
   if (client) return client;
-  if (useBedrock()) {
+  const backend = anthropicBackend();
+
+  if (backend === "litellm") {
+    const key = process.env.LITELLM_API_KEY;
+    if (!key) {
+      throw new HttpError(
+        500,
+        "ai_provider_unconfigured",
+        "Claude has no credentials. Set LITELLM_API_KEY to your LiteLLM virtual key in the API env and restart.",
+      );
+    }
+    // LiteLLM exposes Anthropic's own /v1/messages surface, so the stock
+    // SDK works unchanged against it — only the base URL and the key
+    // change. The SDK sends the key as `x-api-key`; the Bearer header is
+    // added because gateway deployments may read either one.
+    client = new Anthropic({
+      baseURL: litellmBaseUrl(),
+      apiKey: key,
+      defaultHeaders: { Authorization: `Bearer ${key}` },
+    });
+    return client;
+  }
+
+  if (backend === "bedrock") {
     // AnthropicBedrock resolves AWS creds from the standard chain
     // (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN, or an
     // IAM role). Region defaults to us-east-1 if AWS_REGION is unset.
@@ -74,12 +148,13 @@ function getClient(): AnyClient {
     );
     return client;
   }
+
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     throw new HttpError(
       500,
       "ai_provider_unconfigured",
-      "Claude has no credentials. Set ANTHROPIC_API_KEY, or enable Bedrock with ANTHROPIC_BEDROCK=1 + AWS creds, in the API env and restart.",
+      "Claude has no credentials. Set ANTHROPIC_API_KEY, or point at the LiteLLM gateway with ANTHROPIC_BACKEND=litellm + LITELLM_API_KEY, in the API env and restart.",
     );
   }
   client = new Anthropic({ apiKey });

--- a/apps/web/src/features/analyst/use-ai-provider.js
+++ b/apps/web/src/features/analyst/use-ai-provider.js
@@ -30,7 +30,9 @@ import {
 const DEFAULT_PROVIDER = "mistral";
 
 export const AI_PROVIDERS = Object.freeze([
-  { id: "anthropic", label: "Claude (Anthropic)", env: "ANTHROPIC_API_KEY" },
+  // Claude is served through the eSpace LiteLLM gateway, so the key the
+  // API needs is the virtual key — not an api.anthropic.com key.
+  { id: "anthropic", label: "Claude (Anthropic)", env: "LITELLM_API_KEY" },
   { id: "mistral", label: "Mistral", env: "MISTRAL_API_KEY" },
   { id: "glm", label: "GLM (Z.ai)", env: "GLM_API_KEY" },
   { id: "openrouter", label: "OpenRouter", env: "OPENROUTER_API_KEY" },

--- a/docs/deployment-coolify.md
+++ b/docs/deployment-coolify.md
@@ -78,7 +78,7 @@ Two application containers + one database, all in **one Coolify project**:
 | `SESSION_SECRET` | **carry over unchanged from Vercel** (see migration) |
 | `INTEGRATION_TOKEN_KEY` | **carry over unchanged from Vercel** (see migration) |
 | `APP_URL` | public web origin (outbound email links) |
-| `AI_PROVIDER` + provider keys | `ANTHROPIC_*`/`AWS_*` · `MISTRAL_*` · `GLM_*` · `OPENROUTER_*` |
+| `AI_PROVIDER` + provider keys | `ANTHROPIC_BACKEND=litellm` + `LITELLM_*` (Claude via the eSpace gateway) · `MISTRAL_*` · `GLM_*` · `OPENROUTER_*` |
 | `RESEND_*` | email transport (`RESEND_API_KEY`, `RESEND_DOMAIN_MODE`, `RESEND_FROM_*`) |
 | `LOG_LEVEL` | e.g. `info` |
 | `<ENGAGEMENT>_GITHUB_CLIENT_ID` | per-engagement OAuth client ids |


### PR DESCRIPTION
Direct Bedrock access is being switched off in favour of eSpace's LiteLLM gateway, which holds the AWS credentials on our behalf. This moves the API's Claude path onto it.

## What was accessing Bedrock

One place: `apps/api/src/modules/ai/anthropic.ts`. It used `AnthropicBedrock` from `@anthropic-ai/bedrock-sdk` with raw AWS credentials whenever `ANTHROPIC_BEDROCK=1` — and `.env.example` shipped that as the default. That path serves all Claude traffic: chat, the goal classifier, and both graders.

## The change

LiteLLM exposes Anthropic's own `/v1/messages` API, so the stock `@anthropic-ai/sdk` works against it unchanged — only the base URL and the key differ. **No call sites changed.**

- `ANTHROPIC_BEDROCK` (2-way) → **`ANTHROPIC_BACKEND`** (3-way: `litellm` | `bedrock` | `direct`), defaulting to `litellm`.
- New `LITELLM_API_KEY` and `LITELLM_BASE_URL` (default `https://litellm.espace.ws`). The base URL tolerates a trailing `/v1`, since that is the form the LiteLLM UI displays and the SDK appends `/v1/messages` itself.
- The gateway routes by its own published alias rather than an Anthropic or Bedrock id, so the litellm backend defaults to `claude-sonnet-5` and needs no `ANTHROPIC_MODEL` override.
- The analyst provider list now names `LITELLM_API_KEY` as the key Claude needs, instead of `ANTHROPIC_API_KEY`.

## Backwards compatibility

Un-migrated environments do not change behaviour on deploy:

| Environment | Resolves to |
|---|---|
| `ANTHROPIC_BACKEND` set | that backend, always wins |
| legacy `ANTHROPIC_BEDROCK=1` | `bedrock` |
| lone `ANTHROPIC_API_KEY`, no gateway key | `direct` |
| anything else | `litellm` |

An unrecognised `ANTHROPIC_BACKEND` falls through to the default rather than throwing.

## Tests

New `apps/api/src/modules/ai/anthropic-backend.test.ts` covers the resolution matrix above plus the per-backend model defaults — 6 tests, all passing, wired into `npm test`. Typecheck is clean; the one `tsc` error in `compose-guards.test.ts` and the 3 failing test files (missing Mongo/env) are pre-existing on `main` and unchanged here.

## Not verified

The gateway handshake is untested against the live endpoint — `litellm.espace.ws` is not reachable from the sandbox this was built in (egress proxy returns 403). Worth one real call after `LITELLM_API_KEY` is set. The configuration follows LiteLLM's standard Anthropic-passthrough surface; I could not locate the team's "LiteLLM Integration" document in Drive or ClickUp to cross-check it.

## Deploy step

`LITELLM_API_KEY` must be set in the API service's environment (Coolify) before this reaches production — the virtual key is deliberately not committed. Without it, Claude requests return a 500 naming the missing variable.

## Note on scope

This branch also carries four commits that predate this work and are not on `main` — companion/desktop routing (`6f16af2`, `b44c470`, `f10dc96`) and a docs audit (`5b04da3`), about 800 lines across `apps/desktop`, `apps/api` companion proxy, and `docs/`. They came with the branch base rather than from this task. Merging this PR merges them too.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129iSx9fFa9gHF6VXk7KR3i)_