### PR TITLE
Stop compose-widget dying at the proxy's 30s ceiling

### DIFF
--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -1,0 +1,116 @@
+/**
+ * Server-sent events for long single-answer requests.
+ *
+ * The problem this solves is not incremental rendering — it is survival.
+ * A reverse proxy severs a response that produces no bytes for ~30s, and
+ * it does so without a status code: the client sees a dead socket, the
+ * server logs `request aborted`, and neither end learns anything. Any
+ * request whose useful work outlasts that window needs to say something
+ * before it finishes, even if it has nothing to say yet.
+ *
+ * So this is deliberately NOT a token-streaming abstraction. The payload
+ * still arrives once, whole, in a single `result` event, which means all
+ * the server-side parsing, validation and repair that runs after the model
+ * replies stays exactly where it is. What changes is that the connection
+ * is provably alive the entire time.
+ *
+ * Wire format (standard SSE, readable by EventSource or a fetch reader):
+ *
+ *   : open                     ← sent immediately, starts the byte flow
+ *   event: progress            ← liveness; `chars` is best-effort
+ *   data: {"chars":128}
+ *
+ *   event: result              ← the response body, once
+ *   data: {...}
+ *
+ *   event: error               ← failure AFTER headers went out
+ *   data: {"error":"…","message":"…"}
+ *
+ * An error before the first byte is NOT sent here — the normal error
+ * handler still owns that case, and can still set a real status code.
+ * Once `open()` is called that option is gone, which is why it takes an
+ * explicit call rather than happening in the constructor.
+ */
+
+import type { Response } from "express";
+
+/** How often to emit a keepalive when nothing else is flowing. */
+const HEARTBEAT_MS = 5_000;
+
+export interface SseChannel {
+  /** True once headers have been flushed and a status can no longer be set. */
+  readonly open: boolean;
+  /** Note progress. Cheap and idempotent — safe to call per token. */
+  tick(chars?: number): void;
+  /** Send the final payload and end the response. */
+  result(body: unknown): void;
+  /** Report a failure that happened after headers went out, and end. */
+  fail(code: string, message: string): void;
+}
+
+/** Does this request want events rather than a single JSON body? */
+export function wantsSse(accept: string | undefined): boolean {
+  return typeof accept === "string" && accept.includes("text/event-stream");
+}
+
+export function openSse(res: Response): SseChannel {
+  res.status(200).set({
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+    // Nginx buffers proxied responses by default, which would hold every
+    // event until the end and defeat the entire point. Harmless elsewhere.
+    "X-Accel-Buffering": "no",
+  });
+
+  // The opening comment is the important byte. It is what tells every hop
+  // in the path that this response has started, before any work happens.
+  res.write(": open\n\n");
+  res.flushHeaders?.();
+
+  let ended = false;
+  let pending = 0;
+
+  const send = (event: string, data: unknown): void => {
+    if (ended) return;
+    res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  };
+
+  // Fires regardless of whether the upstream produces deltas, so providers
+  // with no streaming support are covered by the same mechanism.
+  const heartbeat = setInterval(() => {
+    if (ended) return;
+    send("progress", { chars: pending });
+  }, HEARTBEAT_MS);
+  // Never hold the process open for a keepalive.
+  heartbeat.unref?.();
+
+  const stop = (): void => {
+    ended = true;
+    clearInterval(heartbeat);
+  };
+
+  // A client that navigates away should not keep the interval alive.
+  res.on("close", stop);
+
+  return {
+    get open() {
+      return true;
+    },
+    tick(chars = 0) {
+      pending += chars;
+    },
+    result(body) {
+      if (ended) return;
+      send("result", body);
+      stop();
+      res.end();
+    },
+    fail(code, message) {
+      if (ended) return;
+      send("error", { error: code, message });
+      stop();
+      res.end();
+    },
+  };
+}

