### PR TITLE
Make the Claude backend say what it is at boot

### DIFF
--- a/apps/api/scripts/litellm-check.ts
+++ b/apps/api/scripts/litellm-check.ts
@@ -35,8 +35,12 @@ process.env.MONGO_URI ??= "mongodb://localhost:27017";
 process.env.SESSION_SECRET ??= "litellm-check-placeholder-000000000000";
 process.env.INTEGRATION_TOKEN_KEY ??= "litellm-check-placeholder-00000000000";
 
-const { resolveAnthropicBackend, anthropicModel, anthropicComplete } =
-  await import("../src/modules/ai/anthropic.js");
+const {
+  resolveAnthropicBackend,
+  anthropicModel,
+  anthropicComplete,
+  looksLikeBedrockModelId,
+} = await import("../src/modules/ai/anthropic.js");
 
 const args = process.argv.slice(2);
 const wantModels = args.includes("--models");
@@ -138,7 +142,30 @@ try {
     const blockedByIntermediary =
       status === 403 && /allowlist|egress|forbidden by proxy|tunnel/i.test(message);
 
-    if (blockedByIntermediary) {
+    // LiteLLM returns 403 team_model_access_denied when the key is valid
+    // but the model is outside the team's allow-list. That is a model
+    // problem wearing an auth status code — and the body names every
+    // model the team CAN reach, which is the answer, so surface it.
+    const modelNotAllowed =
+      status === 403 &&
+      /team_model_access_denied|not allowed to access model/i.test(message);
+
+    if (modelNotAllowed) {
+      const allowed = message.match(/models=\[([^\]]*)\]/)?.[1];
+      console.error(
+        `\nThe key is fine — the model is not. This team cannot reach\n` +
+          `"${model}".` +
+          (allowed ? `\n\nIt CAN reach:\n  ${allowed.replace(/['\s]/g, "").split(",").join("\n  ")}` : ""),
+      );
+      console.error(
+        `\nSet ANTHROPIC_MODEL to one of those, or unset it to take the\n` +
+          `default (claude-sonnet-5).` +
+          (looksLikeBedrockModelId(model)
+            ? `\n\nNote "${model}" is a Bedrock id — likely left over from the\n` +
+              `pre-gateway setup. The gateway routes by alias, not Bedrock id.`
+            : ""),
+      );
+    } else if (blockedByIntermediary) {
       console.error(
         `\nThis was blocked BEFORE it reached the gateway — the message above\n` +
           `came from a proxy, not from LiteLLM. The key is not implicated.\n` +

--- a/apps/api/scripts/litellm-check.ts
+++ b/apps/api/scripts/litellm-check.ts
@@ -35,9 +35,8 @@ process.env.MONGO_URI ??= "mongodb://localhost:27017";
 process.env.SESSION_SECRET ??= "litellm-check-placeholder-000000000000";
 process.env.INTEGRATION_TOKEN_KEY ??= "litellm-check-placeholder-00000000000";
 
-const { anthropicBackend, anthropicModel, anthropicComplete } = await import(
-  "../src/modules/ai/anthropic.js"
-);
+const { resolveAnthropicBackend, anthropicModel, anthropicComplete } =
+  await import("../src/modules/ai/anthropic.js");
 
 const args = process.argv.slice(2);
 const wantModels = args.includes("--models");
@@ -59,11 +58,13 @@ function baseUrl(): string {
   return raw.replace(/\/+$/, "").replace(/\/v1$/, "");
 }
 
-const backend = anthropicBackend();
+const resolved = resolveAnthropicBackend();
+const backend = resolved.backend;
 const model = anthropicModel();
 
 console.log("resolved config");
 console.log(`  backend   ${backend}`);
+console.log(`  chosen by ${resolved.source}`);
 console.log(`  model     ${model}`);
 if (backend === "litellm") {
   console.log(`  base url  ${baseUrl()}`);

--- a/apps/api/src/modules/ai/anthropic.ts
+++ b/apps/api/src/modules/ai/anthropic.ts
@@ -125,6 +125,20 @@ function litellmBaseUrl(): string {
  *            (often `us.anthropic.…:0`) prefix — best-effort only, set
  *            ANTHROPIC_MODEL to your account's exact id.
  */
+/**
+ * Does this id look like a Bedrock model / inference-profile rather than a
+ * gateway alias? Bedrock ids carry a vendor prefix (`anthropic.…`), usually
+ * behind a region prefix (`us.`, `eu.`, `apac.`) and sometimes with a `:0`
+ * version suffix. Gateway aliases are bare names like `claude-sonnet-5`.
+ *
+ * Worth detecting because ANTHROPIC_MODEL is read before the backend
+ * switch, so a value left over from Bedrock silently follows the migration
+ * across and every request 403s on a model the gateway will not route.
+ */
+export function looksLikeBedrockModelId(id: string): boolean {
+  return /^(?:[a-z]{2,5}\.)?anthropic\./i.test(id.trim());
+}
+
 export function anthropicModel(): string {
   if (process.env.ANTHROPIC_MODEL) return process.env.ANTHROPIC_MODEL;
   switch (anthropicBackend()) {

--- a/apps/api/src/modules/ai/anthropic.ts
+++ b/apps/api/src/modules/ai/anthropic.ts
@@ -57,23 +57,48 @@ export type AnthropicBackend = "litellm" | "bedrock" | "direct";
 
 const LITELLM_DEFAULT_BASE_URL = "https://litellm.espace.ws";
 
-export function anthropicBackend(): AnthropicBackend {
+/**
+ * Resolve the backend AND why it was chosen.
+ *
+ * The reason matters as much as the answer. Every branch below is a
+ * silent decision: nothing fails, a request just quietly goes somewhere
+ * other than where whoever set the env expected. The legacy branch in
+ * particular means an environment can be fully migrated in code and
+ * still route to Bedrock forever because one stale variable outranks the
+ * default — visible only as an absence of traffic in the gateway's logs,
+ * which is close to impossible to notice.
+ */
+export function resolveAnthropicBackend(): {
+  backend: AnthropicBackend;
+  source: string;
+} {
   const explicit = (process.env.ANTHROPIC_BACKEND || "").trim().toLowerCase();
   if (explicit === "litellm" || explicit === "bedrock" || explicit === "direct") {
-    return explicit;
+    return { backend: explicit, source: "ANTHROPIC_BACKEND" };
   }
 
   const legacyBedrock = (process.env.ANTHROPIC_BEDROCK || "").trim().toLowerCase();
   if (legacyBedrock === "1" || legacyBedrock === "true" || legacyBedrock === "yes") {
-    return "bedrock";
+    return {
+      backend: "bedrock",
+      source:
+        "ANTHROPIC_BEDROCK (legacy flag — set ANTHROPIC_BACKEND=litellm to migrate)",
+    };
   }
 
   // No explicit choice: a direct key with no gateway key means this env
   // predates the migration and should keep talking to api.anthropic.com.
   if (process.env.ANTHROPIC_API_KEY && !process.env.LITELLM_API_KEY) {
-    return "direct";
+    return {
+      backend: "direct",
+      source: "inferred (ANTHROPIC_API_KEY set, LITELLM_API_KEY absent)",
+    };
   }
-  return "litellm";
+  return { backend: "litellm", source: "default" };
+}
+
+export function anthropicBackend(): AnthropicBackend {
+  return resolveAnthropicBackend().backend;
 }
 
 /**

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -17,7 +17,11 @@ import { logger } from "./lib/logger.js";
 import { connect, disconnect } from "./db/client.js";
 import { bootstrap } from "./db/collections.js";
 import { seedDefaultOrg } from "./db/seed.js";
-import { resolveAnthropicBackend, anthropicModel } from "./modules/ai/anthropic.js";
+import {
+  resolveAnthropicBackend,
+  anthropicModel,
+  looksLikeBedrockModelId,
+} from "./modules/ai/anthropic.js";
 
 const SHUTDOWN_DEADLINE_MS = 10_000;
 
@@ -43,10 +47,22 @@ async function main(): Promise<void> {
   // the legacy path is to notice that a gateway's logs stay empty — the
   // requests themselves succeed either way, so nothing surfaces.
   const ai = resolveAnthropicBackend();
+  const aiModel = anthropicModel();
   logger.info(
-    { backend: ai.backend, source: ai.source, model: anthropicModel() },
+    { backend: ai.backend, source: ai.source, model: aiModel },
     `[boot] claude backend: ${ai.backend} (via ${ai.source})`,
   );
+
+  // ANTHROPIC_MODEL is read before the backend switch, so a Bedrock id set
+  // for the old path follows the migration across and 403s on every
+  // request. Say so at boot rather than once per failed classification.
+  if (ai.backend === "litellm" && looksLikeBedrockModelId(aiModel)) {
+    logger.warn(
+      { model: aiModel },
+      `[boot] ANTHROPIC_MODEL="${aiModel}" is a Bedrock id, but the backend is the LiteLLM gateway — ` +
+        `it routes by alias (e.g. claude-sonnet-5). Expect 403 team_model_access_denied until this is changed or unset.`,
+    );
+  }
 
   const server = app.listen(env.PORT, () => {
     logger.info(

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -17,6 +17,7 @@ import { logger } from "./lib/logger.js";
 import { connect, disconnect } from "./db/client.js";
 import { bootstrap } from "./db/collections.js";
 import { seedDefaultOrg } from "./db/seed.js";
+import { resolveAnthropicBackend, anthropicModel } from "./modules/ai/anthropic.js";
 
 const SHUTDOWN_DEADLINE_MS = 10_000;
 
@@ -36,6 +37,16 @@ async function main(): Promise<void> {
         "[boot] mongo bootstrap failed — service is up; readyz will fail until mongo is available + healthy",
       );
     });
+
+  // Say which backend serves Claude, and why it was picked. Without this
+  // the only way to tell a migrated environment from one still pinned to
+  // the legacy path is to notice that a gateway's logs stay empty — the
+  // requests themselves succeed either way, so nothing surfaces.
+  const ai = resolveAnthropicBackend();
+  logger.info(
+    { backend: ai.backend, source: ai.source, model: anthropicModel() },
+    `[boot] claude backend: ${ai.backend} (via ${ai.source})`,
+  );
 
   const server = app.listen(env.PORT, () => {
     logger.info(


### PR DESCRIPTION
Follow-up to #207 and #208. Both commits came out of debugging the live deployment after the migration landed, where two separate stale environment variables silently survived the switch and nothing anywhere pointed at either.

## `feat(api): log which Claude backend is serving, and why`

Nothing in the service named its Claude backend, so a migrated deployment and one still pinned to Bedrock were indistinguishable from the logs. Requests succeed either way — the only symptom is that the gateway's logs stay empty, which is close to impossible to notice.

That gap is not academic. `anthropicBackend()` honours `ANTHROPIC_BEDROCK` when `ANTHROPIC_BACKEND` is unset, deliberately, so environments mid-migration keep working. The cost is that one stale variable outranks the new default indefinitely: the code migrates, the traffic does not.

Resolution is split into `resolveAnthropicBackend()`, which returns the reason alongside the choice, and both are logged at boot:

```
[boot] claude backend: bedrock (via ANTHROPIC_BEDROCK (legacy flag — set ANTHROPIC_BACKEND=litellm to migrate))
```

`anthropicBackend()` delegates to it, so the two cannot drift.

## `fix(api): catch a Bedrock model id left set on the gateway backend`

`anthropicModel()` reads `ANTHROPIC_MODEL` before the backend switch, so a value set for Bedrock follows the migration across unchanged. The gateway routes by alias, not by Bedrock id, and rejects it:

```
403 team_model_access_denied — Tried to access us.anthropic.claude-sonnet-4-6
```

Same shape as the problem above: a stale variable outliving the migration. Warns at boot when the backend is the gateway and the model looks Bedrock-shaped, rather than surfacing once per failed classification.

Also fixes a misdiagnosis in `ai:check`. It treated every 403 as a rejected key, so this error — where the key is fine and the model is not — would have sent someone to rotate a working key. Model-access denials are now split out, and the allow-list LiteLLM returns in the body is printed, since that is the answer to what to set instead.

## Scope

3 files, +104/−10, all in `apps/api`. No change to the request path: the backend and model resolve exactly as before. This is diagnostics plus one corrected error message.

## Verification

Typecheck clean. All 6 `anthropic-backend` tests pass. Both new code paths exercised directly — the legacy-flag branch reports `bedrock` with the model id `anthropic.claude-sonnet-4-6`, and the Bedrock-shaped-id detector was checked against the literal 403 body from the live gateway, extracting all seven allowed model names while leaving bare aliases like `claude-sonnet-5` unflagged.

Neither commit fixes a deployment — both remaining issues are env values, not code.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129iSx9fFa9gHF6VXk7KR3i)_