### PR TITLE
Add a preflight check for the Claude/LiteLLM path

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "test": "tsx --test src/modules/ai/extract/extract.test.ts src/modules/ai/compose-guards.test.ts src/modules/ai/anthropic-backend.test.ts src/modules/integrations/query-runner.test.ts src/modules/integrations/query-routes.test.ts",
     "start": "node dist/server.js",
     "typecheck": "tsc -p tsconfig.json",
+    "ai:check": "tsx scripts/litellm-check.ts",
     "admin:create": "tsx scripts/admin-create.ts",
     "admin:reset-password": "tsx scripts/reset-password.ts",
     "admin:reset-totp": "tsx scripts/reset-totp.ts"

--- a/apps/api/scripts/litellm-check.ts
+++ b/apps/api/scripts/litellm-check.ts
@@ -1,0 +1,178 @@
+/**
+ * One-shot CLI: prove the Claude provider can actually reach its backend.
+ *
+ * Usage:
+ *   npm run ai:check
+ *
+ * Optional:
+ *   --models    also list what the gateway will route (LiteLLM only)
+ *   --prompt=…  send your own text instead of the default ping
+ *
+ * Why this exists:
+ *   Claude is reached through eSpace's LiteLLM gateway, which is only
+ *   resolvable from inside the network. That means the migration cannot be
+ *   verified from a laptop off-VPN, from CI, or from a sandboxed agent —
+ *   the first real proof normally arrives as a 500 in front of a user
+ *   mid-classification, with the failure buried under a generic
+ *   "ai_provider_error".
+ *
+ *   This script moves that discovery forward. It resolves config exactly
+ *   the way the running service does — same `anthropicBackend()`, same
+ *   `anthropicModel()`, same client, same `anthropicComplete()` call path
+ *   — so a pass here means the service's Claude path works, not merely
+ *   that the host is pingable.
+ *
+ * Exit codes: 0 on a successful completion, 1 on any failure.
+ */
+
+// The provider module reaches the shared error handler, which pulls in the
+// env schema and aborts the process when the service-level vars are
+// missing. Nothing here touches Mongo or sessions, and the point of the
+// script is to be runnable in a bare shell, so satisfy the schema with
+// placeholders and import dynamically, after they are set. In the deployed
+// container the real values are already present and these no-op.
+process.env.MONGO_URI ??= "mongodb://localhost:27017";
+process.env.SESSION_SECRET ??= "litellm-check-placeholder-000000000000";
+process.env.INTEGRATION_TOKEN_KEY ??= "litellm-check-placeholder-00000000000";
+
+const { anthropicBackend, anthropicModel, anthropicComplete } = await import(
+  "../src/modules/ai/anthropic.js"
+);
+
+const args = process.argv.slice(2);
+const wantModels = args.includes("--models");
+const promptArg = args.find((a) => a.startsWith("--prompt="));
+const prompt = promptArg
+  ? promptArg.slice("--prompt=".length)
+  : "Reply with exactly: OK";
+
+/** Never print a key. Enough to tell "wrong key" from "no key". */
+function mask(key: string | undefined): string {
+  if (!key) return "(unset)";
+  return key.length <= 8
+    ? `${key.slice(0, 2)}…(${key.length} chars)`
+    : `${key.slice(0, 5)}…${key.slice(-2)} (${key.length} chars)`;
+}
+
+function baseUrl(): string {
+  const raw = (process.env.LITELLM_BASE_URL || "https://litellm.espace.ws").trim();
+  return raw.replace(/\/+$/, "").replace(/\/v1$/, "");
+}
+
+const backend = anthropicBackend();
+const model = anthropicModel();
+
+console.log("resolved config");
+console.log(`  backend   ${backend}`);
+console.log(`  model     ${model}`);
+if (backend === "litellm") {
+  console.log(`  base url  ${baseUrl()}`);
+  console.log(`  key       ${mask(process.env.LITELLM_API_KEY)}`);
+} else if (backend === "direct") {
+  console.log(`  key       ${mask(process.env.ANTHROPIC_API_KEY)}`);
+} else {
+  console.log(`  region    ${process.env.AWS_REGION || "us-east-1 (default)"}`);
+  console.log("  NOTE      direct Bedrock is being retired — see ANTHROPIC_BACKEND");
+}
+console.log("");
+
+/**
+ * The gateway's model list. Worth fetching on failure specifically: a
+ * wrong model name and a wrong key both surface as an opaque 4xx on the
+ * completion, and seeing the routable names side by side settles which one
+ * it was in a glance.
+ */
+async function listModels(): Promise<string[] | null> {
+  const key = process.env.LITELLM_API_KEY;
+  if (!key) return null;
+  try {
+    const res = await fetch(`${baseUrl()}/v1/models`, {
+      headers: { Authorization: `Bearer ${key}` },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { data?: Array<{ id?: string }> };
+    return (body.data ?? []).map((m) => m.id).filter((id): id is string => !!id);
+  } catch {
+    return null;
+  }
+}
+
+if (wantModels && backend === "litellm") {
+  const models = await listModels();
+  console.log(
+    models
+      ? `gateway routes ${models.length} model(s):\n  ${models.join("\n  ")}\n`
+      : "could not list models — the completion below will say why\n",
+  );
+}
+
+console.log(`sending a test completion to ${backend}…`);
+try {
+  const r = await anthropicComplete({
+    messages: [{ role: "user", content: prompt }],
+    maxTokens: 64,
+    timeoutMs: 30_000,
+  });
+  console.log("");
+  console.log("OK — the Claude path works.");
+  console.log(`  replied     ${JSON.stringify(r.content)}`);
+  console.log(`  model       ${r.model}`);
+  console.log(`  stop reason ${r.stopReason ?? "(none)"}`);
+  console.log(`  usage       ${JSON.stringify(r.usage)}`);
+  process.exit(0);
+} catch (err) {
+  const status = (err as { status?: unknown })?.status;
+  const message = err instanceof Error ? err.message : String(err);
+  console.error("");
+  console.error(`FAILED — ${message}`);
+
+  // Turn the raw status into the specific thing to go change. Each of
+  // these is a distinct fix, and the status alone does not name it.
+  if (backend === "litellm") {
+    // A 403 is ambiguous: it can come from the gateway (key revoked or out
+    // of scope) OR from a proxy/WAF between here and it, which never let
+    // the request through at all. Blaming the key for a network denial
+    // sends people to rotate a perfectly good key, so split on the body.
+    const blockedByIntermediary =
+      status === 403 && /allowlist|egress|forbidden by proxy|tunnel/i.test(message);
+
+    if (blockedByIntermediary) {
+      console.error(
+        `\nThis was blocked BEFORE it reached the gateway — the message above\n` +
+          `came from a proxy, not from LiteLLM. The key is not implicated.\n` +
+          `Allow egress to ${new URL(baseUrl()).host}, or run this from a\n` +
+          `host that already has it (the API container, or on VPN).`,
+      );
+    } else if (status === 401 || status === 403) {
+      console.error(
+        "\nThe gateway rejected the key. Check LITELLM_API_KEY against the\n" +
+          "Virtual Keys page in the LiteLLM UI — a rotated or revoked key\n" +
+          "fails exactly like this.",
+      );
+    } else if (status === 404) {
+      console.error(
+        `\n404 usually means the base URL is wrong, not the key. It must be\n` +
+          `the origin with NO trailing /v1 — the SDK appends /v1/messages\n` +
+          `itself. Currently resolving to: ${baseUrl()}`,
+      );
+    } else if (status === 400) {
+      const models = await listModels();
+      console.error(
+        `\n400 on a well-formed request usually means the model name is not\n` +
+          `routable on this gateway. Trying: ${model}`,
+      );
+      if (models?.length) {
+        console.error(`\nThe gateway routes:\n  ${models.join("\n  ")}`);
+        console.error(`\nSet ANTHROPIC_MODEL to one of those.`);
+      }
+    } else if (status === undefined) {
+      console.error(
+        `\nNo HTTP status came back, so this did not reach the gateway.\n` +
+          `${baseUrl()} resolves only inside the eSpace network — check the\n` +
+          `VPN, or that the container has egress to it.`,
+      );
+    }
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
Follow-up to #207, which moved Claude off direct Bedrock and onto the LiteLLM gateway. That PR could not be verified against the live gateway from the sandbox it was written in, and this closes that gap.

## Why

`litellm.espace.ws` resolves only inside the eSpace network. The migration therefore cannot be verified from a laptop off-VPN, from CI, or from a sandboxed agent. Without a deliberate check, the first real proof that the switch works arrives as a 500 in front of a user mid-classification, with the cause buried under a generic `ai_provider_error`.

## What

`npm run ai:check` in `apps/api`.

It resolves configuration through the same `anthropicBackend()` and `anthropicModel()` the service uses, and calls the same `anthropicComplete()` path — so a pass means the service's Claude path works, not merely that the host answers. It prints the resolved backend, model, base URL and a masked key, then sends one small completion.

Flags: `--models` lists what the gateway will route before calling; `--prompt=…` sends your own text.

## Failure diagnosis

The point is to name the thing to change, since the status alone does not:

| Symptom | Reported cause |
|---|---|
| 401 / 403 from the gateway | virtual key — rotated or revoked |
| 403 naming an allowlist or egress denial | a proxy in front of the gateway; the key is not implicated |
| 404 | base URL carrying a trailing `/v1` (the SDK appends `/v1/messages`) |
| 400 | model not routable — lists the names the gateway does route |
| no HTTP status | never reached the gateway; VPN or container egress |

That second row exists because the first version of this script got it wrong: it diagnosed a proxy's 403 as a rejected key, which would have sent someone to rotate a perfectly good one. Caught by smoke-testing the failure paths.

## Verification

Typecheck clean. Three paths exercised directly: blocked host, missing key, and exit codes (0 on success, 1 on any failure). The API test suite shows the same three pre-existing failures as `main` (`compose-guards`, `query-routes`, `query-runner` — missing Mongo/env), with no new ones.

Note the script sets placeholder values for `MONGO_URI` / `SESSION_SECRET` / `INTEGRATION_TOKEN_KEY` before importing, because the provider module reaches the shared error handler and its env schema. Nothing here touches Mongo, and in the deployed container the real values are already present, so the placeholders no-op.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129iSx9fFa9gHF6VXk7KR3i)_