--- a/apps/api/src/modules/ai/anthropic.ts
+++ b/apps/api/src/modules/ai/anthropic.ts
@@ -220,6 +220,19 @@ interface CompleteInput {
    * something useful instead.
    */
   timeoutMs?: number;
+
+  /**
+   * Called as text arrives. Passing this switches the request to the
+   * streaming API — same inputs, same return value, the reply is just
+   * assembled from deltas instead of arriving whole.
+   *
+   * Two things change for the better when it streams. Bytes move on the
+   * upstream connection continuously, so no idle-timeout anywhere in the
+   * path can mistake a long generation for a dead one; and the caller gets
+   * a liveness signal it can forward to ITS client, which is what keeps a
+   * proxy from severing a slow response mid-flight.
+   */
+  onDelta?: (text: string) => void;
 }
 
 /**
@@ -243,17 +256,34 @@ export async function anthropicComplete(
   stopReason: string | null;
 }> {
   const c = getClient();
+  const body = {
+    model: anthropicModel(),
+    max_tokens: opts.maxTokens ?? 2048,
+    ...(opts.system ? { system: opts.system } : {}),
+    messages: opts.messages,
+  };
+
+  /**
+   * A wall-clock budget and automatic retries are contradictory: the SDK
+   * retries twice by default, so a caller asking to fail at 25s instead
+   * failed at 75s, long after whatever it was racing had given up. Worse,
+   * the later attempts run with nobody listening — burning gateway
+   * capacity to produce an answer that is discarded. When the caller has
+   * named a deadline, honour it exactly and do not retry past it.
+   */
+  const requestOpts = opts.timeoutMs
+    ? [{ timeout: opts.timeoutMs, maxRetries: 0 }]
+    : [];
+
   let msg: Anthropic.Messages.Message;
   try {
-    msg = await c.messages.create(
-      {
-        model: anthropicModel(),
-        max_tokens: opts.maxTokens ?? 2048,
-        ...(opts.system ? { system: opts.system } : {}),
-        messages: opts.messages,
-      },
-      ...(opts.timeoutMs ? [{ timeout: opts.timeoutMs }] : []),
-    );
+    if (opts.onDelta) {
+      const stream = c.messages.stream(body, ...requestOpts);
+      stream.on("text", (text) => opts.onDelta?.(text));
+      msg = await stream.finalMessage();
+    } else {
+      msg = await c.messages.create(body, ...requestOpts);
+    }
   } catch (err) {
     throw mapSdkError(err);
   }

--- a/apps/api/src/modules/ai/controller.ts
+++ b/apps/api/src/modules/ai/controller.ts
@@ -34,6 +34,7 @@ import {
 import { assertDocumentUploadAllowed } from "../../lib/ai-document-policy.js";
 import { resolveRequestedId, selectProvider } from "./provider.js";
 import { anthropicComplete, isAnthropicId } from "./anthropic.js";
+import { openSse, wantsSse, type SseChannel } from "../../lib/sse.js";
 // Import from the leaf `limits` module, NOT from ./extract/index.js — the
 // latter reaches run-in-worker.ts and its `new Worker(...)` call, which
 // Turbopack can't statically analyse and which breaks the web build when it
@@ -1475,6 +1476,17 @@ const COMPOSE_MAX_TOKENS = 4_000;
  */
 const COMPOSE_TIMEOUT_MS = 25_000;
 
+/**
+ * The same budget for a client that speaks SSE.
+ *
+ * The 25s above exists only because a silent response gets severed at ~30s.
+ * A stream is never silent — it emits from the first millisecond and keeps
+ * emitting — so that ceiling does not apply and the limit can be what the
+ * work actually needs. Compose asks for up to COMPOSE_MAX_TOKENS of JSON,
+ * which through a gateway can legitimately run past a minute.
+ */
+const COMPOSE_STREAM_TIMEOUT_MS = 120_000;
+
 interface CleanComposedBlock {
   cadence?: string;
   prompt?: string;
@@ -1778,6 +1790,15 @@ export async function composeWidgetHandler(
   res: Response,
   next: NextFunction,
 ): Promise<void> {
+  // Opened lazily: everything up to the model call can still fail with a
+  // real status code, and once the stream is open that option is gone.
+  let sse: SseChannel | null = null;
+  const streaming = wantsSse(req.headers.accept);
+  const respond = (body: unknown): void => {
+    if (sse) sse.result(body);
+    else res.json(body);
+  };
+
   try {
     const session = req.session;
     if (!session) {
@@ -1811,6 +1832,11 @@ export async function composeWidgetHandler(
     // misleading "returned non-JSON content".
     let truncated = false;
 
+    // From here on the work can outlast the proxy's idle ceiling, so start
+    // the stream before the model call rather than after it.
+    if (streaming) sse = openSse(res);
+    const budgetMs = streaming ? COMPOSE_STREAM_TIMEOUT_MS : COMPOSE_TIMEOUT_MS;
+
     if (
       isAnthropicId(
         resolveRequestedId({ request: req, bodyProvider: payload.provider ?? null }),
@@ -1820,7 +1846,8 @@ export async function composeWidgetHandler(
         system: COMPOSE_WIDGET_SYSTEM_PROMPT,
         messages: [{ role: "user", content: userPrompt }],
         maxTokens: COMPOSE_MAX_TOKENS,
-        timeoutMs: COMPOSE_TIMEOUT_MS,
+        timeoutMs: budgetMs,
+        ...(sse ? { onDelta: (t: string) => sse?.tick(t.length) } : {}),
       });
       content = r.content;
       modelName = r.model;
@@ -1841,7 +1868,7 @@ export async function composeWidgetHandler(
           { role: "system", content: COMPOSE_WIDGET_SYSTEM_PROMPT },
           { role: "user", content: userPrompt },
         ],
-      }, COMPOSE_TIMEOUT_MS);
+      }, budgetMs);
       const data = upstream.data as CompletionResponse;
       content = data.choices?.[0]?.message?.content ?? "";
       modelName = data.model;
@@ -2024,7 +2051,7 @@ export async function composeWidgetHandler(
         },
         "[ai] compose-widget seeded default fields",
       );
-      res.json({
+      respond({
         spec: fallback.spec,
         seeded: true,
         unrepresented,
@@ -2053,7 +2080,7 @@ export async function composeWidgetHandler(
       },
       "[ai] composed a custom widget",
     );
-    res.json({
+    respond({
       spec: built.spec,
       seeded,
       unrepresented,
@@ -2061,6 +2088,18 @@ export async function composeWidgetHandler(
       provider: providerId,
     });
   } catch (err) {
+    // Once the stream is open the status line is already sent, so the
+    // normal error handler cannot do its job — report in-band instead, and
+    // keep the shape the client would have received from it.
+    if (sse) {
+      const e = err as { code?: string; message?: string };
+      logger.warn(
+        { err: e.message, path: "/api/v1/ai/compose-widget" },
+        "[ai] compose-widget failed after the stream opened",
+      );
+      sse.fail(e.code ?? "compose_failed", e.message ?? "Compose failed.");
+      return;
+    }
     next(err);
   }
 }

--- a/apps/web/src/features/analyst/compose-widget.js
+++ b/apps/web/src/features/analyst/compose-widget.js
@@ -90,6 +90,13 @@ export async function composeWidget({
     headers: {
       "Content-Type": "application/json",
       "x-ai-provider": provider,
+      // Ask for events, not a single body. Compose routinely runs past the
+      // ~30s a proxy will hold a silent response open, and being severed
+      // yields no status and no message — the request just dies. A stream
+      // emits from the first millisecond, so the connection stays provably
+      // alive for as long as the work takes. The payload is unchanged; it
+      // arrives whole, in one `result` event.
+      Accept: "text/event-stream",
     },
     body: JSON.stringify({
       goalId,
@@ -103,11 +110,22 @@ export async function composeWidget({
     signal,
   });
 
-  const body = await res.json().catch(() => ({}));
+  // The server honours the Accept header, but a cached bundle or an older
+  // deployment can still answer with plain JSON — read whichever arrived
+  // rather than assuming, so a version skew degrades instead of breaking.
+  const body = res.headers.get("content-type")?.includes("text/event-stream")
+    ? await readSseResult(res)
+    : await res.json().catch(() => ({}));
+
   if (!res.ok) {
     throw new Error(
       body?.error?.message || body?.error || `Couldn't build a tracker (${res.status}).`,
     );
+  }
+  // An SSE response is always HTTP 200 — the status line is sent before the
+  // work starts — so an in-band failure has to be checked separately.
+  if (body?.__sseError) {
+    throw new Error(body.message || "Couldn't build a tracker.");
   }
   if (!body?.spec) throw new Error("The AI returned no tracker — try rephrasing.");
   // `seeded: true` means the model's field list was unusable and the server
@@ -182,6 +200,70 @@ export async function extractComposeAttachment({ goalId, file, signal }) {
     warnings: toStringList(extracted.warnings),
     info: toStringList(extracted.info),
   };
+}
+
+/**
+ * Read an SSE response down to its single terminal event.
+ *
+ * Not a general EventSource replacement — `EventSource` cannot POST, and
+ * this stream carries exactly one payload. `progress` events exist only to
+ * keep the connection warm and carry nothing worth surfacing, so they are
+ * counted and dropped. Resolves with the `result` payload, or with an
+ * `__sseError` marker for a failure reported in-band (the status line is
+ * long gone by then, so it cannot arrive as an HTTP error).
+ */
+async function readSseResult(res) {
+  const reader = res.body?.getReader();
+  if (!reader) throw new Error("Couldn't build a tracker — the response had no body.");
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let out = null;
+
+  try {
+    while (!out) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // Frames are separated by a blank line. Anything after the last one
+      // is a partial frame and stays in the buffer for the next chunk.
+      let split;
+      while ((split = buffer.indexOf("\n\n")) !== -1) {
+        const frame = buffer.slice(0, split);
+        buffer = buffer.slice(split + 2);
+
+        let event = "message";
+        const data = [];
+        for (const raw of frame.split("\n")) {
+          const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
+          if (!line || line.startsWith(":")) continue; // keepalive comment
+          if (line.startsWith("event:")) event = line.slice(6).trim();
+          else if (line.startsWith("data:")) data.push(line.slice(5).trim());
+        }
+        if (!data.length) continue;
+
+        let payload;
+        try {
+          payload = JSON.parse(data.join("\n"));
+        } catch {
+          continue; // a malformed frame is not worth failing the whole run
+        }
+
+        if (event === "result") out = payload;
+        else if (event === "error") out = { __sseError: true, ...payload };
+      }
+    }
+  } finally {
+    // Let the socket go as soon as the answer is in hand, rather than
+    // waiting for the server to close it.
+    reader.cancel().catch(() => {});
+  }
+
+  if (!out) {
+    throw new Error("The connection closed before the tracker was ready. Try again.");
+  }
+  return out;
 }
 
 /** Drop an empty/absent attachment entirely rather than sending `{text: ""}`. */


### PR DESCRIPTION
Compose has been failing since the gateway migration while the other AI endpoints kept working. Two independent faults, both of which only show up on a call that runs long — and compose is the only one that does. The other three call sites omit `timeoutMs` entirely and ask for 1,024–2,048 tokens, so they finish well inside the window.

## Fault 1: retries defeated the deadline

`COMPOSE_TIMEOUT_MS` is 25s, chosen deliberately to fail just under the ~30s a proxy will hold a silent response open, so the user gets a real error instead of a severed socket. But `getClient()` never set `maxRetries`, so the SDK default of 2 applied — the call failed at 75s, not 25s. The proxy cut the client off at 30s regardless, producing exactly the statusless failure the 25s was written to avoid, while two more attempts ran to completion with nobody listening.

Timings from the live logs match to the second:

| Time | Event |
|---|---|
| t=0 | request starts |
| t=25s | attempt 1 hits the deadline |
| t=30s | proxy severs — `request aborted`, `statusCode: null`, `responseTime: 29996` |
| t=50s / t=75s | attempts 2 and 3 time out, unobserved |
| t=76.3s | `ai_provider_unreachable` |

`anthropicComplete` now passes `maxRetries: 0` whenever the caller names a timeout, since a wall-clock budget and automatic retries are contradictory.

## Fault 2: 25s is not enough, and only exists because of silence

That alone makes the failure honest, not absent — 4,000 tokens of JSON through the gateway legitimately needs longer. The ceiling exists only because a silent response gets severed, so the fix is to stop being silent.

Compose now answers `Accept: text/event-stream` with SSE. **This is not token streaming.** The payload still arrives once, whole, in a single `result` event, so all the parsing, validation, seeding and repair that runs after the model replies is untouched — deliberate, to keep the blast radius small. What changes is that a byte goes out immediately and keeps going out. The budget rises to 120s because the ceiling no longer applies.

Liveness comes from a **heartbeat timer rather than from deltas**, so providers with no streaming support — the `callProvider` path, an opaque await — are covered by the same mechanism. `anthropicComplete` additionally forwards real deltas via `onDelta`, which keeps the upstream connection busy too.

Failures after the stream opens are reported in-band, since the status line is long gone by then. The plain-JSON path is untouched and still serves any client that does not ask for events, and the web client sniffs the response content-type rather than assuming, so a cached bundle or an older deployment degrades instead of breaking.

## Verification

Server channel and client reader exercised against each other over a real socket: `result` payload arrives intact, `error` events surface as a throw, and a request without the Accept header still gets plain JSON.

The property that matters, measured on a 12s response that never produced a single delta:

```
time to first byte: 24ms
longest silence:  5000ms
  24ms    : open
  5018ms  event: progress
  10018ms event: progress
  12021ms event: result
```

Typecheck clean. API suite 20 pass / 3 fail — the same three pre-existing failures as `main` (`compose-guards`, `query-routes`, `query-runner`, all missing Mongo/env).

## Not done

- `COMPOSE_MAX_TOKENS` left at 4,000. The comment above it records that the value exists *because* replies were being truncated at 1,500; lowering it would walk back a fix.
- No proxy config touched. Confirming the real Traefik timeout is still worth doing — the 29996ms abort points at 30s, and knowing it for certain tells you whether the 5s heartbeat has enough margin.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129iSx9fFa9gHF6VXk7KR3i)_